### PR TITLE
fix: add --allow-dirty to cargo publish for tag-based versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,6 @@ jobs:
         uses: rust-lang/crates-io-auth-action@v1
 
       - name: Publish
-        run: cargo publish
+        run: cargo publish --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Summary
- `cargo publish` rejects uncommitted changes by default
- Since tag-based versioning modifies Cargo.toml at publish time, `--allow-dirty` is required

## Test plan
- [ ] Re-tag v0.1.5 after merge and verify publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)