### PR TITLE
docs: add Known Limitations section to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -283,6 +283,15 @@ struct AppConfig {
 let cfg: AppConfig = config.deserialize()?; // 起動時に即座に失敗
 ```
 
+## 既知の制約
+
+- **`include url(...)` と `include classpath(...)`** は未対応です。Lightbend 仕様の JVM 固有形式です。`include "file"`、`include file("file")`、`include required(...)` のみ対応しています。
+- **監視/リロード機能なし** — 設定はロード時に解析されます。ライブリロードには、変更時に `parse()` や `parse_file()` を再呼び出ししてください。
+- **ストリーミングパーサーなし** — 入力全体がメモリに読み込まれます。
+- **`.properties` include** — 基本的な `key=value` 形式のみ対応。複数行値（バックスラッシュ継続）、Unicode エスケープ、キーエスケープには対応していません。
+
+API の詳細ドキュメントは [docs.rs](https://docs.rs/hocon-parser)（クレート公開後に利用可能）を参照してください。
+
 ## セキュリティに関する注意
 
 信頼できない HOCON 入力を解析する場合、以下に注意してください：

--- a/README.ja.md
+++ b/README.ja.md
@@ -285,8 +285,9 @@ let cfg: AppConfig = config.deserialize()?; // 起動時に即座に失敗
 
 ## 既知の制約
 
-- **`include url(...)` と `include classpath(...)`** は未対応です。Lightbend 仕様の JVM 固有形式です。`include "file"`、`include file("file")`、`include required(...)` のみ対応しています。
-- **監視/リロード機能なし** — 設定はロード時に解析されます。ライブリロードには、変更時に `parse()` や `parse_file()` を再呼び出ししてください。
+- **`include url(...)`** は未対応です。リモート設定の取得はパーサーのスコープ外です。アプリケーションの HTTP クライアントでコンテンツを取得し、`parse()` に渡してください。
+- **`include classpath(...)`** は未対応です。これは JVM 固有の include 形式で、Java ランタイム外には同等の仕組みがありません。
+- **監視/リロード機能なし** — 設定はロード時に解析されます。ライブリロードには、変更時に `parse()` や `parse_file()` を再度呼び出してください。
 - **ストリーミングパーサーなし** — 入力全体がメモリに読み込まれます。
 - **`.properties` include** — 基本的な `key=value` 形式のみ対応。複数行値（バックスラッシュ継続）、Unicode エスケープ、キーエスケープには対応していません。
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,15 @@ struct AppConfig {
 let cfg: AppConfig = config.deserialize()?; // fails fast on startup
 ```
 
+## Known Limitations
+
+- **`include url(...)` and `include classpath(...)`** are not supported. These are JVM-specific include forms from the Lightbend spec. Only `include "file"`, `include file("file")`, and `include required(...)` are supported.
+- **No watch/reload** — the library parses config at load time. For live-reloading, re-call `parse()` or `parse_file()` on change.
+- **No streaming parser** — the entire input is loaded into memory.
+- **`.properties` include** — supports basic `key=value` syntax. Does not support multiline values (backslash continuation), unicode escapes, or key escaping from the full Java .properties specification.
+
+For full API documentation, see [docs.rs](https://docs.rs/hocon-parser) (available after crate publication).
+
 ## Security Considerations
 
 When parsing untrusted HOCON input, be aware of:

--- a/README.md
+++ b/README.md
@@ -344,8 +344,9 @@ let cfg: AppConfig = config.deserialize()?; // fails fast on startup
 
 ## Known Limitations
 
-- **`include url(...)` and `include classpath(...)`** are not supported. These are JVM-specific include forms from the Lightbend spec. Only `include "file"`, `include file("file")`, and `include required(...)` are supported.
-- **No watch/reload** — the library parses config at load time. For live-reloading, re-call `parse()` or `parse_file()` on change.
+- **`include url(...)`** is not supported. Fetching remote configuration is outside the scope of this parser. Use your application's HTTP client to fetch the content, then pass it to `parse()`.
+- **`include classpath(...)`** is not supported. This is a JVM-specific include form with no equivalent outside Java runtimes.
+- **No watch/reload** — the library parses config at load time. For live-reloading, call `parse()` / `parse_file()` again on change.
 - **No streaming parser** — the entire input is loaded into memory.
 - **`.properties` include** — supports basic `key=value` syntax. Does not support multiline values (backslash continuation), unicode escapes, or key escaping from the full Java .properties specification.
 


### PR DESCRIPTION
## Summary
- Add "Known Limitations" section before "Security Considerations" in both README.md and README.ja.md documenting unsupported JVM-specific include forms, lack of watch/reload, no streaming parser, and .properties parsing limitations.
- Add link to docs.rs for full API documentation.

## Test plan
- [ ] Verify README.md renders correctly on GitHub
- [ ] Verify README.ja.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)