### PR TITLE
fix: v1.0 quick fixes — crate rename and README updates

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -283,6 +283,13 @@ struct AppConfig {
 let cfg: AppConfig = config.deserialize()?; // 起動時に即座に失敗
 ```
 
+## セキュリティに関する注意
+
+信頼できない HOCON 入力を解析する場合、以下に注意してください：
+
+- **include のパストラバーサル:** `include "../../../etc/passwd"` は `base_dir` からの相対パスで解決されます。信頼できない入力を解析する場合は、include パスを検証してください。
+- **入力サイズ:** パーサーには入力サイズの制限がありません。信頼できない入力の場合は、`parse()` を呼ぶ前にサイズを検証してください。
+
 ## ライセンス
 
 Apache License 2.0 — [LICENSE](LICENSE) を参照。

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@
 [![codecov](https://codecov.io/gh/o3co/rs.hocon/branch/main/graph/badge.svg)](https://codecov.io/gh/o3co/rs.hocon)
 [![License](https://img.shields.io/crates/l/hocon-parser.svg)](LICENSE)
 
-[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md)に完全準拠した Rust パーサー。ゼロコピーレキサー、再帰下降パーサー、型付き `Config` API を備え、オプションで Serde 統合に対応。
+[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md)に完全準拠した Rust パーサー。手書きレキサー、再帰下降パーサー、型付き `Config` API を備え、オプションで Serde 統合に対応。
 
 > **[Claude Code](https://claude.ai/claude-code)（Anthropic）による設計・実装。**
 > [GitHub Copilot](https://github.com/features/copilot) および [OpenAI Codex](https://openai.com/index/openai-codex/) によるレビュー。

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,10 +1,10 @@
-# o3co-hocon — Rust 向け HOCON パーサー
+# hocon-parser — Rust 向け HOCON パーサー
 
-[![Crates.io](https://img.shields.io/crates/v/o3co-hocon.svg)](https://crates.io/crates/o3co-hocon)
-[![docs.rs](https://docs.rs/o3co-hocon/badge.svg)](https://docs.rs/o3co-hocon)
+[![Crates.io](https://img.shields.io/crates/v/hocon-parser.svg)](https://crates.io/crates/hocon-parser)
+[![docs.rs](https://docs.rs/hocon-parser/badge.svg)](https://docs.rs/hocon-parser)
 [![CI](https://github.com/o3co/rs.hocon/actions/workflows/test.yml/badge.svg)](https://github.com/o3co/rs.hocon/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/o3co/rs.hocon/branch/main/graph/badge.svg)](https://codecov.io/gh/o3co/rs.hocon)
-[![License](https://img.shields.io/crates/l/o3co-hocon.svg)](LICENSE)
+[![License](https://img.shields.io/crates/l/hocon-parser.svg)](LICENSE)
 
 [Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md)に完全準拠した Rust パーサー。ゼロコピーレキサー、再帰下降パーサー、型付き `Config` API を備え、オプションで Serde 統合に対応。
 
@@ -20,13 +20,13 @@
 ### 1. インストール
 
 ```sh
-cargo add o3co-hocon
+cargo add hocon-parser
 ```
 
 Serde サポートを有効にする場合:
 
 ```sh
-cargo add o3co-hocon --features serde
+cargo add hocon-parser --features serde
 ```
 
 ### 2. 使い方

--- a/README.md
+++ b/README.md
@@ -342,6 +342,13 @@ struct AppConfig {
 let cfg: AppConfig = config.deserialize()?; // fails fast on startup
 ```
 
+## Security Considerations
+
+When parsing untrusted HOCON input, be aware of:
+
+- **Path traversal in includes:** `include "../../../etc/passwd"` will resolve relative to `base_dir`. Validate include paths if parsing untrusted input.
+- **Input size:** The parser has no built-in input size limit. For untrusted input, validate size before calling `parse()`.
+
 ## License
 
 Licensed under the [Apache License, Version 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/crates/l/hocon-parser.svg)](LICENSE)
 
 Full [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md)-compliant
-parser for Rust. Zero-copy lexer, recursive-descent parser, and a typed `Config` API
+parser for Rust. Hand-written lexer, recursive-descent parser, and a typed `Config` API
 with optional Serde integration.
 
 [日本語](README.ja.md)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# o3co-hocon — HOCON Parser for Rust
+# hocon-parser — HOCON Parser for Rust
 
