### PR TITLE
chore: rename crate to hocon-parser, add CHANGELOG 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-04-04
+
+### Added
+
+- `HoconError` unified error type for parse functions (preserves Parse, Resolve, Io variants)
+- `#[non_exhaustive]` on all public types for semver safety
+- `DeserializeError` re-exported from crate root
+- `include required()` and `include required(file())` directives
+- Circular include detection with include stack
+- Performance benchmarks in README
+- Library comparison tables in README (vs hocon-rs, vs config-rs)
+- Security Considerations section in README
+- Known Limitations section in README
+- `Debug`, `Clone`, `PartialEq` derives on `Config`
+
+### Fixed
+
+- Include probe order: `.properties → .json → .conf` (`.conf` wins)
+- Error on unknown escape sequences in quoted strings
+- Unquoted string forbidden characters aligned with HOCON spec (`?!@*&^\`)
+
+### Changed
+
+- **Breaking:** Crate renamed from `o3co-hocon` to `hocon-parser`
+- **Breaking:** Parse functions return `Result<Config, HoconError>` instead of `Result<Config, ParseError>`
+- **Breaking:** Serde internal types (`HoconDeserializer`, `HoconMapAccess`, `HoconSeqAccess`) hidden from public API
+- **Breaking:** `#[non_exhaustive]` added to `HoconValue`, `ScalarValue`, `ParseError`, `ResolveError`, `ConfigError`, `DeserializeError`
+- Cross-language spec alignment with ts.hocon and go.hocon
+- README: "zero-copy lexer" corrected to "hand-written lexer"
+
 ## [0.1.2] - 2026-03-30
 
 ### Fixed
@@ -41,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional Serde deserialization support (`serde` feature flag)
 - Lightbend equivalence tests (equiv01 through equiv05)
 
+[1.0.0]: https://github.com/o3co/rs.hocon/compare/v0.1.5...v1.0.0
 [0.1.2]: https://github.com/o3co/rs.hocon/releases/tag/v0.1.2
 [0.1.1]: https://github.com/o3co/rs.hocon/releases/tag/v0.1.1
 [0.1.0]: https://github.com/o3co/rs.hocon/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "o3co-hocon"
-version = "0.0.0-snapshot"
+name = "hocon-parser"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.82"
 description = "Full Lightbend HOCON specification-compliant parser for Rust"


### PR DESCRIPTION
## Summary

- Rename crate from `o3co-hocon` to `hocon-parser` in Cargo.toml
- Update version from `0.0.0-snapshot` to `1.0.0`
- Add CHANGELOG entry for v1.0.0 release (2026-04-04) documenting breaking changes, new features (HoconError, non_exhaustive, include required), fixes, and cross-language alignment

## Test plan

- [ ] Verify `cargo check` passes with new crate name
- [ ] Verify CHANGELOG formatting renders correctly on GitHub
- [ ] Confirm all prior version entries are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)