### PR TITLE
test: add auto-discovery lightbend conformance tests with expected JSON

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - name: Cache expected JSON
+        uses: actions/cache@v4
+        with:
+          path: |
+            tests/testdata/expected
+            .xx-hocon-version
+          key: xx-hocon-expected-${{ github.run_id }}
+          restore-keys: xx-hocon-expected-
+      - name: Fetch expected JSON
+        run: make testdata
       - run: cargo test
         if: matrix.rust == 'stable'
       # MSRV: remove criterion dev-dependency before testing because
@@ -41,6 +51,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache expected JSON
+        uses: actions/cache@v4
+        with:
+          path: |
+            tests/testdata/expected
+            .xx-hocon-version
+          key: xx-hocon-expected-${{ github.run_id }}
+          restore-keys: xx-hocon-expected-
+      - name: Fetch expected JSON
+        run: make testdata
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: cargo llvm-cov --features serde --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           path: |
             tests/testdata/expected
             .xx-hocon-version
-          key: xx-hocon-expected-${{ github.run_id }}
+          key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}
           restore-keys: xx-hocon-expected-
       - name: Fetch expected JSON
         run: make testdata
@@ -57,7 +57,7 @@ jobs:
           path: |
             tests/testdata/expected
             .xx-hocon-version
-          key: xx-hocon-expected-${{ github.run_id }}
+          key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}
           restore-keys: xx-hocon-expected-
       - name: Fetch expected JSON
         run: make testdata

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ Cargo.lock
 
 # Superpowers (development process artifacts)
 docs/superpowers/
+
+# Fetched testdata from xx.hocon (run `make testdata` to populate)
+tests/testdata/expected/
+.xx-hocon-version

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+TESTDATA_REPO  := o3co/xx.hocon
+TESTDATA_REF   := main
+EXPECTED_DIR   := tests/testdata/expected
+
+.PHONY: testdata test
+
+testdata:
+	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ]; then \
+	  remote_sha=$$(curl -s "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4); \
+	  local_sha=$$(cat .xx-hocon-version); \
+	  if [ "$$remote_sha" = "$$local_sha" ]; then \
+	    echo "Expected JSON up to date ($$local_sha)"; exit 0; \
+	  fi; \
+	fi; \
+	tmpdir="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmpdir"' EXIT INT TERM; \
+	mkdir -p "$(EXPECTED_DIR)"; \
+	curl -sL "https://github.com/$(TESTDATA_REPO)/archive/$(TESTDATA_REF).tar.gz" -o "$$tmpdir/archive.tar.gz"; \
+	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1; \
+	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/"; \
+	curl -s "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version; \
+	echo "Done. Fetched $$(cat .xx-hocon-version)"
+
+test:
+	cargo test

--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,19 @@ EXPECTED_DIR   := tests/testdata/expected
 
 testdata:
 	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ]; then \
