### PR TITLE
feat: unified HoconError type for parse functions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -84,7 +84,7 @@ pub enum HoconError {
     Parse(ParseError),
     /// Substitution resolution failure (missing key, cycle, etc.).
     Resolve(ResolveError),
-    /// File I/O error (e.g., include file not found).
+    /// File I/O error when reading the top-level config file.
     Io(std::io::Error),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,3 +71,57 @@ impl fmt::Display for ConfigError {
 }
 
 impl std::error::Error for ConfigError {}
+
+/// Unified error type returned by top-level parse functions.
+///
+/// Wraps the three possible failure modes: syntax errors ([`ParseError`]),
+/// substitution resolution failures ([`ResolveError`]), and file I/O
+/// errors ([`std::io::Error`]).
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum HoconError {
+    /// Syntax error during lexing or parsing.
+    Parse(ParseError),
+    /// Substitution resolution failure (missing key, cycle, etc.).
+    Resolve(ResolveError),
+    /// File I/O error (e.g., include file not found).
+    Io(std::io::Error),
+}
+
+impl fmt::Display for HoconError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HoconError::Parse(e) => write!(f, "{}", e),
+            HoconError::Resolve(e) => write!(f, "{}", e),
+            HoconError::Io(e) => write!(f, "I/O error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for HoconError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            HoconError::Parse(e) => Some(e),
+            HoconError::Resolve(e) => Some(e),
+            HoconError::Io(e) => Some(e),
+        }
+    }
+}
+
+impl From<ParseError> for HoconError {
+    fn from(e: ParseError) -> Self {
+        HoconError::Parse(e)
+    }
+}
+
+impl From<ResolveError> for HoconError {
+    fn from(e: ResolveError) -> Self {
+        HoconError::Resolve(e)
+    }
+}
+
+impl From<std::io::Error> for HoconError {
+    fn from(e: std::io::Error) -> Self {
+        HoconError::Io(e)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@
 //! - [`HoconError`] -- unified error returned by parse functions. Wraps:
 //!   - [`ParseError`] -- syntax errors during lexing or parsing (includes line/column).
 //!   - [`ResolveError`] -- substitution resolution failures, cycle detection.
-//!   - `std::io::Error` -- file I/O errors.
+//!   - `std::io::Error` -- file I/O errors (top-level file read; include file errors appear as [`ResolveError`]).
 //! - [`ConfigError`] -- missing keys or type mismatches when accessing values.
 //!
 //! ## HOCON Specification
@@ -146,7 +146,8 @@ pub fn parse_file_with_env<P: AsRef<Path>>(
     env: &HashMap<String, String>,
 ) -> Result<Config, HoconError> {
     let path = path.as_ref();
-    let content = std::fs::read_to_string(path)?;
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {}", path.display(), e)))?;
     let tokens = lexer::tokenize(&content)?;
     let ast = parser::parse_tokens(&tokens)?;
     let mut opts = resolver::ResolveOptions::new(env.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,8 +98,10 @@
 //!
 //! ## Error Types
 //!
-//! - [`ParseError`] -- syntax errors during lexing or parsing (includes line/column).
-//! - [`ResolveError`] -- substitution resolution failures, cycle detection.
+//! - [`HoconError`] -- unified error returned by parse functions. Wraps:
+//!   - [`ParseError`] -- syntax errors during lexing or parsing (includes line/column).
+//!   - [`ResolveError`] -- substitution resolution failures, cycle detection.
+//!   - `std::io::Error` -- file I/O errors.
 //! - [`ConfigError`] -- missing keys or type mismatches when accessing values.
 //!
 //! ## HOCON Specification
@@ -119,7 +121,7 @@ pub mod value;
 pub mod serde;
 
 pub use config::Config;
-pub use error::{ConfigError, ParseError, ResolveError};
+pub use error::{ConfigError, HoconError, ParseError, ResolveError};
 pub use value::{HoconValue, ScalarValue};
 
 #[cfg(feature = "serde")]
@@ -129,12 +131,12 @@ use std::collections::HashMap;
 use std::path::Path;
 
 /// Parse a HOCON string into a Config.
-pub fn parse(input: &str) -> Result<Config, ParseError> {
+pub fn parse(input: &str) -> Result<Config, HoconError> {
     parse_with_env(input, &std::env::vars().collect())
 }
 
 /// Parse a HOCON file into a Config.
-pub fn parse_file<P: AsRef<Path>>(path: P) -> Result<Config, ParseError> {
+pub fn parse_file<P: AsRef<Path>>(path: P) -> Result<Config, HoconError> {
     parse_file_with_env(path, &std::env::vars().collect())
 }
 
@@ -142,50 +144,38 @@ pub fn parse_file<P: AsRef<Path>>(path: P) -> Result<Config, ParseError> {
 pub fn parse_file_with_env<P: AsRef<Path>>(
     path: P,
     env: &HashMap<String, String>,
-) -> Result<Config, ParseError> {
+) -> Result<Config, HoconError> {
     let path = path.as_ref();
-    let content = std::fs::read_to_string(path).map_err(|e| ParseError {
-        message: format!("failed to read file {}: {}", path.display(), e),
-        line: 0,
-        col: 0,
-    })?;
+    let content = std::fs::read_to_string(path)?;
     let tokens = lexer::tokenize(&content)?;
     let ast = parser::parse_tokens(&tokens)?;
     let mut opts = resolver::ResolveOptions::new(env.clone());
     if let Some(dir) = path.parent() {
         opts = opts.with_base_dir(dir.to_path_buf());
     }
-    let value = resolver::resolve(ast, &opts).map_err(|e| ParseError {
-        message: e.message,
-        line: e.line,
-        col: e.col,
-    })?;
+    let value = resolver::resolve(ast, &opts)?;
     match value {
         HoconValue::Object(fields) => Ok(Config::new(fields)),
-        _ => Err(ParseError {
+        _ => Err(HoconError::Parse(ParseError {
             message: "root must be an object".into(),
             line: 1,
             col: 1,
-        }),
+        })),
     }
 }
 
 /// Parse a HOCON string with a custom environment variable map.
-pub fn parse_with_env(input: &str, env: &HashMap<String, String>) -> Result<Config, ParseError> {
+pub fn parse_with_env(input: &str, env: &HashMap<String, String>) -> Result<Config, HoconError> {
     let tokens = lexer::tokenize(input)?;
     let ast = parser::parse_tokens(&tokens)?;
     let opts = resolver::ResolveOptions::new(env.clone());
-    let value = resolver::resolve(ast, &opts).map_err(|e| ParseError {
-        message: e.message,
-        line: e.line,
-        col: e.col,
-    })?;
+    let value = resolver::resolve(ast, &opts)?;
     match value {
         HoconValue::Object(fields) => Ok(Config::new(fields)),
-        _ => Err(ParseError {
+        _ => Err(HoconError::Parse(ParseError {
             message: "root must be an object".into(),
             line: 1,
             col: 1,
-        }),
+        })),
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -450,3 +450,42 @@ fn unquoted_forbids_spec_special_chars() {
         );
     }
 }
+
+#[test]
+fn parse_error_is_hocon_error_parse_variant() {
+    let result = hocon::parse("{ unterminated");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    match err {
+        hocon::HoconError::Parse(pe) => {
+            assert!(pe.line > 0 || pe.col > 0, "should have position info");
+        }
+        _ => panic!("expected HoconError::Parse, got {:?}", err),
+    }
+}
+
+#[test]
+fn resolve_error_is_hocon_error_resolve_variant() {
+    let result = hocon::parse("a = ${missing.required.key}");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    match err {
+        hocon::HoconError::Resolve(re) => {
+            assert!(!re.path.is_empty(), "should have substitution path");
+        }
+        _ => panic!("expected HoconError::Resolve, got {:?}", err),
+    }
+}
+
+#[test]
+fn io_error_is_hocon_error_io_variant() {
+    let result = hocon::parse_file("/nonexistent/path/to/file.conf");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    match err {
+        hocon::HoconError::Io(io_err) => {
+            assert_eq!(io_err.kind(), std::io::ErrorKind::NotFound);
+        }
+        _ => panic!("expected HoconError::Io, got {:?}", err),
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -463,7 +463,7 @@ fn parse_error_is_hocon_error_parse_variant() {
                 "should have position info (line and col)"
             );
         }
-        _ => panic!("expected HoconError::Parse, got {:?}", err),
+        other => panic!("expected HoconError::Parse, got {:?}", other),
     }
 }
 
@@ -476,7 +476,7 @@ fn resolve_error_is_hocon_error_resolve_variant() {
         hocon::HoconError::Resolve(re) => {
             assert!(!re.path.is_empty(), "should have substitution path");
         }
-        _ => panic!("expected HoconError::Resolve, got {:?}", err),
+        other => panic!("expected HoconError::Resolve, got {:?}", other),
     }
 }
 
@@ -494,6 +494,6 @@ fn io_error_is_hocon_error_io_variant() {
         hocon::HoconError::Io(io_err) => {
             assert_eq!(io_err.kind(), std::io::ErrorKind::NotFound);
         }
-        _ => panic!("expected HoconError::Io, got {:?}", err),
+        other => panic!("expected HoconError::Io, got {:?}", other),
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -458,7 +458,10 @@ fn parse_error_is_hocon_error_parse_variant() {
     let err = result.unwrap_err();
     match err {
         hocon::HoconError::Parse(pe) => {
-            assert!(pe.line > 0 || pe.col > 0, "should have position info");
+            assert!(
+                pe.line > 0 && pe.col > 0,
+                "should have position info (line and col)"
+            );
         }
         _ => panic!("expected HoconError::Parse, got {:?}", err),
     }
@@ -479,7 +482,12 @@ fn resolve_error_is_hocon_error_resolve_variant() {
 
 #[test]
 fn io_error_is_hocon_error_io_variant() {
-    let result = hocon::parse_file("/nonexistent/path/to/file.conf");
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "hocon_test_nonexistent_{}.conf",
+        std::process::id()
+    ));
+    let result = hocon::parse_file(&path);
     assert!(result.is_err());
     let err = result.unwrap_err();
     match err {


### PR DESCRIPTION
## Summary

Replace `Result<Config, ParseError>` with `Result<Config, HoconError>` on all public parse functions.

**Before:** `ResolveError` was converted to `ParseError` with `line: 0, col: 0`, losing the substitution `path` field. I/O errors were also stuffed into `ParseError`.

**After:** `HoconError` enum preserves the original error variant:
- `HoconError::Parse(ParseError)` — syntax errors
- `HoconError::Resolve(ResolveError)` — substitution failures (path preserved)
- `HoconError::Io(std::io::Error)` — file I/O errors

**Breaking change** for 0.x → 1.0. Existing code using `.unwrap()` or `.is_err()` continues to work. Code matching on `ParseError` specifically needs to match on `HoconError` variants instead.

## Test plan

- [ ] 3 new tests verify each HoconError variant (RED → GREEN TDD)
- [ ] All existing tests pass (`.unwrap()` / `.is_err()` compatible)
- [ ] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)