### PR TITLE
fix: error on unterminated triple-quoted strings (#19)

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -207,6 +207,7 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
             pos += 3;
             col += 3;
             let mut value = String::new();
+            let mut found_closing = false;
             loop {
                 if pos >= chars.len() {
                     break;
@@ -222,6 +223,7 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
                         for _ in 0..(quote_count - 3) {
                             value.push('"');
                         }
+                        found_closing = true;
                         break;
                     }
                     for _ in 0..quote_count {
@@ -237,6 +239,13 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
                 }
                 value.push(chars[pos]);
                 pos += 1;
+            }
+            if !found_closing {
+                return Err(ParseError {
+                    message: "unterminated triple-quoted string".into(),
+                    line: sl,
+                    col: sc,
+                });
             }
             if value.starts_with('\n') {
                 value = value[1..].to_string();
@@ -633,5 +642,10 @@ mod tests {
     #[test]
     fn throws_on_unterminated_substitution() {
         assert!(tokenize("${foo").is_err());
+    }
+
+    #[test]
+    fn throws_on_unterminated_triple_quoted_string() {
+        assert!(tokenize(r#""""unterminated"#).is_err());
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -497,3 +497,9 @@ fn io_error_is_hocon_error_io_variant() {
         other => panic!("expected HoconError::Io, got {:?}", other),
     }
 }
+
+#[test]
+fn test_unterminated_triple_quoted_string_errors() {
+    let result = hocon::parse(r#"a = """unterminated"#);
+    assert!(result.is_err(), "expected error for unterminated triple-quoted string");
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -501,5 +501,8 @@ fn io_error_is_hocon_error_io_variant() {
 #[test]
 fn test_unterminated_triple_quoted_string_errors() {
     let result = hocon::parse(r#"a = """unterminated"#);
-    assert!(result.is_err(), "expected error for unterminated triple-quoted string");
+    assert!(
+        result.is_err(),
+        "expected error for unterminated triple-quoted string"
+    );
 }


### PR DESCRIPTION
## Summary
- Lexer now returns `ParseError` when a triple-quoted string reaches EOF without closing `"""`
- Added `found_closing` flag to triple-quote parsing loop for reliable EOF detection
- Consistent with existing behavior for unterminated regular quoted strings and substitutions

## Test plan
- [x] Unit test `throws_on_unterminated_triple_quoted_string` — lexer returns Err
- [x] Integration test `test_unterminated_triple_quoted_string_errors` — `hocon::parse` returns Err
- [x] Full test suite (206 tests) passes with zero regressions

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)