### PR TITLE
fix: align benchmark data generators with Go pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,17 +221,17 @@ Measured with [Criterion](https://github.com/bheisler/criterion.rs). Each iterat
 
 | Scenario | ops/sec | Time per op |
 |---|---|---|
-| Small config (10 keys) | ~33,000 | ~30 µs |
-| Medium config (100 keys) | ~1,000 | ~776 µs |
-| Large config (1,000 keys) | ~16 | ~64 ms |
-| 10 substitutions | ~24,000 | ~41 µs |
-| 50 substitutions | ~3,000 | ~321 µs |
-| 100 substitutions | ~1,000 | ~1.0 ms |
-| Depth 5 nesting | ~63,000 | ~16 µs |
-| Depth 10 nesting | ~54,000 | ~19 µs |
-| Depth 20 nesting | ~41,000 | ~24 µs |
+| Small config (10 keys) | ~62,000 | ~16 µs |
+| Medium config (100 keys) | ~19,000 | ~52 µs |
+| Large config (1,000 keys) | ~2,400 | ~408 µs |
+| 10 substitutions | ~37,000 | ~27 µs |
+| 50 substitutions | ~12,000 | ~86 µs |
+| 100 substitutions | ~6,400 | ~156 µs |
+| Depth 5 nesting | ~58,000 | ~17 µs |
+| Depth 10 nesting | ~50,000 | ~20 µs |
+| Depth 20 nesting | ~39,000 | ~26 µs |
 
-For typical application configs (loaded once at startup), the parsing cost is negligible — even a 1,000-key config parses in under 65 ms.
+For typical application configs (loaded once at startup), the parsing cost is negligible — even a 1,000-key config parses in under 0.5 ms.
 
 ## Comparison
 

--- a/benches/parse_bench.rs
+++ b/benches/parse_bench.rs
@@ -14,28 +14,37 @@
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-/// Generate a flat/shallow HOCON config string with `total_keys` keys spread
-/// across objects up to `max_depth` levels deep.
+/// Generate a HOCON config string with `total_keys` keys distributed across
+/// `max_depth` braced groups (matching the Go benchmark generator pattern).
 fn generate_config(total_keys: usize, max_depth: usize) -> String {
+    let max_depth = max_depth.min(total_keys).max(1);
+    let keys_per_group = total_keys / max_depth;
     let mut buf = String::new();
-    for i in 0..total_keys {
-        let depth = if max_depth == 0 { 0 } else { i % max_depth };
-        let segments: Vec<String> = (0..=depth).map(|d| format!("level{d}")).collect();
-        let path = segments.join(".");
-        buf.push_str(&format!("{path}.key{i} = \"value{i}\"\n"));
+    for d in 0..max_depth {
+        let count = if d == max_depth - 1 {
+            total_keys - keys_per_group * (max_depth - 1)
+        } else {
+            keys_per_group
+        };
+        buf.push_str(&format!("group{d} {{\n"));
+        for i in 0..count {
+            buf.push_str(&format!("  key{i} = \"value{d}_{i}\"\n"));
+        }
+        buf.push_str("}\n");
     }
     buf
 }
 
-/// Generate a HOCON string with `count` base keys followed by `count`
-/// substitution keys that reference them via `${}`.
+/// Generate a HOCON string with flat base keys followed by substitution keys
+/// that reference them via `${}` (matching the Go benchmark generator pattern).
 fn generate_with_substitutions(count: usize) -> String {
     let mut buf = String::new();
-    for i in 0..count {
-        buf.push_str(&format!("base.key{i} = \"val{i}\"\n"));
+    let total = count * 2;
+    for i in 0..total {
+        buf.push_str(&format!("base{i} = \"value{i}\"\n"));
     }
     for i in 0..count {
-        buf.push_str(&format!("sub.key{i} = ${{base.key{i}}}\n"));
+        buf.push_str(&format!("sub{i} = ${{base{}}}\n", i % total));
     }
     buf
 }
@@ -70,27 +79,27 @@ fn bench_config_size(c: &mut Criterion) {
     let mut group = c.benchmark_group("config_size");
 
     let small = generate_config(10, 2);
-    let medium = generate_config(100, 3);
-    let large = generate_config(1000, 4);
+    let medium = generate_config(100, 4);
+    let large = generate_config(1000, 6);
 
     group.bench_function("parse_small_10", |b| {
         b.iter(|| {
             let config = hocon::parse(black_box(&small)).unwrap();
-            black_box(config.get_string("level0.key0").unwrap());
+            black_box(config.get_string("group0.key0").unwrap());
         });
     });
 
     group.bench_function("parse_medium_100", |b| {
         b.iter(|| {
             let config = hocon::parse(black_box(&medium)).unwrap();
-            black_box(config.get_string("level0.key0").unwrap());
+            black_box(config.get_string("group0.key0").unwrap());
         });
     });
 
     group.bench_function("parse_large_1000", |b| {
         b.iter(|| {
             let config = hocon::parse(black_box(&large)).unwrap();
-            black_box(config.get_string("level0.key0").unwrap());
+            black_box(config.get_string("group0.key0").unwrap());
         });
     });
 
@@ -111,21 +120,21 @@ fn bench_substitutions(c: &mut Criterion) {
     group.bench_function("substitutions_10", |b| {
         b.iter(|| {
             let config = hocon::parse(black_box(&sub10)).unwrap();
-            black_box(config.get_string("sub.key0").unwrap());
+            black_box(config.get_string("sub0").unwrap());
         });
     });
 
     group.bench_function("substitutions_50", |b| {
         b.iter(|| {
             let config = hocon::parse(black_box(&sub50)).unwrap();
-            black_box(config.get_string("sub.key0").unwrap());
+            black_box(config.get_string("sub0").unwrap());
         });
     });
 
     group.bench_function("substitutions_100", |b| {
         b.iter(|| {
             let config = hocon::parse(black_box(&sub100)).unwrap();
-            black_box(config.get_string("sub.key0").unwrap());
+            black_box(config.get_string("sub0").unwrap());
         });
     });
 


### PR DESCRIPTION
## Summary

- Replace dot-path benchmark generator with braced-object groups matching Go's `generate_config`
- Replace nested substitution keys (`base.key0`) with flat keys (`base0`) matching Go's `generate_with_substitutions`
- Update sample lookup paths accordingly (`group0.key0`, `sub0`)
- Update README Performance table with new numbers

The old generator produced dot-path lines (`level0.level1.key3 = "value3"`) which forced the parser to split dots, build nested objects, and deep-merge for every line. This made the "large" benchmark ~150x slower than Go, but was measuring a different workload, not a real perf difference.

### New benchmark results

| Scenario | Before | After |
|---|---|---|
| Large config (1,000 keys) | ~64 ms | ~408 µs |
| Medium config (100 keys) | ~776 µs | ~52 µs |
| 100 substitutions | ~1.0 ms | ~156 µs |

## Test plan

- [x] `cargo test` passes
- [x] `cargo bench` runs successfully with new generators

🤖 Generated with [Claude Code](https://claude.com/claude-code)