### PR TITLE
ci: switch to tag-based versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,14 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-set-version
+        run: cargo install cargo-set-version
 
       - name: Set version from tag
-        run: |
-          TAG="${GITHUB_REF#refs/tags/v}"
-          echo "Publishing version ${TAG}"
-          sed -i "s/^version = .*/version = \"${TAG}\"/" Cargo.toml
-
-      - uses: dtolnay/rust-toolchain@stable
+        run: cargo set-version "${GITHUB_REF#refs/tags/v}"
 
       - run: cargo test
       - run: cargo test --features serde

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,14 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify tag matches Cargo.toml version
+      - name: Set version from tag
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"
-          CARGO_VER="$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')"
-          if [ "$TAG" != "$CARGO_VER" ]; then
-            echo "::error::Tag v${TAG} does not match Cargo.toml version ${CARGO_VER}"
-            exit 1
-          fi
+          echo "Publishing version ${TAG}"
+          sed -i "s/^version = .*/version = \"${TAG}\"/" Cargo.toml
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "o3co-hocon"
-version = "0.1.5-alpha.1"
+version = "0.0.0-snapshot"
 edition = "2021"
 rust-version = "1.82"
 description = "Full Lightbend HOCON specification-compliant parser for Rust"


### PR DESCRIPTION
## Summary
- Replace version verification with tag-based version injection in publish workflow
- Set `Cargo.toml` version to `0.0.0-snapshot` (version derived from git tag at publish time)
- Eliminates need for version bump PRs before releases

## How it works
1. Push a tag like `v0.1.5`
2. Publish CI extracts `0.1.5` from the tag
3. `sed` sets the version in Cargo.toml
4. Test + publish proceeds as before

## Test plan
- [ ] Verify publish workflow runs correctly on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)