### PR TITLE
fix: P1 error on unknown escape sequences in quoted strings

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -308,7 +308,13 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
                             pos += 4;
                             col += 4;
                         }
-                        _ => value.push(esc),
+                        _ => {
+                            return Err(ParseError {
+                                message: format!("unknown escape sequence: \\{}", esc),
+                                line: sl,
+                                col: col.saturating_sub(1),
+                            });
+                        }
                     }
                 } else {
                     value.push(chars[pos]);

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -310,7 +310,10 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
                         }
                         _ => {
                             return Err(ParseError {
-                                message: format!("unknown escape sequence: \\{}", esc),
+                                message: format!(
+                                    "unknown escape sequence: \\{}",
+                                    esc.escape_debug()
+                                ),
                                 line: sl,
                                 col: col.saturating_sub(1),
                             });

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -402,3 +402,16 @@ fn test_include_classpath_not_supported() {
         "include classpath(...) should return an error"
     );
 }
+
+// Task 2c: unknown escape sequences should error
+#[test]
+fn test_unknown_escape_sequence_error() {
+    let result = hocon::parse(r#"key = "hello\qworld""#);
+    assert!(result.is_err(), "unknown escape \\q should error");
+}
+
+#[test]
+fn test_unknown_escape_a_error() {
+    let result = hocon::parse(r#"key = "\a""#);
+    assert!(result.is_err(), "unknown escape \\a should error");
+}


### PR DESCRIPTION
## Summary
- **Unknown escape sequences** — `\q`, `\a` etc. now error instead of silently dropping backslash
- `\uXXXX` validation and `.properties` parser already correct — no changes needed

## Test Plan
- [x] 193 tests passing (cargo test), including 19 Lightbend conformance
- [x] Unknown escapes: `\q`, `\a` return ParseError
- [x] No regressions in any existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)