-[![Crates.io](https://img.shields.io/crates/v/o3co-hocon.svg)](https://crates.io/crates/o3co-hocon)
-[![docs.rs](https://docs.rs/o3co-hocon/badge.svg)](https://docs.rs/o3co-hocon)
+[![Crates.io](https://img.shields.io/crates/v/hocon-parser.svg)](https://crates.io/crates/hocon-parser)
+[![docs.rs](https://docs.rs/hocon-parser/badge.svg)](https://docs.rs/hocon-parser)
 [![CI](https://github.com/o3co/rs.hocon/actions/workflows/test.yml/badge.svg)](https://github.com/o3co/rs.hocon/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/o3co/rs.hocon/branch/main/graph/badge.svg)](https://codecov.io/gh/o3co/rs.hocon)
-[![License](https://img.shields.io/crates/l/o3co-hocon.svg)](LICENSE)
+[![License](https://img.shields.io/crates/l/hocon-parser.svg)](LICENSE)
 
 Full [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md)-compliant
 parser for Rust. Zero-copy lexer, recursive-descent parser, and a typed `Config` API
@@ -17,13 +17,13 @@ with optional Serde integration.
 ### 1. Install
 
 ```sh
-cargo add o3co-hocon
+cargo add hocon-parser
 ```
 
 To enable Serde support:
 
 ```sh
-cargo add o3co-hocon --features serde
+cargo add hocon-parser --features serde
 ```
 
 ### 2. Use
@@ -244,7 +244,7 @@ For typical application configs (loaded once at startup), the parsing cost is ne
 | Substitutions (`${path}`) | ✅ | ✅ |
 | Optional substitutions (`${?path}`) | ✅ | ✅ |
 | Include | ✅ | ✅ |
-| `include required()` | ✅ | ❌ |
+| `include required(file(...))` | ✅ | ❌ |
 | Object/Array concatenation | ✅ | ✅ |
 | Type coercion | ✅ | ⚠️ |
 | Duration parsing | ✅ | ✅ |

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use std::fmt;
 /// Error returned when HOCON input contains a syntax error.
 ///
 /// Includes the line and column where the error was detected.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ParseError {
     /// Human-readable description of the error.
@@ -27,6 +28,7 @@ impl std::error::Error for ParseError {}
 
 /// Error returned when substitution resolution fails (e.g., missing
 /// required substitution, cyclic reference).
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ResolveError {
     /// Human-readable description of the error.
@@ -53,6 +55,7 @@ impl std::error::Error for ResolveError {}
 
 /// Error returned by [`Config`](crate::Config) getters when a key is missing
 /// or the value has the wrong type.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ConfigError {
     /// Human-readable description of the error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,9 @@ pub use config::Config;
 pub use error::{ConfigError, ParseError, ResolveError};
 pub use value::{HoconValue, ScalarValue};
 
+#[cfg(feature = "serde")]
+pub use serde::DeserializeError;
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -6,6 +6,7 @@ use std::fmt;
 // Error type
 // ---------------------------------------------------------------------------
 
+#[non_exhaustive]
 #[derive(Debug)]
 pub struct DeserializeError {
     pub message: String,

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -32,12 +32,12 @@ impl ::serde::de::Error for DeserializeError {
 // Deserializer
 // ---------------------------------------------------------------------------
 
-pub struct HoconDeserializer<'de> {
+pub(crate) struct HoconDeserializer<'de> {
     value: &'de HoconValue,
 }
 
 impl<'de> HoconDeserializer<'de> {
-    pub fn new(value: &'de HoconValue) -> Self {
+    pub(crate) fn new(value: &'de HoconValue) -> Self {
         Self { value }
     }
 }
@@ -346,7 +346,7 @@ use ::serde::de::IntoDeserializer;
 // MapAccess
 // ---------------------------------------------------------------------------
 
-pub struct HoconMapAccess<'de> {
+pub(crate) struct HoconMapAccess<'de> {
     iter: indexmap::map::Iter<'de, String, HoconValue>,
     current_value: Option<&'de HoconValue>,
 }
@@ -413,7 +413,7 @@ impl<'de, 'a> ::serde::Deserializer<'de> for StringKeyDeserializer<'a> {
 // SeqAccess
 // ---------------------------------------------------------------------------
 
-pub struct HoconSeqAccess<'de> {
+pub(crate) struct HoconSeqAccess<'de> {
     iter: std::slice::Iter<'de, HoconValue>,
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -6,6 +6,7 @@ use indexmap::IndexMap;
 /// with it through the typed getters on `Config`, but it is also returned
 /// directly by [`Config::get`](crate::Config::get) and
 /// [`Config::get_list`](crate::Config::get_list).
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub enum HoconValue {
     /// An ordered map of key-value pairs (HOCON object / JSON object).
@@ -17,6 +18,7 @@ pub enum HoconValue {
 }
 
 /// A scalar (leaf) value inside a HOCON document.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub enum ScalarValue {
     /// A string value.

--- a/tests/lightbend_test.rs
+++ b/tests/lightbend_test.rs
@@ -45,7 +45,9 @@ fn hocon_to_json(v: &hocon::HoconValue) -> serde_json::Value {
             hocon::ScalarValue::Float(f) => serde_json::json!(*f),
             hocon::ScalarValue::Bool(b) => serde_json::Value::Bool(*b),
             hocon::ScalarValue::Null => serde_json::Value::Null,
+            _ => unreachable!("unknown ScalarValue variant"),
         },
+        _ => unreachable!("unknown HoconValue variant"),
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace `o3co-hocon` with `hocon-parser` in all README references (badges, cargo add instructions)
- Add `#[non_exhaustive]` to 6 public types for semver safety (HoconValue, ScalarValue, ParseError, ResolveError, ConfigError, DeserializeError)
- Hide serde internal types (`HoconDeserializer`, `HoconMapAccess`, `HoconSeqAccess`) — changed from `pub` to `pub(crate)`
- Re-export `DeserializeError` from crate root for API consistency
- Fix inaccurate "zero-copy" claim in README (→ "hand-written lexer")
- Clarify `include required(...)` scope in comparison table
- Add Security Considerations section to READMEs

**Note:** Cargo.toml `name` remains `o3co-hocon` — will be changed to `hocon-parser` at 1.0 publish time (crate name already reserved). All breaking changes (non_exhaustive, serde visibility) are intentional for the 0.x → 1.0 transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)