-	  remote_sha=$$(curl -s "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4); \
-	  local_sha=$$(cat .xx-hocon-version); \
+	  remote_sha=$$(curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4) && \
+	  local_sha=$$(cat .xx-hocon-version) && \
 	  if [ "$$remote_sha" = "$$local_sha" ]; then \
 	    echo "Expected JSON up to date ($$local_sha)"; exit 0; \
 	  fi; \
 	fi; \
-	tmpdir="$$(mktemp -d)"; \
-	trap 'rm -rf "$$tmpdir"' EXIT INT TERM; \
-	mkdir -p "$(EXPECTED_DIR)"; \
-	curl -sL "https://github.com/$(TESTDATA_REPO)/archive/$(TESTDATA_REF).tar.gz" -o "$$tmpdir/archive.tar.gz"; \
-	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1; \
-	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/"; \
-	curl -s "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version; \
+	tmpdir="$$(mktemp -d)" && \
+	trap 'rm -rf "$$tmpdir"' EXIT INT TERM && \
+	mkdir -p "$(EXPECTED_DIR)" && \
+	curl -sfL "https://github.com/$(TESTDATA_REPO)/archive/$(TESTDATA_REF).tar.gz" -o "$$tmpdir/archive.tar.gz" && \
+	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1 && \
+	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/" && \
+	curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version && \
 	echo "Done. Fetched $$(cat .xx-hocon-version)"
 
 test:

--- a/tests/lightbend_test.rs
+++ b/tests/lightbend_test.rs
@@ -377,8 +377,7 @@ fn lightbend_test13_bad_substitution() {
 #[test]
 fn lightbend_suite_expected_json() {
     let testdata = testdata_dir();
-    let expected_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/testdata/expected");
+    let expected_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/testdata/expected");
 
     assert!(
         expected_dir.exists(),
@@ -388,12 +387,14 @@ fn lightbend_suite_expected_json() {
 
     // Known failures — skip these (linked to open issues)
     let skip: std::collections::HashSet<&str> = [
-        "test01-expected.json",  // system.* contains env-specific values (HOME, PATH, etc.)
-        "test02-expected.json",  // empty-key ("".""."") and quoted-key ("a.b.c") bugs
-        "test09-expected.json",  // delayed merge: object merge with substitution incomplete
-        "test10-expected.json",  // rs.hocon#36: nested include substitution scope
-        "file-include-expected.json",  // file() include semantics differ from JVM classpath
-    ].into_iter().collect();
+        "test01-expected.json", // system.* contains env-specific values (HOME, PATH, etc.)
+        "test02-expected.json", // empty-key ("".""."") and quoted-key ("a.b.c") bugs
+        "test09-expected.json", // delayed merge: object merge with substitution incomplete
+        "test10-expected.json", // rs.hocon#36: nested include substitution scope
+        "file-include-expected.json", // file() include semantics differ from JVM classpath
+    ]
+    .into_iter()
+    .collect();
 
     let mut tested = 0;
     for entry in fs::read_dir(&expected_dir).unwrap() {
@@ -421,14 +422,16 @@ fn lightbend_suite_expected_json() {
         parse_and_compare(&conf_path, &expected_path);
         tested += 1;
     }
-    assert!(tested > 0, "No expected JSON tests were run. Check tests/testdata/expected/");
+    assert!(
+        tested > 0,
+        "No expected JSON tests were run. Check tests/testdata/expected/"
+    );
 }
 
 #[test]
 fn lightbend_suite_expected_errors() {
     let testdata = testdata_dir();
-    let expected_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/testdata/expected");
+    let expected_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/testdata/expected");
 
     assert!(
         expected_dir.exists(),

--- a/tests/lightbend_test.rs
+++ b/tests/lightbend_test.rs
@@ -439,6 +439,7 @@ fn lightbend_suite_expected_errors() {
         expected_dir.display()
     );
 
+    let mut tested = 0;
     for entry in fs::read_dir(&expected_dir).unwrap() {
         let entry = entry.unwrap();
         let name = entry.file_name().to_string_lossy().to_string();
@@ -462,5 +463,10 @@ fn lightbend_suite_expected_errors() {
             "Expected error for {} but got success",
             conf_path.display()
         );
+        tested += 1;
     }
+    assert!(
+        tested > 0,
+        "No expected error tests were run. Check tests/testdata/expected/"
+    );
 }

--- a/tests/lightbend_test.rs
+++ b/tests/lightbend_test.rs
@@ -369,3 +369,95 @@ fn lightbend_test13_bad_substitution() {
         "Expected error for unresolved substitution in test13-reference-bad-substitutions.conf"
     );
 }
+
+// --- Auto-discovery tests using expected JSON from xx.hocon ---
+
+/// Auto-discover test*.conf files that have matching *-expected.json
+/// in the expected directory and compare parsed output.
+#[test]
+fn lightbend_suite_expected_json() {
+    let testdata = testdata_dir();
+    let expected_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/testdata/expected");
+
+    assert!(
+        expected_dir.exists(),
+        "Missing expected JSON fixtures at {}. Run `make testdata` before `cargo test`.",
+        expected_dir.display()
+    );
+
+    // Known failures — skip these (linked to open issues)
+    let skip: std::collections::HashSet<&str> = [
+        "test01-expected.json",  // system.* contains env-specific values (HOME, PATH, etc.)
+        "test02-expected.json",  // empty-key ("".""."") and quoted-key ("a.b.c") bugs
+        "test09-expected.json",  // delayed merge: object merge with substitution incomplete
+        "test10-expected.json",  // rs.hocon#36: nested include substitution scope
+        "file-include-expected.json",  // file() include semantics differ from JVM classpath
+    ].into_iter().collect();
+
+    let mut tested = 0;
+    for entry in fs::read_dir(&expected_dir).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name().to_string_lossy().to_string();
+
+        if !name.ends_with("-expected.json") {
+            continue;
+        }
+        if skip.contains(name.as_str()) {
+            eprintln!("SKIP (known failure): {}", name);
+            continue;
+        }
+
+        let conf_name = name.replace("-expected.json", ".conf");
+        let conf_path = testdata.join(&conf_name);
+        let expected_path = expected_dir.join(&name);
+
+        if !conf_path.exists() {
+            eprintln!("SKIP (conf not found): {}", conf_name);
+            continue;
+        }
+
+        eprintln!("TEST: {} vs {}", conf_name, name);
+        parse_and_compare(&conf_path, &expected_path);
+        tested += 1;
+    }
+    assert!(tested > 0, "No expected JSON tests were run. Check tests/testdata/expected/");
+}
+
+#[test]
+fn lightbend_suite_expected_errors() {
+    let testdata = testdata_dir();
+    let expected_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/testdata/expected");
+
+    assert!(
+        expected_dir.exists(),
+        "Missing expected JSON fixtures at {}. Run `make testdata` before `cargo test`.",
+        expected_dir.display()
+    );
+
+    for entry in fs::read_dir(&expected_dir).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name().to_string_lossy().to_string();
+
+        if !name.ends_with("-expected-error.json") {
+            continue;
+        }
+
+        let conf_name = name.replace("-expected-error.json", ".conf");
+        let conf_path = testdata.join(&conf_name);
+
+        if !conf_path.exists() {
+            eprintln!("SKIP (conf not found): {}", conf_name);
+            continue;
+        }
+
+        eprintln!("TEST (expect error): {}", conf_name);
+        let result = hocon::parse_file(&conf_path);
+        assert!(
+            result.is_err(),
+            "Expected error for {} but got success",
+            conf_path.display()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `make testdata` to fetch expected JSON from [o3co/xx.hocon](https://github.com/o3co/xx.hocon)
- Add `lightbend_suite_expected_json` and `lightbend_suite_expected_errors` auto-discovery tests
- 10 JSON comparison tests pass, 2 error tests pass, 5 skipped (known issues)

## Discovered issues
- test02: empty-string key substitution `${""."".""}` not resolved
- test09: object merge via substitution doesn't propagate all fields
- test01: `system.*` section has env-dependent values (expected JSON needs filtering)
- file-include: behavior diverges from reference implementation

## Test plan
- [x] `make testdata` fetches expected JSON
- [x] `cargo test lightbend_suite` passes (12 pass, 5 skip)
- [x] Full test suite passes with zero regressions

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)