### PR TITLE
ci: switch to OIDC trusted publishing for crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -21,8 +25,15 @@ jobs:
           fi
 
       - uses: dtolnay/rust-toolchain@stable
+
       - run: cargo test
       - run: cargo test --features serde
-      - run: cargo publish
+
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish
+        run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Summary
- Replace `CARGO_REGISTRY_TOKEN` secret with `rust-lang/crates-io-auth-action`
- Add `id-token: write` permission for OIDC
- No stored secrets needed for publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)