### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "o3co-hocon"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.82"
 description = "Full Lightbend HOCON specification-compliant parser for Rust"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.4 for crates.io publish via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)