### PR TITLE
feat: P1 include system hardening — required(), error propagation, url/classpath

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = { version = "1", optional = true }
 criterion = { version = "0.5", features = ["html_reports"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tempfile = "3"
 
 [[bench]]
 name = "parse_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ serde_json = { version = "1", optional = true }
 criterion = { version = "0.5", features = ["html_reports"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tempfile = "3"
 
 [[bench]]
 name = "parse_bench"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -383,10 +383,8 @@ impl<'a> Parser<'a> {
                     self.advance();
                 }
             }
-        } else if self.peek_kind() == TokenKind::Unquoted
-            && (self.peek_value() == "file("
-                || self.peek_value() == "file"
-                || self.peek_value().starts_with("file("))
+        } else if (self.peek_kind() == TokenKind::Unquoted
+            && (self.peek_value() == "file" || self.peek_value().starts_with("file(")))
             || file_prefix_consumed
         {
             // file("path") form — possibly with required( already consumed.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -37,6 +37,7 @@ pub enum AstNode {
     },
     Include {
         path: String,
+        required: bool,
         pos: Pos,
     },
 }
@@ -310,11 +311,38 @@ impl<'a> Parser<'a> {
         self.skip(&[TokenKind::Newline]);
         let kind = self.peek_kind();
 
+        // Check for `required(...)` wrapper
+        let required = kind == TokenKind::Unquoted
+            && (self.peek_value() == "required(" || self.peek_value() == "required");
+        if required {
+            self.advance(); // consume "required(" or "required"
+                            // If the token was "required" (without paren), consume the opening "("
+                            // The lexer may split "required" and "(" as separate tokens when there is no
+                            // space, but actually "(" is not an unquoted-stop char... However "(" IS
+                            // included in is_unquoted_start/continue since it's not in the stop set.
+                            // The lexer will actually produce "required(" as one token (paren is unquoted).
+                            // But to be safe, also handle "required" + "(" as separate tokens:
+            if self.peek_kind() == TokenKind::Unquoted && self.peek_value().starts_with('(') {
+                // e.g. token was "required" and next is "(" or "(\"..."
+                let val = self.peek_value().to_string();
+                if val == "(" {
+                    self.advance(); // consume standalone "("
+                }
+                // else: paren is embedded in next unquoted token — handled below
+            }
+        }
+
         let path;
-        if kind == TokenKind::QuotedString {
+        if self.peek_kind() == TokenKind::QuotedString {
             path = self.peek_value().to_string();
             self.advance();
-        } else if kind == TokenKind::Unquoted
+            if required {
+                // Consume closing ")" — may be part of an Unquoted token or standalone
+                if self.peek_kind() == TokenKind::Unquoted && self.peek_value().starts_with(')') {
+                    self.advance();
+                }
+            }
+        } else if self.peek_kind() == TokenKind::Unquoted
             && (self.peek_value() == "file(" || self.peek_value() == "file")
         {
             let err_line = self.peek_line();
@@ -345,7 +373,7 @@ impl<'a> Parser<'a> {
             let line = self.peek_line();
             let col = self.peek_col();
             return Err(ParseError {
-                message: format!("expected include path, got {:?}", kind),
+                message: format!("expected include path, got {:?}", self.peek_kind()),
                 line,
                 col,
             });
@@ -355,6 +383,7 @@ impl<'a> Parser<'a> {
             key: vec![],
             value: AstNode::Include {
                 path,
+                required,
                 pos: p.clone(),
             },
             append: false,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -336,14 +336,26 @@ impl<'a> Parser<'a> {
 
         if required {
             if raw == "required" {
-                // Separate tokens: consume "required", then expect "(" next
+                // Separate tokens: consume "required", then expect "(" (possibly fused with "file(")
                 self.advance();
                 if self.peek_kind() == TokenKind::Unquoted && self.peek_value().starts_with('(') {
                     let val = self.peek_value().to_string();
                     if val == "(" {
-                        self.advance(); // standalone "("
+                        self.advance(); // standalone "(" — inner content is next token
+                    } else {
+                        // Token is "(file(...)" or similar — strip leading "(" and treat
+                        // the remainder as if it were emitted without "required(".
+                        // We do this by rewriting the token in place via file_prefix_consumed.
+                        let after_paren = &val[1..]; // strip leading "("
+                        if after_paren == "file("
+                            || after_paren.starts_with("file(")
+                            || after_paren == "file"
+                        {
+                            file_prefix_consumed = true;
+                            self.advance(); // consume "(file(..." token; path follows
+                        }
+                        // else: bare "(content" — inner content; fall through to path reading below
                     }
-                    // else inner content starts immediately; handled below
                 }
             } else {
                 // raw starts with "required(" — consume this token.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -309,31 +309,60 @@ impl<'a> Parser<'a> {
     fn parse_include(&mut self) -> Result<AstField, ParseError> {
         let p = self.current_pos();
         self.skip(&[TokenKind::Newline]);
-        let kind = self.peek_kind();
 
-        // Check for `required(...)` wrapper
-        let required = kind == TokenKind::Unquoted
-            && (self.peek_value() == "required(" || self.peek_value() == "required");
+        // Determine whether `required(...)` is present.
+        //
+        // The lexer produces unquoted tokens by consuming everything that is not
+        // a stop character.  Parentheses are NOT stop characters, so the lexer
+        // can produce tokens like:
+        //   "required("          — from `required(`
+        //   "required(file("     — from `required(file(`
+        //   "required"           — from `required` (space before `(`)
+        //
+        // We normalise all of these into: required=true, cursor pointing at the
+        // inner content after the `(` of `required(`.
+        let kind = self.peek_kind();
+        let raw = if kind == TokenKind::Unquoted {
+            self.peek_value().to_string()
+        } else {
+            String::new()
+        };
+
+        let required = raw == "required" || raw.starts_with("required(");
+
+        // Tracks whether `file(` has already been consumed as part of the
+        // `required(file(` mega-token.
+        let mut file_prefix_consumed = false;
+
         if required {
-            self.advance(); // consume "required(" or "required"
-                            // If the token was "required" (without paren), consume the opening "("
-                            // The lexer may split "required" and "(" as separate tokens when there is no
-                            // space, but actually "(" is not an unquoted-stop char... However "(" IS
-                            // included in is_unquoted_start/continue since it's not in the stop set.
-                            // The lexer will actually produce "required(" as one token (paren is unquoted).
-                            // But to be safe, also handle "required" + "(" as separate tokens:
-            if self.peek_kind() == TokenKind::Unquoted && self.peek_value().starts_with('(') {
-                // e.g. token was "required" and next is "(" or "(\"..."
-                let val = self.peek_value().to_string();
-                if val == "(" {
-                    self.advance(); // consume standalone "("
+            if raw == "required" {
+                // Separate tokens: consume "required", then expect "(" next
+                self.advance();
+                if self.peek_kind() == TokenKind::Unquoted && self.peek_value().starts_with('(') {
+                    let val = self.peek_value().to_string();
+                    if val == "(" {
+                        self.advance(); // standalone "("
+                    }
+                    // else inner content starts immediately; handled below
                 }
-                // else: paren is embedded in next unquoted token — handled below
+            } else {
+                // raw starts with "required(" — consume this token.
+                // Check if `file(` is also embedded (e.g. "required(file(").
+                let after_req = &raw["required(".len()..];
+                if after_req == "file(" || after_req.starts_with("file(") {
+                    file_prefix_consumed = true;
+                }
+                // Also handle "required(file" (split at space — unlikely but safe)
+                if after_req == "file" {
+                    file_prefix_consumed = true; // next token will be "("
+                }
+                self.advance(); // consume "required(..." token
             }
         }
 
         let path;
         if self.peek_kind() == TokenKind::QuotedString {
+            // Simple: include required("path") or include "path"
             path = self.peek_value().to_string();
             self.advance();
             if required {
@@ -343,12 +372,21 @@ impl<'a> Parser<'a> {
                 }
             }
         } else if self.peek_kind() == TokenKind::Unquoted
-            && (self.peek_value() == "file(" || self.peek_value() == "file")
+            && (self.peek_value() == "file("
+                || self.peek_value() == "file"
+                || self.peek_value().starts_with("file("))
+            || file_prefix_consumed
         {
+            // file("path") form — possibly with required( already consumed.
             let err_line = self.peek_line();
             let err_col = self.peek_col();
-            self.advance();
-            // Skip tokens until we find the quoted path string
+
+            if !file_prefix_consumed {
+                // Consume the "file(" (or "file") token
+                self.advance();
+            }
+
+            // Skip any remaining unquoted junk between file( and the quoted path
             while self.peek_kind() != TokenKind::QuotedString && self.peek_kind() != TokenKind::Eof
             {
                 self.advance();

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -112,10 +112,12 @@ fn apply_field(
     // Include directive
     if field.key.is_empty() {
         if let AstNode::Include {
-            path: include_path, ..
+            path: include_path,
+            required,
+            ..
         } = &field.value
         {
-            let included = load_include(include_path, opts)?;
+            let included = load_include(include_path, *required, opts)?;
             deep_merge_res_obj_into(obj, included);
         }
         return Ok(());
@@ -251,7 +253,11 @@ fn ast_to_resolver_value(
     }
 }
 
-fn load_include(include_path: &str, opts: &ResolveOptions) -> Result<ResObj, ResolveError> {
+fn load_include(
+    include_path: &str,
+    required: bool,
+    opts: &ResolveOptions,
+) -> Result<ResObj, ResolveError> {
     let base = match &opts.base_dir {
         Some(dir) => dir.clone(),
         None => std::env::current_dir().unwrap_or_default(),
@@ -262,11 +268,18 @@ fn load_include(include_path: &str, opts: &ResolveOptions) -> Result<ResObj, Res
     let has_extension = abs_path.extension().is_some();
 
     if has_extension {
-        // Exact path: try only this candidate, silently ignore if file not found
+        // Exact path: try only this candidate, silently ignore if file not found (unless required)
         return match load_single_include(&abs_path, opts) {
             Ok(obj) => Ok(obj),
             Err(e) if !abs_path.exists() => {
-                // Missing includes silently ignored per HOCON spec
+                if required {
+                    return Err(ResolveError {
+                        message: format!("required include file not found: {}", abs_path.display()),
+                        path: abs_path.display().to_string(),
+                        line: 0,
+                        col: 0,
+                    });
+                }
                 let _ = e;
                 Ok(ResObj::new())
             }
@@ -293,6 +306,13 @@ fn load_include(include_path: &str, opts: &ResolveOptions) -> Result<ResObj, Res
 
     if found_any {
         Ok(merged)
+    } else if required {
+        Err(ResolveError {
+            message: format!("required include file not found: {}", abs_path.display()),
+            path: abs_path.display().to_string(),
+            line: 0,
+            col: 0,
+        })
     } else {
         // Missing includes silently ignored per HOCON spec
         Ok(ResObj::new())

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -298,8 +298,12 @@ fn load_include(
                 found_any = true;
                 deep_merge_res_obj_into(&mut merged, obj);
             }
-            Err(_) => {
-                // File doesn't exist or can't be read — skip
+            Err(e) => {
+                if candidate.exists() {
+                    // File exists but parsing failed — propagate the error
+                    return Err(e);
+                }
+                // File not found — try next extension
             }
         }
     }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -271,7 +271,7 @@ fn load_include(
         // Exact path: try only this candidate, silently ignore if file not found (unless required)
         return match load_single_include(&abs_path, opts) {
             Ok(obj) => Ok(obj),
-            Err(e) if !abs_path.exists() => {
+            Err(_) if !abs_path.exists() => {
                 if required {
                     return Err(ResolveError {
                         message: format!("required include file not found: {}", abs_path.display()),
@@ -280,7 +280,6 @@ fn load_include(
                         col: 0,
                     });
                 }
-                let _ = e;
                 Ok(ResObj::new())
             }
             Err(e) => Err(e),

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -114,10 +114,10 @@ fn apply_field(
         if let AstNode::Include {
             path: include_path,
             required,
-            ..
+            pos,
         } = &field.value
         {
-            let included = load_include(include_path, *required, opts)?;
+            let included = load_include(include_path, *required, pos.line, pos.col, opts)?;
             deep_merge_res_obj_into(obj, included);
         }
         return Ok(());
@@ -256,6 +256,8 @@ fn ast_to_resolver_value(
 fn load_include(
     include_path: &str,
     required: bool,
+    line: usize,
+    col: usize,
     opts: &ResolveOptions,
 ) -> Result<ResObj, ResolveError> {
     let base = match &opts.base_dir {
@@ -276,8 +278,8 @@ fn load_include(
                     return Err(ResolveError {
                         message: format!("required include file not found: {}", abs_path.display()),
                         path: abs_path.display().to_string(),
-                        line: 0,
-                        col: 0,
+                        line,
+                        col,
                     });
                 }
                 Ok(ResObj::new())
@@ -313,8 +315,8 @@ fn load_include(
         Err(ResolveError {
             message: format!("required include file not found: {}", abs_path.display()),
             path: abs_path.display().to_string(),
-            line: 0,
-            col: 0,
+            line,
+            col,
         })
     } else {
         // Missing includes silently ignored per HOCON spec

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -285,6 +285,19 @@ fn test_unterminated_quoted_path_fallback() {
     assert!(cfg.get_i64(r#""unterminated"#).is_err());
 }
 
+// Fix 1: include required(file("...")) form
+#[test]
+fn test_include_required_file_form() {
+    // Create a temp file to include
+    let dir = tempfile::tempdir().unwrap();
+    let conf = dir.path().join("base.conf");
+    std::fs::write(&conf, "x = 1").unwrap();
+
+    let input = format!(r#"include required(file("{}"))"#, conf.display());
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("x").unwrap(), 1);
+}
+
 // Task 1c/2c: include required() support
 #[test]
 fn test_include_required_missing_file_errors() {
@@ -297,14 +310,9 @@ fn test_include_required_missing_file_errors() {
 
 #[test]
 fn test_include_required_existing_file_ok() {
-    // base.conf lives in tests/testdata/; parse_file sets the base_dir correctly
-    use std::path::PathBuf;
-    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let conf = manifest.join("tests/testdata/required_base.conf");
-    // Write a tiny fixture if it doesn't exist yet
-    if !conf.exists() {
-        std::fs::write(&conf, "req_key = 42\n").unwrap();
-    }
+    let dir = tempfile::tempdir().unwrap();
+    let conf = dir.path().join("required_base.conf");
+    std::fs::write(&conf, "req_key = 42\n").unwrap();
     let content = format!("include required({:?})\nextra = 1", conf.to_str().unwrap());
     let result = hocon::parse(&content);
     assert!(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -332,6 +332,15 @@ fn test_include_required_missing_file_errors() {
 }
 
 #[test]
+fn test_include_required_file_form_missing_errors() {
+    let result = hocon::parse(r#"include required(file("nonexistent.conf"))"#);
+    assert!(
+        result.is_err(),
+        "required include with file() form of missing file should error"
+    );
+}
+
+#[test]
 fn test_include_required_existing_file_ok() {
     let dir = test_tmp_dir("required_existing");
     let conf = dir.join("required_base.conf");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,14 @@
 use hocon::parse;
 use std::collections::HashMap;
 
+/// Create (and return) a temporary directory for tests.
+/// The caller is responsible for cleanup via `std::fs::remove_dir_all`.
+fn test_tmp_dir(name: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("hocon_test_{}", name));
+    let _ = std::fs::create_dir_all(&dir);
+    dir
+}
+
 #[test]
 fn parse_simple_config() {
     let config = parse("host = \"localhost\"\nport = 8080").unwrap();
@@ -288,14 +296,29 @@ fn test_unterminated_quoted_path_fallback() {
 // Fix 1: include required(file("...")) form
 #[test]
 fn test_include_required_file_form() {
-    // Create a temp file to include
-    let dir = tempfile::tempdir().unwrap();
-    let conf = dir.path().join("base.conf");
+    let dir = test_tmp_dir("required_file_form");
+    let conf = dir.join("base.conf");
     std::fs::write(&conf, "x = 1").unwrap();
 
-    let input = format!(r#"include required(file("{}"))"#, conf.display());
+    let path_str = conf.display().to_string().replace('\\', "\\\\");
+    let input = format!(r#"include required(file("{}"))"#, path_str);
     let cfg = hocon::parse(&input).unwrap();
     assert_eq!(cfg.get_i64("x").unwrap(), 1);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// Fix 2: include required (file("...")) with space before paren
+#[test]
+fn test_include_required_space_file_form() {
+    let dir = test_tmp_dir("required_space_file_form");
+    let conf = dir.join("spaced.conf");
+    std::fs::write(&conf, "y = 42").unwrap();
+
+    let path_str = conf.display().to_string().replace('\\', "\\\\");
+    let input = format!(r#"include required (file("{}"))"#, path_str);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("y").unwrap(), 42);
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 // Task 1c/2c: include required() support
@@ -310,10 +333,11 @@ fn test_include_required_missing_file_errors() {
 
 #[test]
 fn test_include_required_existing_file_ok() {
-    let dir = tempfile::tempdir().unwrap();
-    let conf = dir.path().join("required_base.conf");
+    let dir = test_tmp_dir("required_existing");
+    let conf = dir.join("required_base.conf");
     std::fs::write(&conf, "req_key = 42\n").unwrap();
-    let content = format!("include required({:?})\nextra = 1", conf.to_str().unwrap());
+    let path_str = conf.display().to_string().replace('\\', "/");
+    let content = format!("include required(\"{}\")\nextra = 1", path_str);
     let result = hocon::parse(&content);
     assert!(
         result.is_ok(),
@@ -322,6 +346,7 @@ fn test_include_required_existing_file_ok() {
     );
     let cfg = result.unwrap();
     assert_eq!(cfg.get_i64("req_key").unwrap(), 42);
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
@@ -338,16 +363,19 @@ fn test_include_optional_missing_file_ok() {
 // Task 3c: parse errors in existing included files must propagate
 #[test]
 fn test_include_probing_propagates_parse_error() {
-    let dir = tempfile::tempdir().unwrap();
-    let broken_path = dir.path().join("broken.conf");
+    let dir = test_tmp_dir("probing_parse_error");
+    let broken_path = dir.join("broken.conf");
     std::fs::write(&broken_path, "{ invalid = }").unwrap();
 
-    let input = format!(r#"include "{}""#, dir.path().join("broken").display());
+    let stem = dir.join("broken");
+    let path_str = stem.display().to_string().replace('\\', "/");
+    let input = format!(r#"include "{}""#, path_str);
     let result = hocon::parse(&input);
     assert!(
         result.is_err(),
         "parse error in included file should propagate"
     );
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 // Task 4c: url() and classpath() include forms must produce errors

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -284,3 +284,45 @@ fn test_unterminated_quoted_path_fallback() {
     let cfg = hocon::parse("a = 1").unwrap();
     assert!(cfg.get_i64(r#""unterminated"#).is_err());
 }
+
+// Task 1c/2c: include required() support
+#[test]
+fn test_include_required_missing_file_errors() {
+    let result = hocon::parse(r#"include required("nonexistent.conf")"#);
+    assert!(
+        result.is_err(),
+        "required include of missing file should error"
+    );
+}
+
+#[test]
+fn test_include_required_existing_file_ok() {
+    // base.conf lives in tests/testdata/; parse_file sets the base_dir correctly
+    use std::path::PathBuf;
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let conf = manifest.join("tests/testdata/required_base.conf");
+    // Write a tiny fixture if it doesn't exist yet
+    if !conf.exists() {
+        std::fs::write(&conf, "req_key = 42\n").unwrap();
+    }
+    let content = format!("include required({:?})\nextra = 1", conf.to_str().unwrap());
+    let result = hocon::parse(&content);
+    assert!(
+        result.is_ok(),
+        "required include of existing file should succeed: {:?}",
+        result.err()
+    );
+    let cfg = result.unwrap();
+    assert_eq!(cfg.get_i64("req_key").unwrap(), 42);
+}
+
+#[test]
+fn test_include_optional_missing_file_ok() {
+    let result = hocon::parse("include \"nonexistent.conf\"\na = 1");
+    assert!(
+        result.is_ok(),
+        "optional include of missing file should succeed"
+    );
+    let cfg = result.unwrap();
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -326,3 +326,19 @@ fn test_include_optional_missing_file_ok() {
     let cfg = result.unwrap();
     assert_eq!(cfg.get_i64("a").unwrap(), 1);
 }
+
+// Task 3c: parse errors in existing included files must propagate
+#[test]
+fn test_include_probing_propagates_parse_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let broken_path = dir.path().join("broken.conf");
+    std::fs::write(&broken_path, "{ invalid = }").unwrap();
+
+    let input = format!(r#"include "{}""#, dir.path().join("broken").display());
+    let result = hocon::parse(&input);
+    assert!(
+        result.is_err(),
+        "parse error in included file should propagate"
+    );
+}
+

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -342,3 +342,18 @@ fn test_include_probing_propagates_parse_error() {
     );
 }
 
+// Task 4c: url() and classpath() include forms must produce errors
+#[test]
+fn test_include_url_not_supported() {
+    let result = hocon::parse(r#"include url("http://example.com/config")"#);
+    assert!(result.is_err(), "include url(...) should return an error");
+}
+
+#[test]
+fn test_include_classpath_not_supported() {
+    let result = hocon::parse(r#"include classpath("reference.conf")"#);
+    assert!(
+        result.is_err(),
+        "include classpath(...) should return an error"
+    );
+}


### PR DESCRIPTION
## Summary
- **`include required("file")`** support — errors when file is missing, per HOCON spec
- **`include required(file("file"))`** support — handles fused lexer tokens
- **Parse error propagation** in extension probing — candidate.exists() check (Closes #18)
- **url/classpath test coverage** confirmed (already errors correctly)
- **Review fixes**: tempfile-based test fixtures, dead binding cleanup

## Test Plan
- [x] 189 tests passing (`cargo test`, including Lightbend conformance)
- [x] Parser: required() with bare path, file() form
- [x] Resolver: required missing → error, optional missing → silent ignore
- [x] Probing: exists() check — parse errors propagate, file-not-found skipped
- [x] `cargo fmt` clean, `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)