### PR TITLE
fix: P0 Phase 2-4 — deep-merge, coercion, duration/bytes, quoted paths, stray brace

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -305,10 +305,10 @@ fn split_config_path(path: &str) -> Vec<String> {
                 seg.push(chars[i]);
                 i += 1;
             }
-            segments.push(seg);
             if !closed {
-                break;
+                return vec![path.to_string()]; // treat as literal if unterminated
             }
+            segments.push(seg);
             // skip optional '.' separator
             if i < chars.len() && chars[i] == '.' {
                 i += 1;
@@ -423,7 +423,11 @@ fn parse_bytes(s: &str) -> Option<i64> {
         n.checked_mul(multiplier)
     } else {
         let num: f64 = num_str.parse().ok()?;
-        Some((num * multiplier as f64).round() as i64)
+        let result = (num * multiplier as f64).round();
+        if !result.is_finite() || result > i64::MAX as f64 || result < i64::MIN as f64 {
+            return None;
+        }
+        Some(result as i64)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -381,7 +381,7 @@ fn parse_duration(s: &str) -> Option<std::time::Duration> {
 fn parse_bytes(s: &str) -> Option<i64> {
     let s = s.trim();
     let num_end = s
-        .find(|c: char| !c.is_ascii_digit() && c != '.' && c != '-')
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
         .unwrap_or(s.len());
     let num_str = s[..num_end].trim();
     let unit_str = s[num_end..].trim();
@@ -403,7 +403,7 @@ fn parse_bytes(s: &str) -> Option<i64> {
 
     // Try lossless integer path first, fall back to f64 for fractional values
     if let Ok(n) = num_str.parse::<i64>() {
-        Some(n * multiplier)
+        n.checked_mul(multiplier)
     } else {
         let num: f64 = num_str.parse().ok()?;
         Some((num * multiplier as f64) as i64)

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,19 +19,8 @@ impl Config {
 
     // Walk the dot-separated path through nested objects.
     fn lookup_node(&self, path: &str) -> Option<&HoconValue> {
-        let mut parts = path.splitn(2, '.');
-        let key = parts.next()?;
-        let rest = parts.next();
-
-        let value = self.root.get(key)?;
-
-        match rest {
-            None => Some(value),
-            Some(remaining) => match value {
-                HoconValue::Object(map) => lookup_in_map(map, remaining),
-                _ => None,
-            },
-        }
+        let segments = split_config_path(path);
+        lookup_in_map_by_segments(&self.root, &segments)
     }
 
     /// Return the raw [`HoconValue`] at the given dot-separated path,
@@ -280,21 +269,63 @@ impl Config {
     }
 }
 
-// Free function that walks a map recursively using a dot path, avoiding lifetime issues
-// in methods that would need to return references into temporary Config values.
-fn lookup_in_map<'a>(map: &'a IndexMap<String, HoconValue>, path: &str) -> Option<&'a HoconValue> {
-    let mut parts = path.splitn(2, '.');
-    let key = parts.next()?;
-    let rest = parts.next();
+/// Split a HOCON config path into segments, respecting quoted keys.
+/// e.g. `server."web.api".port` → `["server", "web.api", "port"]`
+fn split_config_path(path: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let chars: Vec<char> = path.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == '"' {
+            // Quoted segment — collect until closing quote
+            i += 1; // skip opening quote
+            let start = i;
+            while i < chars.len() && chars[i] != '"' {
+                i += 1;
+            }
+            segments.push(chars[start..i].iter().collect());
+            if i < chars.len() {
+                i += 1; // skip closing quote
+            }
+            // skip optional '.' separator
+            if i < chars.len() && chars[i] == '.' {
+                i += 1;
+            }
+        } else {
+            // Unquoted segment — collect until '.' or '"'
+            let start = i;
+            while i < chars.len() && chars[i] != '.' && chars[i] != '"' {
+                i += 1;
+            }
+            if i > start {
+                segments.push(chars[start..i].iter().collect());
+            }
+            // skip optional '.' separator
+            if i < chars.len() && chars[i] == '.' {
+                i += 1;
+            }
+        }
+    }
+    segments
+}
 
+fn lookup_in_map_by_segments<'a>(
+    map: &'a IndexMap<String, HoconValue>,
+    segments: &[String],
+) -> Option<&'a HoconValue> {
+    if segments.is_empty() {
+        return None;
+    }
+    let key = &segments[0];
+    let rest = &segments[1..];
     let value = map.get(key)?;
-
-    match rest {
-        None => Some(value),
-        Some(remaining) => match value {
-            HoconValue::Object(inner) => lookup_in_map(inner, remaining),
+    if rest.is_empty() {
+        Some(value)
+    } else {
+        match value {
+            HoconValue::Object(inner) => lookup_in_map_by_segments(inner, rest),
             _ => None,
-        },
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,10 @@ impl Config {
         match self.lookup_node(path) {
             None => Err(missing(path)),
             Some(HoconValue::Scalar(ScalarValue::String(s))) => Ok(s.clone()),
+            Some(HoconValue::Scalar(ScalarValue::Int(n))) => Ok(n.to_string()),
+            Some(HoconValue::Scalar(ScalarValue::Float(f))) => Ok(f.to_string()),
+            Some(HoconValue::Scalar(ScalarValue::Bool(b))) => Ok(b.to_string()),
+            Some(HoconValue::Scalar(ScalarValue::Null)) => Ok("null".to_string()),
             _ => Err(type_mismatch(path, "String")),
         }
     }
@@ -419,9 +423,38 @@ mod tests {
     }
 
     #[test]
-    fn get_string_error_on_non_string() {
+    fn get_string_coerces_int() {
         let c = make_config(vec![("port", iv(8080))]);
-        assert!(c.get_string("port").is_err());
+        assert_eq!(c.get_string("port").unwrap(), "8080");
+    }
+
+    #[test]
+    fn get_string_coerces_float() {
+        let c = make_config(vec![("ratio", fv(3.14))]);
+        // f64::to_string may produce "3.14" or similar; just check it parses back
+        let s = c.get_string("ratio").unwrap();
+        let v: f64 = s.parse().unwrap();
+        assert!((v - 3.14).abs() < 1e-10);
+    }
+
+    #[test]
+    fn get_string_coerces_bool() {
+        let c = make_config(vec![("flag", bv(true))]);
+        assert_eq!(c.get_string("flag").unwrap(), "true");
+    }
+
+    #[test]
+    fn get_string_coerces_null() {
+        let c = make_config(vec![("v", HoconValue::Scalar(ScalarValue::Null))]);
+        assert_eq!(c.get_string("v").unwrap(), "null");
+    }
+
+    #[test]
+    fn get_string_error_on_object() {
+        let mut inner = IndexMap::new();
+        inner.insert("x".into(), iv(1));
+        let c = make_config(vec![("obj", HoconValue::Object(inner))]);
+        assert!(c.get_string("obj").is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -341,27 +341,30 @@ fn parse_duration(s: &str) -> Option<std::time::Duration> {
 
 fn parse_bytes(s: &str) -> Option<i64> {
     let s = s.trim();
-    let num_end = s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len());
+    let num_end = s
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .unwrap_or(s.len());
     let num_str = s[..num_end].trim();
     let unit_str = s[num_end..].trim();
 
-    let num: i64 = num_str.parse().ok()?;
+    let num: f64 = num_str.parse().ok()?;
 
-    // Case-sensitive matching: KB vs KiB matters
-    let multiplier: i64 = match unit_str {
-        "B" | "byte" | "bytes" => 1,
-        "KB" | "kilobyte" | "kilobytes" => 1_000,
-        "KiB" | "kibibyte" | "kibibytes" => 1_024,
-        "MB" | "megabyte" | "megabytes" => 1_000_000,
-        "MiB" | "mebibyte" | "mebibytes" => 1_048_576,
-        "GB" | "gigabyte" | "gigabytes" => 1_000_000_000,
-        "GiB" | "gibibyte" | "gibibytes" => 1_073_741_824,
-        "TB" | "terabyte" | "terabytes" => 1_000_000_000_000,
-        "TiB" | "tebibyte" | "tebibytes" => 1_099_511_627_776,
+    // Case-sensitive matching: KB vs KiB matters. Short forms (K, M, G, T) are
+    // treated as SI decimal units (KB, MB, GB, TB).
+    let multiplier: f64 = match unit_str {
+        "" | "B" | "byte" | "bytes" => 1.0,
+        "K" | "KB" | "kilobyte" | "kilobytes" => 1_000.0,
+        "KiB" | "kibibyte" | "kibibytes" => 1_024.0,
+        "M" | "MB" | "megabyte" | "megabytes" => 1_000_000.0,
+        "MiB" | "mebibyte" | "mebibytes" => 1_048_576.0,
+        "G" | "GB" | "gigabyte" | "gigabytes" => 1_000_000_000.0,
+        "GiB" | "gibibyte" | "gibibytes" => 1_073_741_824.0,
+        "T" | "TB" | "terabyte" | "terabytes" => 1_000_000_000_000.0,
+        "TiB" | "tebibyte" | "tebibytes" => 1_099_511_627_776.0,
         _ => return None,
     };
 
-    Some(num * multiplier)
+    Some((num * multiplier) as i64)
 }
 
 fn missing(path: &str) -> ConfigError {

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,9 @@ impl Config {
 
     /// Return the value at `path` as a `String`.
     ///
-    /// Returns [`ConfigError`] if the path is missing or the value is not a string.
+    /// Scalar values (Int, Float, Bool, Null) are coerced to their string
+    /// representation. Returns [`ConfigError`] if the path is missing or
+    /// the value is an Object or Array.
     pub fn get_string(&self, path: &str) -> Result<String, ConfigError> {
         match self.lookup_node(path) {
             None => Err(missing(path)),
@@ -161,8 +163,11 @@ impl Config {
     /// Accepts HOCON duration strings (e.g., `"30 seconds"`, `"100ms"`,
     /// `"2 hours"`). Bare integers are interpreted as milliseconds.
     ///
-    /// Supported units: `ns`, `us`, `ms`, `s`/`second`/`seconds`,
-    /// `m`/`minute`/`minutes`, `h`/`hour`/`hours`, `d`/`day`/`days`.
+    /// Supported units: `ns`/`nano`/`nanos`/`nanosecond`/`nanoseconds`,
+    /// `us`/`micro`/`micros`/`microsecond`/`microseconds`,
+    /// `ms`/`milli`/`millis`/`millisecond`/`milliseconds`,
+    /// `s`/`second`/`seconds`, `m`/`minute`/`minutes`,
+    /// `h`/`hour`/`hours`, `d`/`day`/`days`, `w`/`week`/`weeks`.
     pub fn get_duration(&self, path: &str) -> Result<std::time::Duration, ConfigError> {
         match self.lookup_node(path) {
             None => Err(missing(path)),
@@ -195,8 +200,11 @@ impl Config {
     /// Accepts HOCON byte-size strings (e.g., `"512 MB"`, `"1 GiB"`).
     /// Bare integers are returned as-is (assumed bytes).
     ///
-    /// Supported units: `B`, `KB`/`KiB`, `MB`/`MiB`, `GB`/`GiB`, `TB`/`TiB`
-    /// (and long forms like `megabytes`, `mebibytes`).
+    /// Supported units: `B`/`byte`/`bytes`, `K`/`KB`/`kilobyte`/`kilobytes`,
+    /// `KiB`/`kibibyte`/`kibibytes`, `M`/`MB`/`megabyte`/`megabytes`,
+    /// `MiB`/`mebibyte`/`mebibytes`, `G`/`GB`/`gigabyte`/`gigabytes`,
+    /// `GiB`/`gibibyte`/`gibibytes`, `T`/`TB`/`terabyte`/`terabytes`,
+    /// `TiB`/`tebibyte`/`tebibytes`. Fractional numbers (e.g. `0.5M`) are supported.
     pub fn get_bytes(&self, path: &str) -> Result<i64, ConfigError> {
         let v = self.lookup_node(path).ok_or_else(|| ConfigError {
             message: format!("path not found: {}", path),
@@ -373,29 +381,33 @@ fn parse_duration(s: &str) -> Option<std::time::Duration> {
 fn parse_bytes(s: &str) -> Option<i64> {
     let s = s.trim();
     let num_end = s
-        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .find(|c: char| !c.is_ascii_digit() && c != '.' && c != '-')
         .unwrap_or(s.len());
     let num_str = s[..num_end].trim();
     let unit_str = s[num_end..].trim();
 
-    let num: f64 = num_str.parse().ok()?;
-
     // Case-sensitive matching: KB vs KiB matters. Short forms (K, M, G, T) are
     // treated as SI decimal units (KB, MB, GB, TB).
-    let multiplier: f64 = match unit_str {
-        "" | "B" | "byte" | "bytes" => 1.0,
-        "K" | "KB" | "kilobyte" | "kilobytes" => 1_000.0,
-        "KiB" | "kibibyte" | "kibibytes" => 1_024.0,
-        "M" | "MB" | "megabyte" | "megabytes" => 1_000_000.0,
-        "MiB" | "mebibyte" | "mebibytes" => 1_048_576.0,
-        "G" | "GB" | "gigabyte" | "gigabytes" => 1_000_000_000.0,
-        "GiB" | "gibibyte" | "gibibytes" => 1_073_741_824.0,
-        "T" | "TB" | "terabyte" | "terabytes" => 1_000_000_000_000.0,
-        "TiB" | "tebibyte" | "tebibytes" => 1_099_511_627_776.0,
+    let multiplier: i64 = match unit_str {
+        "" | "B" | "byte" | "bytes" => 1,
+        "K" | "KB" | "kilobyte" | "kilobytes" => 1_000,
+        "KiB" | "kibibyte" | "kibibytes" => 1_024,
+        "M" | "MB" | "megabyte" | "megabytes" => 1_000_000,
+        "MiB" | "mebibyte" | "mebibytes" => 1_048_576,
+        "G" | "GB" | "gigabyte" | "gigabytes" => 1_000_000_000,
+        "GiB" | "gibibyte" | "gibibytes" => 1_073_741_824,
+        "T" | "TB" | "terabyte" | "terabytes" => 1_000_000_000_000,
+        "TiB" | "tebibyte" | "tebibytes" => 1_099_511_627_776,
         _ => return None,
     };
 
-    Some((num * multiplier) as i64)
+    // Try lossless integer path first, fall back to f64 for fractional values
+    if let Ok(n) = num_str.parse::<i64>() {
+        Some(n * multiplier)
+    } else {
+        let num: f64 = num_str.parse().ok()?;
+        Some((num * multiplier as f64) as i64)
+    }
 }
 
 fn missing(path: &str) -> ConfigError {

--- a/src/config.rs
+++ b/src/config.rs
@@ -279,21 +279,35 @@ impl Config {
 
 /// Split a HOCON config path into segments, respecting quoted keys.
 /// e.g. `server."web.api".port` → `["server", "web.api", "port"]`
+/// Empty segments are preserved: `a..b` → `["a", "", "b"]`.
+/// Quoted segments process escape sequences (e.g. `\"` → `"`).
 fn split_config_path(path: &str) -> Vec<String> {
     let mut segments = Vec::new();
     let chars: Vec<char> = path.chars().collect();
     let mut i = 0;
     while i < chars.len() {
         if chars[i] == '"' {
-            // Quoted segment — collect until closing quote
+            // Quoted segment — collect until closing quote, processing escapes
             i += 1; // skip opening quote
-            let start = i;
-            while i < chars.len() && chars[i] != '"' {
+            let mut seg = String::new();
+            let mut closed = false;
+            while i < chars.len() {
+                if chars[i] == '\\' && i + 1 < chars.len() {
+                    seg.push(chars[i + 1]);
+                    i += 2;
+                    continue;
+                }
+                if chars[i] == '"' {
+                    closed = true;
+                    i += 1;
+                    break;
+                }
+                seg.push(chars[i]);
                 i += 1;
             }
-            segments.push(chars[start..i].iter().collect());
-            if i < chars.len() {
-                i += 1; // skip closing quote
+            segments.push(seg);
+            if !closed {
+                break;
             }
             // skip optional '.' separator
             if i < chars.len() && chars[i] == '.' {
@@ -301,18 +315,21 @@ fn split_config_path(path: &str) -> Vec<String> {
             }
         } else {
             // Unquoted segment — collect until '.' or '"'
+            // Always push the segment (even empty) to preserve consecutive-dot semantics.
             let start = i;
             while i < chars.len() && chars[i] != '.' && chars[i] != '"' {
                 i += 1;
             }
-            if i > start {
-                segments.push(chars[start..i].iter().collect());
-            }
+            segments.push(chars[start..i].iter().collect());
             // skip optional '.' separator
             if i < chars.len() && chars[i] == '.' {
                 i += 1;
             }
         }
+    }
+    // A trailing dot means there is a final empty segment
+    if path.ends_with('.') {
+        segments.push(String::new());
     }
     segments
 }
@@ -406,7 +423,7 @@ fn parse_bytes(s: &str) -> Option<i64> {
         n.checked_mul(multiplier)
     } else {
         let num: f64 = num_str.parse().ok()?;
-        Some((num * multiplier as f64) as i64)
+        Some((num * multiplier as f64).round() as i64)
     }
 }
 
@@ -808,5 +825,37 @@ mod tests {
     fn get_bytes_option_missing() {
         let c = make_config(vec![]);
         assert!(c.get_bytes_option("s").is_none());
+    }
+
+    #[test]
+    fn get_bytes_fractional_rounds() {
+        // 1.5 KiB = 1536 bytes exactly; rounding should not change it
+        let c = make_config(vec![("s", sv("1.5 KiB"))]);
+        assert_eq!(c.get_bytes("s").unwrap(), 1536);
+    }
+
+    #[test]
+    fn split_config_path_consecutive_dots_preserve_empty() {
+        let segs = split_config_path("a..b");
+        assert_eq!(segs, vec!["a", "", "b"]);
+    }
+
+    #[test]
+    fn split_config_path_trailing_dot_empty_segment() {
+        let segs = split_config_path("a.b.");
+        assert_eq!(segs, vec!["a", "b", ""]);
+    }
+
+    #[test]
+    fn split_config_path_quoted_escape() {
+        // "a\"b" as a path key should produce the key: a"b
+        let segs = split_config_path(r#""a\"b""#);
+        assert_eq!(segs, vec!["a\"b"]);
+    }
+
+    #[test]
+    fn split_config_path_quoted_with_dot() {
+        let segs = split_config_path(r#"server."web.api".port"#);
+        assert_eq!(segs, vec!["server", "web.api", "port"]);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -323,13 +323,14 @@ fn parse_duration(s: &str) -> Option<std::time::Duration> {
     let num: f64 = num_str.parse().ok()?;
 
     let nanos_per_unit: f64 = match unit_str.as_str() {
-        "ns" | "nanosecond" | "nanoseconds" => 1.0,
-        "us" | "microsecond" | "microseconds" => 1_000.0,
-        "ms" | "millisecond" | "milliseconds" => 1_000_000.0,
+        "ns" | "nano" | "nanos" | "nanosecond" | "nanoseconds" => 1.0,
+        "us" | "micro" | "micros" | "microsecond" | "microseconds" => 1_000.0,
+        "ms" | "milli" | "millis" | "millisecond" | "milliseconds" => 1_000_000.0,
         "s" | "second" | "seconds" => 1_000_000_000.0,
         "m" | "minute" | "minutes" => 60_000_000_000.0,
         "h" | "hour" | "hours" => 3_600_000_000_000.0,
         "d" | "day" | "days" => 86_400_000_000_000.0,
+        "w" | "week" | "weeks" => 604_800_000_000_000.0,
         _ => return None,
     };
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -24,7 +24,6 @@ pub enum AstNode {
         pos: Pos,
         /// True when this scalar was synthesized by the parser as whitespace
         /// between concatenated tokens (not user-authored).
-        #[allow(dead_code)]
         separator: bool,
     },
     Concat {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -89,7 +89,10 @@ pub fn parse_tokens(tokens: &[Token]) -> Result<AstNode, ParseError> {
         if parser.peek_kind() != TokenKind::Eof {
             let pos = parser.current_pos();
             return Err(ParseError {
-                message: format!("unexpected token after closing brace: {:?}", parser.peek_kind()),
+                message: format!(
+                    "unexpected token after closing brace: {:?}",
+                    parser.peek_kind()
+                ),
                 line: pos.line,
                 col: pos.col,
             });

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -51,6 +51,7 @@ pub fn parse_tokens(tokens: &[Token]) -> Result<AstNode, ParseError> {
     let mut parser = Parser { tokens, pos: 0 };
     parser.skip(&[TokenKind::Newline]);
     if parser.peek_kind() == TokenKind::LBrace {
+        let first_pos = parser.current_pos();
         parser.pos += 1;
         let node = parser.parse_object(true)?;
         let mut all_fields = match node {
@@ -80,9 +81,20 @@ pub fn parse_tokens(tokens: &[Token]) -> Result<AstNode, ParseError> {
             }
         }
 
+        // Verify no remaining tokens after braced root (e.g. stray `}`)
+        parser.skip(&[TokenKind::Newline]);
+        if parser.peek_kind() != TokenKind::Eof {
+            let pos = parser.current_pos();
+            return Err(ParseError {
+                message: format!("unexpected token after closing brace: {:?}", parser.peek_kind()),
+                line: pos.line,
+                col: pos.col,
+            });
+        }
+
         Ok(AstNode::Object {
             fields: all_fields,
-            pos: Pos { line: 1, col: 1 },
+            pos: first_pos,
         })
     } else {
         parser.parse_object(false)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,6 +22,10 @@ pub enum AstNode {
     Scalar {
         value: ScalarValue,
         pos: Pos,
+        /// True when this scalar was synthesized by the parser as whitespace
+        /// between concatenated tokens (not user-authored).
+        #[allow(dead_code)]
+        separator: bool,
     },
     Concat {
         nodes: Vec<AstNode>,
@@ -398,6 +402,7 @@ impl<'a> Parser<'a> {
                     AstNode::Scalar {
                         value: ScalarValue::String(val),
                         pos: Pos { line, col },
+                        separator: false,
                     }
                 }
                 TokenKind::Unquoted => {
@@ -405,6 +410,7 @@ impl<'a> Parser<'a> {
                     AstNode::Scalar {
                         value: parse_scalar_value(&val),
                         pos: Pos { line, col },
+                        separator: false,
                     }
                 }
                 TokenKind::Colon | TokenKind::Equals if !parts.is_empty() => {
@@ -412,6 +418,7 @@ impl<'a> Parser<'a> {
                     AstNode::Scalar {
                         value: ScalarValue::String(val),
                         pos: Pos { line, col },
+                        separator: false,
                     }
                 }
                 _ => break,
@@ -424,6 +431,7 @@ impl<'a> Parser<'a> {
                         line: t_line,
                         col: t_col,
                     },
+                    separator: true,
                 });
             }
             parts.push(node);

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -50,6 +50,8 @@ struct SubstPlaceholder {
 #[derive(Debug, Clone)]
 struct ConcatPlaceholder {
     nodes: Vec<ResolverValue>,
+    /// Parallel array: true if the corresponding node is a parser-synthesized separator.
+    separator_flags: Vec<bool>,
 }
 
 #[derive(Debug, Clone)]
@@ -225,11 +227,14 @@ fn ast_to_resolver_value(
             col: pos.col,
         })),
         AstNode::Concat { nodes, .. } => {
-            let rv_nodes: Vec<ResolverValue> = nodes
-                .into_iter()
-                .map(|node| ast_to_resolver_value(node, opts))
-                .collect::<Result<_, _>>()?;
-            Ok(ResolverValue::Concat(ConcatPlaceholder { nodes: rv_nodes }))
+            let mut separator_flags = Vec::with_capacity(nodes.len());
+            let mut rv_nodes = Vec::with_capacity(nodes.len());
+            for node in nodes {
+                let is_sep = matches!(node, AstNode::Scalar { separator: true, .. });
+                rv_nodes.push(ast_to_resolver_value(node, opts)?);
+                separator_flags.push(is_sep);
+            }
+            Ok(ResolverValue::Concat(ConcatPlaceholder { nodes: rv_nodes, separator_flags }))
         }
         AstNode::Include { .. } => Ok(ResolverValue::Resolved(HoconValue::Scalar(
             ScalarValue::Null,
@@ -423,7 +428,7 @@ fn resolve_val(
     match v {
         ResolverValue::Subst(s) => resolve_subst(s, scope, root, resolving, cache, env),
         ResolverValue::Concat(c) => {
-            resolve_concat(&c.nodes, scope, root, resolving, cache, env).map(Some)
+            resolve_concat(&c.nodes, &c.separator_flags, scope, root, resolving, cache, env).map(Some)
         }
         ResolverValue::Append(a) => resolve_append(a, scope, root, resolving, cache, env).map(Some),
         ResolverValue::Obj(o) => resolve_res_obj(o, root, resolving, cache, env).map(Some),
@@ -529,16 +534,18 @@ fn resolve_subst(
 
 fn resolve_concat(
     nodes: &[ResolverValue],
+    separator_flags: &[bool],
     scope: &ResObj,
     root: &ResObj,
     resolving: &mut HashSet<String>,
     cache: &mut HashMap<String, HoconValue>,
     env: &HashMap<String, String>,
 ) -> Result<HoconValue, ResolveError> {
-    let mut resolved = Vec::new();
-    for n in nodes {
+    let mut resolved: Vec<(HoconValue, bool)> = Vec::new();
+    for (i, n) in nodes.iter().enumerate() {
+        let is_sep = separator_flags.get(i).copied().unwrap_or(false);
         if let Some(v) = resolve_val(n, scope, root, resolving, cache, env)? {
-            resolved.push(v);
+            resolved.push((v, is_sep));
         }
     }
 
@@ -546,22 +553,20 @@ fn resolve_concat(
         return Ok(HoconValue::Scalar(ScalarValue::Null));
     }
     if resolved.len() == 1 {
-        return Ok(resolved.into_iter().next().unwrap());
+        return Ok(resolved.into_iter().next().unwrap().0);
     }
 
-    // Object concatenation — whitespace-only string scalars between objects are ignored
-    // (the parser inserts a literal " " between space-separated tokens)
-    let is_whitespace_scalar = |v: &HoconValue| matches!(
-        v,
-        HoconValue::Scalar(ScalarValue::String(s)) if s.trim().is_empty()
-    );
+    // Object concatenation — only skip parser-synthesized separators (not user-authored strings).
     if resolved
         .iter()
-        .all(|v| matches!(v, HoconValue::Object(_)) || is_whitespace_scalar(v))
-        && resolved.iter().any(|v| matches!(v, HoconValue::Object(_)))
+        .all(|(v, is_sep)| matches!(v, HoconValue::Object(_)) || *is_sep)
+        && resolved.iter().any(|(v, _)| matches!(v, HoconValue::Object(_)))
     {
         let mut merged = IndexMap::new();
-        for v in resolved {
+        for (v, is_sep) in resolved {
+            if is_sep {
+                continue; // skip parser-synthesized separator whitespace
+            }
             if let HoconValue::Object(fields) = v {
                 for (k, val) in fields {
                     if let (Some(HoconValue::Object(existing)), HoconValue::Object(new_fields)) =
@@ -573,15 +578,14 @@ fn resolve_concat(
                     }
                 }
             }
-            // whitespace scalars are skipped
         }
         return Ok(HoconValue::Object(merged));
     }
 
     // Array concatenation
-    if resolved.iter().any(|v| matches!(v, HoconValue::Array(_))) {
+    if resolved.iter().any(|(v, _)| matches!(v, HoconValue::Array(_))) {
         let mut items = Vec::new();
-        for v in resolved {
+        for (v, _) in resolved {
             match v {
                 HoconValue::Array(arr) => items.extend(arr),
                 other => items.push(other),
@@ -591,7 +595,7 @@ fn resolve_concat(
     }
 
     // String concatenation
-    let s: String = resolved.iter().map(stringify_value).collect();
+    let s: String = resolved.iter().map(|(v, _)| stringify_value(v)).collect();
     Ok(HoconValue::Scalar(ScalarValue::String(s)))
 }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -549,15 +549,31 @@ fn resolve_concat(
         return Ok(resolved.into_iter().next().unwrap());
     }
 
-    // Object concatenation
-    if resolved.iter().all(|v| matches!(v, HoconValue::Object(_))) {
+    // Object concatenation — whitespace-only string scalars between objects are ignored
+    // (the parser inserts a literal " " between space-separated tokens)
+    let is_whitespace_scalar = |v: &HoconValue| matches!(
+        v,
+        HoconValue::Scalar(ScalarValue::String(s)) if s.trim().is_empty()
+    );
+    if resolved
+        .iter()
+        .all(|v| matches!(v, HoconValue::Object(_)) || is_whitespace_scalar(v))
+        && resolved.iter().any(|v| matches!(v, HoconValue::Object(_)))
+    {
         let mut merged = IndexMap::new();
         for v in resolved {
             if let HoconValue::Object(fields) = v {
                 for (k, val) in fields {
-                    merged.insert(k, val);
+                    if let (Some(HoconValue::Object(existing)), HoconValue::Object(new_fields)) =
+                        (merged.get(&k).cloned(), &val)
+                    {
+                        merged.insert(k, deep_merge_hocon_objects(existing, new_fields.clone()));
+                    } else {
+                        merged.insert(k, val);
+                    }
                 }
             }
+            // whitespace scalars are skipped
         }
         return Ok(HoconValue::Object(merged));
     }
@@ -577,6 +593,23 @@ fn resolve_concat(
     // String concatenation
     let s: String = resolved.iter().map(stringify_value).collect();
     Ok(HoconValue::Scalar(ScalarValue::String(s)))
+}
+
+fn deep_merge_hocon_objects(
+    base: IndexMap<String, HoconValue>,
+    overlay: IndexMap<String, HoconValue>,
+) -> HoconValue {
+    let mut merged = base;
+    for (k, v) in overlay {
+        if let (Some(HoconValue::Object(existing)), HoconValue::Object(new_fields)) =
+            (merged.get(&k).cloned(), &v)
+        {
+            merged.insert(k, deep_merge_hocon_objects(existing, new_fields.clone()));
+        } else {
+            merged.insert(k, v);
+        }
+    }
+    HoconValue::Object(merged)
 }
 
 fn resolve_append(

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -230,11 +230,20 @@ fn ast_to_resolver_value(
             let mut separator_flags = Vec::with_capacity(nodes.len());
             let mut rv_nodes = Vec::with_capacity(nodes.len());
             for node in nodes {
-                let is_sep = matches!(node, AstNode::Scalar { separator: true, .. });
+                let is_sep = matches!(
+                    node,
+                    AstNode::Scalar {
+                        separator: true,
+                        ..
+                    }
+                );
                 rv_nodes.push(ast_to_resolver_value(node, opts)?);
                 separator_flags.push(is_sep);
             }
-            Ok(ResolverValue::Concat(ConcatPlaceholder { nodes: rv_nodes, separator_flags }))
+            Ok(ResolverValue::Concat(ConcatPlaceholder {
+                nodes: rv_nodes,
+                separator_flags,
+            }))
         }
         AstNode::Include { .. } => Ok(ResolverValue::Resolved(HoconValue::Scalar(
             ScalarValue::Null,
@@ -427,9 +436,16 @@ fn resolve_val(
 ) -> Result<Option<HoconValue>, ResolveError> {
     match v {
         ResolverValue::Subst(s) => resolve_subst(s, scope, root, resolving, cache, env),
-        ResolverValue::Concat(c) => {
-            resolve_concat(&c.nodes, &c.separator_flags, scope, root, resolving, cache, env).map(Some)
-        }
+        ResolverValue::Concat(c) => resolve_concat(
+            &c.nodes,
+            &c.separator_flags,
+            scope,
+            root,
+            resolving,
+            cache,
+            env,
+        )
+        .map(Some),
         ResolverValue::Append(a) => resolve_append(a, scope, root, resolving, cache, env).map(Some),
         ResolverValue::Obj(o) => resolve_res_obj(o, root, resolving, cache, env).map(Some),
         ResolverValue::UnresolvedArray(items) => {
@@ -560,7 +576,9 @@ fn resolve_concat(
     if resolved
         .iter()
         .all(|(v, is_sep)| matches!(v, HoconValue::Object(_)) || *is_sep)
-        && resolved.iter().any(|(v, _)| matches!(v, HoconValue::Object(_)))
+        && resolved
+            .iter()
+            .any(|(v, _)| matches!(v, HoconValue::Object(_)))
     {
         let mut merged = IndexMap::new();
         for (v, is_sep) in resolved {
@@ -583,7 +601,10 @@ fn resolve_concat(
     }
 
     // Array concatenation
-    if resolved.iter().any(|(v, _)| matches!(v, HoconValue::Array(_))) {
+    if resolved
+        .iter()
+        .any(|(v, _)| matches!(v, HoconValue::Array(_)))
+    {
         let mut items = Vec::new();
         for (v, _) in resolved {
             match v {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -170,6 +170,31 @@ fn test_trailing_comments_after_braced_root_ok() {
     assert!(result2.is_ok(), "trailing # comments should be accepted");
 }
 
+// Task 11: get_string coercion for non-string scalars
+#[test]
+fn test_get_string_coerces_int() {
+    let cfg = hocon::parse("port = 8080").unwrap();
+    assert_eq!(cfg.get_string("port").unwrap(), "8080");
+}
+
+#[test]
+fn test_get_string_coerces_float() {
+    let cfg = hocon::parse("ratio = 3.14").unwrap();
+    assert_eq!(cfg.get_string("ratio").unwrap(), "3.14");
+}
+
+#[test]
+fn test_get_string_coerces_bool() {
+    let cfg = hocon::parse("enabled = true").unwrap();
+    assert_eq!(cfg.get_string("enabled").unwrap(), "true");
+}
+
+#[test]
+fn test_get_string_coerces_null() {
+    let cfg = hocon::parse("val = null").unwrap();
+    assert_eq!(cfg.get_string("val").unwrap(), "null");
+}
+
 // Task 10: object concatenation deep-merge
 #[test]
 fn test_object_concat_deep_merge() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -169,3 +169,19 @@ fn test_trailing_comments_after_braced_root_ok() {
     let result2 = hocon::parse("{ a = 1 } # comment");
     assert!(result2.is_ok(), "trailing # comments should be accepted");
 }
+
+// Task 10: object concatenation deep-merge
+#[test]
+fn test_object_concat_deep_merge() {
+    let cfg = hocon::parse(r#"a = {x: {y: 1}} {x: {z: 2}}"#).unwrap();
+    assert_eq!(cfg.get_i64("a.x.y").unwrap(), 1);
+    assert_eq!(cfg.get_i64("a.x.z").unwrap(), 2);
+}
+
+#[test]
+fn test_object_concat_deep_merge_multiple() {
+    let cfg = hocon::parse(r#"a = {nested: {a: 1}} {nested: {b: 2}} {nested: {c: 3}}"#).unwrap();
+    assert_eq!(cfg.get_i64("a.nested.a").unwrap(), 1);
+    assert_eq!(cfg.get_i64("a.nested.b").unwrap(), 2);
+    assert_eq!(cfg.get_i64("a.nested.c").unwrap(), 3);
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -170,6 +170,27 @@ fn test_trailing_comments_after_braced_root_ok() {
     assert!(result2.is_ok(), "trailing # comments should be accepted");
 }
 
+// Task 12: duration parsing missing units
+#[test]
+fn test_duration_missing_units() {
+    let tests = vec![
+        ("dur = 1 milli", "dur", 1_000_000u128),
+        ("dur = 2000 micros", "dur", 2_000_000u128),
+        ("dur = 500 nano", "dur", 500u128),
+        ("dur = 500 nanos", "dur", 500u128),
+        ("dur = 1 nanosecond", "dur", 1u128),
+        ("dur = 1 microsecond", "dur", 1_000u128),
+        ("dur = 1 millis", "dur", 1_000_000u128),
+        ("dur = 1 millisecond", "dur", 1_000_000u128),
+        ("dur = 1w", "dur", 604_800_000_000_000u128),
+    ];
+    for (input, path, expected_nanos) in tests {
+        let cfg = hocon::parse(input).unwrap();
+        let dur = cfg.get_duration(path).unwrap();
+        assert_eq!(dur.as_nanos(), expected_nanos, "failed for input: {}", input);
+    }
+}
+
 // Task 11: get_string coercion for non-string scalars
 #[test]
 fn test_get_string_coerces_int() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -216,7 +216,12 @@ fn test_duration_missing_units() {
     for (input, path, expected_nanos) in tests {
         let cfg = hocon::parse(input).unwrap();
         let dur = cfg.get_duration(path).unwrap();
-        assert_eq!(dur.as_nanos(), expected_nanos, "failed for input: {}", input);
+        assert_eq!(
+            dur.as_nanos(),
+            expected_nanos,
+            "failed for input: {}",
+            input
+        );
     }
 }
 
@@ -264,4 +269,18 @@ fn test_object_concat_deep_merge_multiple() {
 #[test]
 fn test_stray_brace_after_root() {
     assert!(hocon::parse("{ a = 1 } }").is_err());
+}
+
+#[test]
+fn test_parse_bytes_overflow_returns_none() {
+    // Fractional value that overflows i64 should return error, not bogus value
+    let cfg = hocon::parse("size = 99999999999999999.0TiB").unwrap();
+    assert!(cfg.get_bytes("size").is_err());
+}
+
+#[test]
+fn test_unterminated_quoted_path_fallback() {
+    // Unterminated quoted path should fall back to literal (no panic)
+    let cfg = hocon::parse("a = 1").unwrap();
+    assert!(cfg.get_i64(r#""unterminated"#).is_err());
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -260,3 +260,8 @@ fn test_object_concat_deep_merge_multiple() {
     assert_eq!(cfg.get_i64("a.nested.b").unwrap(), 2);
     assert_eq!(cfg.get_i64("a.nested.c").unwrap(), 3);
 }
+
+#[test]
+fn test_stray_brace_after_root() {
+    assert!(hocon::parse("{ a = 1 } }").is_err());
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -170,6 +170,20 @@ fn test_trailing_comments_after_braced_root_ok() {
     assert!(result2.is_ok(), "trailing # comments should be accepted");
 }
 
+// Task 14: quoted path segments in Config lookups
+#[test]
+fn test_quoted_path_lookup() {
+    let cfg = hocon::parse(r#""a.b" = 1"#).unwrap();
+    assert!(cfg.has(r#""a.b""#));
+    assert_eq!(cfg.get_i64(r#""a.b""#).unwrap(), 1);
+}
+
+#[test]
+fn test_nested_quoted_path_lookup() {
+    let cfg = hocon::parse(r#"server { "web.api" { port = 8080 } }"#).unwrap();
+    assert_eq!(cfg.get_i64(r#"server."web.api".port"#).unwrap(), 8080);
+}
+
 // Task 13: parse_bytes fractional number support
 #[test]
 fn test_parse_bytes_fractional() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -170,6 +170,21 @@ fn test_trailing_comments_after_braced_root_ok() {
     assert!(result2.is_ok(), "trailing # comments should be accepted");
 }
 
+// Task 13: parse_bytes fractional number support
+#[test]
+fn test_parse_bytes_fractional() {
+    let cfg = hocon::parse("size = 0.5M").unwrap();
+    let bytes = cfg.get_bytes("size").unwrap();
+    assert_eq!(bytes, 500_000);
+}
+
+#[test]
+fn test_parse_bytes_fractional_binary() {
+    let cfg = hocon::parse("size = 1.5MiB").unwrap();
+    let bytes = cfg.get_bytes("size").unwrap();
+    assert_eq!(bytes, 1_572_864);
+}
+
 // Task 12: duration parsing missing units
 #[test]
 fn test_duration_missing_units() {


### PR DESCRIPTION
## Summary
- **Object concatenation deep-merge** — recursive merge instead of shallow (Closes #13)
- **`get_string` coercion** — Int/Float/Bool/Null coerced to String per HOCON spec (Closes #11)
- **Duration parsing** — added missing units: milli, micros, nano, week (Closes #12 duration)
- **`parse_bytes` fractional support** — `0.5M` now works; integer path preserves precision (Closes #12 bytes)
- **Quoted path segments** in Config lookups (Closes #10)
- **Stray `}` detection** + root pos from actual tokens (Phase 1 Copilot followup)
- **Code review fixes** — `parse_bytes` i64 precision, AST separator flag for object concat, doc comments

## Test Plan
- [x] 178 tests passing (`cargo test`, including 19 Lightbend conformance)
- [x] Deep-merge tests: 2-way and 3-way nested merges
- [x] Coercion tests: int, float, bool, null → string
- [x] Duration tests: 9 unit variants including `1w`
- [x] Bytes tests: fractional `0.5M`, `1.5MiB`
- [x] Quoted path tests: dotted keys, nested segments
- [x] Stray brace test: `{ a = 1 } }` returns error
- [x] Reviewed by Claude (code-reviewer) and Codex CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)