### PR TITLE
refactor: store scalars as raw string + ScalarType

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::error::ConfigError;
-use crate::value::{HoconValue, ScalarValue};
+use crate::value::{HoconValue, ScalarType};
 use indexmap::IndexMap;
 
 /// A parsed HOCON configuration object.
@@ -38,11 +38,7 @@ impl Config {
     pub fn get_string(&self, path: &str) -> Result<String, ConfigError> {
         match self.lookup_node(path) {
             None => Err(missing(path)),
-            Some(HoconValue::Scalar(ScalarValue::String(s))) => Ok(s.clone()),
-            Some(HoconValue::Scalar(ScalarValue::Int(n))) => Ok(n.to_string()),
-            Some(HoconValue::Scalar(ScalarValue::Float(f))) => Ok(f.to_string()),
-            Some(HoconValue::Scalar(ScalarValue::Bool(b))) => Ok(b.to_string()),
-            Some(HoconValue::Scalar(ScalarValue::Null)) => Ok("null".to_string()),
+            Some(HoconValue::Scalar(sv)) => Ok(sv.raw.clone()),
             _ => Err(type_mismatch(path, "String")),
         }
     }
@@ -55,18 +51,18 @@ impl Config {
     pub fn get_i64(&self, path: &str) -> Result<i64, ConfigError> {
         match self.lookup_node(path) {
             None => Err(missing(path)),
-            Some(HoconValue::Scalar(ScalarValue::Int(n))) => Ok(*n),
-            Some(HoconValue::Scalar(ScalarValue::Float(f))) => {
-                // Only accept whole numbers
-                if f.fract() == 0.0 && f.is_finite() {
-                    Ok(*f as i64)
-                } else {
-                    Err(type_mismatch(path, "i64"))
+            Some(HoconValue::Scalar(sv)) => {
+                // Try direct i64 parse first
+                if let Ok(n) = sv.raw.parse::<i64>() {
+                    return Ok(n);
                 }
-            }
-            Some(HoconValue::Scalar(ScalarValue::String(s))) => {
-                // Strict parse: no hex, no leading/trailing whitespace
-                s.parse::<i64>().map_err(|_| type_mismatch(path, "i64"))
+                // Fallback: float-like strings that are whole numbers
+                if let Ok(f) = sv.raw.parse::<f64>() {
+                    if f.fract() == 0.0 && f.is_finite() {
+                        return Ok(f as i64);
+                    }
+                }
+                Err(type_mismatch(path, "i64"))
             }
             _ => Err(type_mismatch(path, "i64")),
         }
@@ -80,10 +76,8 @@ impl Config {
     pub fn get_f64(&self, path: &str) -> Result<f64, ConfigError> {
         match self.lookup_node(path) {
             None => Err(missing(path)),
-            Some(HoconValue::Scalar(ScalarValue::Float(f))) => Ok(*f),
-            Some(HoconValue::Scalar(ScalarValue::Int(n))) => Ok(*n as f64),
-            Some(HoconValue::Scalar(ScalarValue::String(s))) => {
-                s.parse::<f64>().map_err(|_| type_mismatch(path, "f64"))
+            Some(HoconValue::Scalar(sv)) => {
+                sv.raw.parse::<f64>().map_err(|_| type_mismatch(path, "f64"))
             }
             _ => Err(type_mismatch(path, "f64")),
         }
@@ -97,8 +91,7 @@ impl Config {
     pub fn get_bool(&self, path: &str) -> Result<bool, ConfigError> {
         match self.lookup_node(path) {
             None => Err(missing(path)),
-            Some(HoconValue::Scalar(ScalarValue::Bool(b))) => Ok(*b),
-            Some(HoconValue::Scalar(ScalarValue::String(s))) => match s.to_lowercase().as_str() {
+            Some(HoconValue::Scalar(sv)) => match sv.raw.to_lowercase().as_str() {
                 "true" | "yes" | "on" => Ok(true),
                 "false" | "no" | "off" => Ok(false),
                 _ => Err(type_mismatch(path, "bool")),
@@ -172,17 +165,24 @@ impl Config {
     pub fn get_duration(&self, path: &str) -> Result<std::time::Duration, ConfigError> {
         match self.lookup_node(path) {
             None => Err(missing(path)),
-            Some(HoconValue::Scalar(ScalarValue::String(s))) => {
-                parse_duration(s).ok_or_else(|| ConfigError {
-                    message: format!("invalid duration at {}: {}", path, s),
+            Some(HoconValue::Scalar(sv)) => {
+                // Try as duration string first
+                if let Some(d) = parse_duration(&sv.raw) {
+                    return Ok(d);
+                }
+                // Number types: bare integer = milliseconds, bare float = milliseconds
+                if sv.value_type == ScalarType::Number {
+                    if let Ok(n) = sv.raw.parse::<i64>() {
+                        return Ok(std::time::Duration::from_millis(n as u64));
+                    }
+                    if let Ok(f) = sv.raw.parse::<f64>() {
+                        return Ok(std::time::Duration::from_secs_f64(f / 1000.0));
+                    }
+                }
+                Err(ConfigError {
+                    message: format!("invalid duration at {}: {}", path, sv.raw),
                     path: path.to_string(),
                 })
-            }
-            Some(HoconValue::Scalar(ScalarValue::Int(n))) => {
-                Ok(std::time::Duration::from_millis(*n as u64))
-            }
-            Some(HoconValue::Scalar(ScalarValue::Float(f))) => {
-                Ok(std::time::Duration::from_secs_f64(*f / 1000.0))
             }
             _ => Err(ConfigError {
                 message: format!("expected duration at {}", path),
@@ -212,13 +212,22 @@ impl Config {
             path: path.to_string(),
         })?;
         match v {
-            HoconValue::Scalar(ScalarValue::String(s)) => {
-                parse_bytes(s).ok_or_else(|| ConfigError {
-                    message: format!("invalid byte size at {}: {}", path, s),
+            HoconValue::Scalar(sv) => {
+                // Try byte-size string first
+                if let Some(b) = parse_bytes(&sv.raw) {
+                    return Ok(b);
+                }
+                // Bare number: return as-is (assumed bytes)
+                if sv.value_type == ScalarType::Number {
+                    if let Ok(n) = sv.raw.parse::<i64>() {
+                        return Ok(n);
+                    }
+                }
+                Err(ConfigError {
+                    message: format!("invalid byte size at {}: {}", path, sv.raw),
                     path: path.to_string(),
                 })
             }
-            HoconValue::Scalar(ScalarValue::Int(n)) => Ok(*n),
             _ => Err(ConfigError {
                 message: format!("expected byte size at {}", path),
                 path: path.to_string(),
@@ -461,16 +470,16 @@ mod tests {
     }
 
     fn sv(s: &str) -> HoconValue {
-        HoconValue::Scalar(ScalarValue::String(s.into()))
+        HoconValue::Scalar(ScalarValue::string(s.into()))
     }
     fn iv(n: i64) -> HoconValue {
-        HoconValue::Scalar(ScalarValue::Int(n))
+        HoconValue::Scalar(ScalarValue::number(n.to_string()))
     }
     fn fv(n: f64) -> HoconValue {
-        HoconValue::Scalar(ScalarValue::Float(n))
+        HoconValue::Scalar(ScalarValue::number(n.to_string()))
     }
     fn bv(b: bool) -> HoconValue {
-        HoconValue::Scalar(ScalarValue::Bool(b))
+        HoconValue::Scalar(ScalarValue::boolean(b))
     }
 
     #[test]
@@ -514,7 +523,7 @@ mod tests {
 
     #[test]
     fn get_string_coerces_null() {
-        let c = make_config(vec![("v", HoconValue::Scalar(ScalarValue::Null))]);
+        let c = make_config(vec![("v", HoconValue::Scalar(ScalarValue::null()))]);
         assert_eq!(c.get_string("v").unwrap(), "null");
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,7 +58,11 @@ impl Config {
                 }
                 // Fallback: float-like strings that are whole numbers
                 if let Ok(f) = sv.raw.parse::<f64>() {
-                    if f.fract() == 0.0 && f.is_finite() {
+                    if f.fract() == 0.0
+                        && f.is_finite()
+                        && f >= i64::MIN as f64
+                        && f < (i64::MAX as f64)
+                    {
                         return Ok(f as i64);
                     }
                 }
@@ -553,6 +557,20 @@ mod tests {
     fn get_i64_error_on_non_numeric() {
         let c = make_config(vec![("host", sv("localhost"))]);
         assert!(c.get_i64("host").is_err());
+    }
+
+    #[test]
+    fn get_i64_error_on_overflow() {
+        // "1e20" parses as f64 but overflows i64 range
+        let c = make_config(vec![("big", sv("1e20"))]);
+        assert!(c.get_i64("big").is_err());
+    }
+
+    #[test]
+    fn get_i64_error_on_i64_max_plus_one() {
+        // 9223372036854775808 == i64::MAX + 1, parses as f64 but must not saturate
+        let c = make_config(vec![("big", sv("9223372036854775808"))]);
+        assert!(c.get_i64("big").is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,14 +56,18 @@ impl Config {
                 if let Ok(n) = sv.raw.parse::<i64>() {
                     return Ok(n);
                 }
-                // Fallback: float-like strings that are whole numbers
-                if let Ok(f) = sv.raw.parse::<f64>() {
-                    if f.fract() == 0.0
-                        && f.is_finite()
-                        && f >= i64::MIN as f64
-                        && f < (i64::MAX as f64)
-                    {
-                        return Ok(f as i64);
+                // Only use f64 fallback for float-like literals (contains '.' or exponent)
+                let is_float_like =
+                    sv.raw.contains('.') || sv.raw.contains('e') || sv.raw.contains('E');
+                if is_float_like {
+                    if let Ok(f) = sv.raw.parse::<f64>() {
+                        if f.fract() == 0.0
+                            && f.is_finite()
+                            && f >= i64::MIN as f64
+                            && f < (i64::MAX as f64)
+                        {
+                            return Ok(f as i64);
+                        }
                     }
                 }
                 Err(type_mismatch(path, "i64"))

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,9 +182,21 @@ impl Config {
                 // Number types: bare integer = milliseconds, bare float = milliseconds
                 if sv.value_type == ScalarType::Number {
                     if let Ok(n) = sv.raw.parse::<i64>() {
+                        if n < 0 {
+                            return Err(ConfigError {
+                                message: format!("negative duration at {}: {}", path, sv.raw),
+                                path: path.to_string(),
+                            });
+                        }
                         return Ok(std::time::Duration::from_millis(n as u64));
                     }
                     if let Ok(f) = sv.raw.parse::<f64>() {
+                        if f < 0.0 || !f.is_finite() {
+                            return Err(ConfigError {
+                                message: format!("invalid duration at {}: {}", path, sv.raw),
+                                path: path.to_string(),
+                            });
+                        }
                         return Ok(std::time::Duration::from_secs_f64(f / 1000.0));
                     }
                 }
@@ -398,6 +410,9 @@ fn parse_duration(s: &str) -> Option<std::time::Duration> {
     let unit_str = s[num_end..].trim().to_lowercase();
 
     let num: f64 = num_str.parse().ok()?;
+    if num < 0.0 || !num.is_finite() {
+        return None;
+    }
 
     let nanos_per_unit: f64 = match unit_str.as_str() {
         "ns" | "nano" | "nanos" | "nanosecond" | "nanoseconds" => 1.0,

--- a/src/config.rs
+++ b/src/config.rs
@@ -213,17 +213,19 @@ impl Config {
         })?;
         match v {
             HoconValue::Scalar(sv) => {
-                // Try byte-size string first
-                if let Some(b) = parse_bytes(&sv.raw) {
-                    return Ok(b);
-                }
-                // Bare number: return as-is (assumed bytes)
+                // Bare integer number: return as-is (assumed bytes)
                 if sv.value_type == ScalarType::Number {
                     if let Ok(n) = sv.raw.parse::<i64>() {
                         return Ok(n);
                     }
+                    // Bare float without unit (e.g. "1.5") is not valid for bytes
+                    return Err(ConfigError {
+                        message: format!("expected byte size at {}", path),
+                        path: path.to_string(),
+                    });
                 }
-                Err(ConfigError {
+                // String type: try byte-size string (e.g. "512 MB", "1.5 KiB")
+                parse_bytes(&sv.raw).ok_or_else(|| ConfigError {
                     message: format!("invalid byte size at {}: {}", path, sv.raw),
                     path: path.to_string(),
                 })

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,9 +80,10 @@ impl Config {
     pub fn get_f64(&self, path: &str) -> Result<f64, ConfigError> {
         match self.lookup_node(path) {
             None => Err(missing(path)),
-            Some(HoconValue::Scalar(sv)) => {
-                sv.raw.parse::<f64>().map_err(|_| type_mismatch(path, "f64"))
-            }
+            Some(HoconValue::Scalar(sv)) => sv
+                .raw
+                .parse::<f64>()
+                .map_err(|_| type_mismatch(path, "f64")),
             _ => Err(type_mismatch(path, "f64")),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,9 +32,9 @@ impl Config {
 
     /// Return the value at `path` as a `String`.
     ///
-    /// Scalar values (Int, Float, Bool, Null) are coerced to their string
-    /// representation. Returns [`ConfigError`] if the path is missing or
-    /// the value is an Object or Array.
+    /// Returns the raw string for any scalar value (string, number, boolean,
+    /// or null). Returns [`ConfigError`] if the path is missing or the value
+    /// is an Object or Array.
     pub fn get_string(&self, path: &str) -> Result<String, ConfigError> {
         match self.lookup_node(path) {
             None => Err(missing(path)),
@@ -197,7 +197,14 @@ impl Config {
                                 path: path.to_string(),
                             });
                         }
-                        return Ok(std::time::Duration::from_secs_f64(f / 1000.0));
+                        let secs = f / 1000.0;
+                        if secs > u64::MAX as f64 {
+                            return Err(ConfigError {
+                                message: format!("duration too large at {}: {}", path, sv.raw),
+                                path: path.to_string(),
+                            });
+                        }
+                        return Ok(std::time::Duration::from_secs_f64(secs));
                     }
                 }
                 Err(ConfigError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ pub mod serde;
 
 pub use config::Config;
 pub use error::{ConfigError, HoconError, ParseError, ResolveError};
-pub use value::{HoconValue, ScalarValue};
+pub use value::{HoconValue, ScalarType, ScalarValue};
 
 #[cfg(feature = "serde")]
 pub use serde::DeserializeError;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,6 @@
 use crate::error::ParseError;
 use crate::lexer::{Token, TokenKind};
-use crate::value::ScalarValue;
+use crate::value::{ScalarType, ScalarValue};
 
 #[derive(Debug, Clone)]
 pub struct Pos {
@@ -479,7 +479,7 @@ impl<'a> Parser<'a> {
                 TokenKind::QuotedString | TokenKind::TripleQuotedString => {
                     let (_, val, line, col) = self.advance_get();
                     AstNode::Scalar {
-                        value: ScalarValue::String(val),
+                        value: ScalarValue::string(val),
                         pos: Pos { line, col },
                         separator: false,
                     }
@@ -495,7 +495,7 @@ impl<'a> Parser<'a> {
                 TokenKind::Colon | TokenKind::Equals if !parts.is_empty() => {
                     let (_, val, line, col) = self.advance_get();
                     AstNode::Scalar {
-                        value: ScalarValue::String(val),
+                        value: ScalarValue::string(val),
                         pos: Pos { line, col },
                         separator: false,
                     }
@@ -505,7 +505,7 @@ impl<'a> Parser<'a> {
 
             if had_space {
                 parts.push(AstNode::Scalar {
-                    value: ScalarValue::String(" ".into()),
+                    value: ScalarValue::string(" ".into()),
                     pos: Pos {
                         line: t_line,
                         col: t_col,
@@ -570,27 +570,21 @@ impl<'a> Parser<'a> {
 
 fn parse_scalar_value(raw: &str) -> ScalarValue {
     match raw {
-        "true" => return ScalarValue::Bool(true),
-        "false" => return ScalarValue::Bool(false),
-        "null" => return ScalarValue::Null,
+        "true" | "false" => {
+            return ScalarValue::new(raw.to_string(), ScalarType::Boolean);
+        }
+        "null" => return ScalarValue::null(),
         _ => {}
     }
 
-    // Try integer first (no dot, no exponent)
-    if !raw.contains('.') && !raw.contains('e') && !raw.contains('E') {
-        if let Ok(n) = raw.parse::<i64>() {
-            return ScalarValue::Int(n);
+    // Number detection: first char must be 0-9 or - (Lightbend-aligned)
+    if let Some(first) = raw.bytes().next() {
+        if (first.is_ascii_digit() || first == b'-') && raw.parse::<f64>().is_ok() {
+            return ScalarValue::number(raw.to_string());
         }
     }
 
-    // Try float
-    if let Ok(f) = raw.parse::<f64>() {
-        if !raw.is_empty() {
-            return ScalarValue::Float(f);
-        }
-    }
-
-    ScalarValue::String(raw.to_string())
+    ScalarValue::string(raw.to_string())
 }
 
 #[cfg(test)]
@@ -665,52 +659,55 @@ mod tests {
     fn parses_boolean_and_null() {
         let node = parse("a = true\nb = false\nc = null");
         let fs = fields(&node);
-        assert!(matches!(
-            &fs[0].value,
-            AstNode::Scalar {
-                value: ScalarValue::Bool(true),
-                ..
-            }
-        ));
-        assert!(matches!(
-            &fs[1].value,
-            AstNode::Scalar {
-                value: ScalarValue::Bool(false),
-                ..
-            }
-        ));
-        assert!(matches!(
-            &fs[2].value,
-            AstNode::Scalar {
-                value: ScalarValue::Null,
-                ..
-            }
-        ));
+        if let AstNode::Scalar { value, .. } = &fs[0].value {
+            assert_eq!(value.value_type, ScalarType::Boolean);
+            assert_eq!(value.raw, "true");
+        } else {
+            panic!("expected scalar");
+        }
+        if let AstNode::Scalar { value, .. } = &fs[1].value {
+            assert_eq!(value.value_type, ScalarType::Boolean);
+            assert_eq!(value.raw, "false");
+        } else {
+            panic!("expected scalar");
+        }
+        if let AstNode::Scalar { value, .. } = &fs[2].value {
+            assert_eq!(value.value_type, ScalarType::Null);
+        } else {
+            panic!("expected scalar");
+        }
     }
 
     #[test]
     fn parses_integer_scalars() {
         let node = parse("port = 8080");
-        assert!(matches!(
-            &fields(&node)[0].value,
-            AstNode::Scalar {
-                value: ScalarValue::Int(8080),
-                ..
-            }
-        ));
+        if let AstNode::Scalar { value, .. } = &fields(&node)[0].value {
+            assert_eq!(value.value_type, ScalarType::Number);
+            assert_eq!(value.raw, "8080");
+        } else {
+            panic!("expected scalar");
+        }
     }
 
     #[test]
     fn parses_float_scalars() {
         let node = parse("ratio = 1.5");
-        if let AstNode::Scalar {
-            value: ScalarValue::Float(f),
-            ..
-        } = &fields(&node)[0].value
-        {
-            assert!((f - 1.5).abs() < f64::EPSILON);
+        if let AstNode::Scalar { value, .. } = &fields(&node)[0].value {
+            assert_eq!(value.value_type, ScalarType::Number);
+            assert_eq!(value.raw, "1.5");
         } else {
-            panic!("expected float");
+            panic!("expected scalar");
+        }
+    }
+
+    #[test]
+    fn dot_prefix_is_string_not_number() {
+        let node = parse("v = .33");
+        if let AstNode::Scalar { value, .. } = &fields(&node)[0].value {
+            assert_eq!(value.value_type, ScalarType::String);
+            assert_eq!(value.raw, ".33");
+        } else {
+            panic!("expected scalar");
         }
     }
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -33,7 +33,7 @@ pub fn properties_to_hocon(input: &str) -> HoconValue {
         set_nested(
             &mut root,
             &segments,
-            HoconValue::Scalar(ScalarValue::String(value)),
+            HoconValue::Scalar(ScalarValue::string(value)),
         );
     }
 
@@ -120,14 +120,14 @@ mod tests {
             if let Some(HoconValue::Object(a)) = map.get("a") {
                 assert_eq!(
                     a.get("b"),
-                    Some(&HoconValue::Scalar(ScalarValue::String("1".into())))
+                    Some(&HoconValue::Scalar(ScalarValue::string("1".into())))
                 );
             } else {
                 panic!("expected nested object for 'a'");
             }
             assert_eq!(
                 map.get("c"),
-                Some(&HoconValue::Scalar(ScalarValue::String("hello".into())))
+                Some(&HoconValue::Scalar(ScalarValue::string("hello".into())))
             );
         } else {
             panic!("expected object");

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -252,7 +252,10 @@ mod tests {
         let a = obj(&v).get("a").cloned().unwrap();
         match a {
             HoconValue::Object(map) => {
-                assert_eq!(map.get("c"), Some(&HoconValue::Scalar(ScalarValue::number("3".into()))));
+                assert_eq!(
+                    map.get("c"),
+                    Some(&HoconValue::Scalar(ScalarValue::number("3".into())))
+                );
                 assert_eq!(
                     map.get("q"),
                     Some(&HoconValue::Scalar(ScalarValue::number("10".into())))

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -51,7 +51,7 @@ mod tests {
         let v = resolve_str("host = \"localhost\"");
         assert_eq!(
             obj(&v).get("host"),
-            Some(&HoconValue::Scalar(ScalarValue::String("localhost".into())))
+            Some(&HoconValue::Scalar(ScalarValue::string("localhost".into())))
         );
     }
 
@@ -60,7 +60,7 @@ mod tests {
         let v = resolve_str("port = 8080");
         assert_eq!(
             obj(&v).get("port"),
-            Some(&HoconValue::Scalar(ScalarValue::Int(8080)))
+            Some(&HoconValue::Scalar(ScalarValue::number("8080".into())))
         );
     }
 
@@ -86,7 +86,7 @@ mod tests {
         let v = resolve_str("x = 1\nx = 2");
         assert_eq!(
             obj(&v).get("x"),
-            Some(&HoconValue::Scalar(ScalarValue::Int(2)))
+            Some(&HoconValue::Scalar(ScalarValue::number("2".into())))
         );
     }
 
@@ -132,7 +132,7 @@ mod tests {
         let v = resolve_str("host = \"localhost\"\nurl = ${host}");
         assert_eq!(
             obj(&v).get("url"),
-            Some(&HoconValue::Scalar(ScalarValue::String("localhost".into())))
+            Some(&HoconValue::Scalar(ScalarValue::string("localhost".into())))
         );
     }
 
@@ -141,7 +141,7 @@ mod tests {
         let v = resolve_str("server { host = \"x\" }\nhost = ${server.host}");
         assert_eq!(
             obj(&v).get("host"),
-            Some(&HoconValue::Scalar(ScalarValue::String("x".into())))
+            Some(&HoconValue::Scalar(ScalarValue::string("x".into())))
         );
     }
 
@@ -150,7 +150,7 @@ mod tests {
         let v = resolve_str("a = 1\nb = ${?a}");
         assert_eq!(
             obj(&v).get("b"),
-            Some(&HoconValue::Scalar(ScalarValue::Int(1)))
+            Some(&HoconValue::Scalar(ScalarValue::number("1".into())))
         );
     }
 
@@ -165,7 +165,7 @@ mod tests {
         let v = resolve_str("port = 50051\nport = ${?GRPC_PORT}");
         assert_eq!(
             obj(&v).get("port"),
-            Some(&HoconValue::Scalar(ScalarValue::Int(50051)))
+            Some(&HoconValue::Scalar(ScalarValue::number("50051".into())))
         );
     }
 
@@ -176,7 +176,7 @@ mod tests {
         let v = resolve_str_with_env("port = 50051\nport = ${?GRPC_PORT}", &env);
         assert_eq!(
             obj(&v).get("port"),
-            Some(&HoconValue::Scalar(ScalarValue::String("9090".into())))
+            Some(&HoconValue::Scalar(ScalarValue::string("9090".into())))
         );
     }
 
@@ -194,15 +194,15 @@ mod tests {
         let v = resolve_str_with_env("b = ${MY_VAR}", &env);
         assert_eq!(
             obj(&v).get("b"),
-            Some(&HoconValue::Scalar(ScalarValue::String("hello".into())))
+            Some(&HoconValue::Scalar(ScalarValue::string("hello".into())))
         );
     }
 
     #[test]
     fn resolves_self_referential_substitution() {
         let v = resolve_str("path = \"/usr\"\npath = ${path}:/extra");
-        if let Some(HoconValue::Scalar(ScalarValue::String(s))) = obj(&v).get("path") {
-            assert!(s.contains("/usr"));
+        if let Some(HoconValue::Scalar(sv)) = obj(&v).get("path") {
+            assert!(sv.raw.contains("/usr"));
         } else {
             panic!("expected string");
         }
@@ -214,7 +214,7 @@ mod tests {
         let v = resolve_str("x={q:10}\ny=5\nb=${x}\nb=${y}");
         assert_eq!(
             obj(&v).get("b"),
-            Some(&HoconValue::Scalar(ScalarValue::Int(5)))
+            Some(&HoconValue::Scalar(ScalarValue::number("5".into())))
         );
     }
 
@@ -223,7 +223,7 @@ mod tests {
         let v = resolve_str("host = \"localhost\"\nurl = \"http://\"${host}");
         assert_eq!(
             obj(&v).get("url"),
-            Some(&HoconValue::Scalar(ScalarValue::String(
+            Some(&HoconValue::Scalar(ScalarValue::string(
                 "http://localhost".into()
             )))
         );
@@ -241,7 +241,7 @@ mod tests {
         let v = resolve_str("url = ${host}\nhost = \"localhost\"");
         assert_eq!(
             obj(&v).get("url"),
-            Some(&HoconValue::Scalar(ScalarValue::String("localhost".into())))
+            Some(&HoconValue::Scalar(ScalarValue::string("localhost".into())))
         );
     }
 
@@ -252,10 +252,10 @@ mod tests {
         let a = obj(&v).get("a").cloned().unwrap();
         match a {
             HoconValue::Object(map) => {
-                assert_eq!(map.get("c"), Some(&HoconValue::Scalar(ScalarValue::Int(3))));
+                assert_eq!(map.get("c"), Some(&HoconValue::Scalar(ScalarValue::number("3".into()))));
                 assert_eq!(
                     map.get("q"),
-                    Some(&HoconValue::Scalar(ScalarValue::Int(10)))
+                    Some(&HoconValue::Scalar(ScalarValue::number("10".into())))
                 );
             }
             other => panic!("expected object, got {:?}", other),

--- a/src/resolver/structure_builder.rs
+++ b/src/resolver/structure_builder.rs
@@ -196,7 +196,7 @@ impl<'a> StructureBuilder<'a> {
                 }))
             }
             AstNode::Include { .. } => Ok(ResolverValue::Resolved(HoconValue::Scalar(
-                ScalarValue::Null,
+                ScalarValue::null(),
             ))),
         }
     }

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -78,7 +78,7 @@ impl<'a> SubstitutionResolver<'a> {
                 for item in items {
                     let resolved = self
                         .resolve_val(item, scope)?
-                        .unwrap_or(HoconValue::Scalar(ScalarValue::Null));
+                        .unwrap_or(HoconValue::Scalar(ScalarValue::null()));
                     resolved_items.push(resolved);
                 }
                 Ok(Some(HoconValue::Array(resolved_items)))
@@ -207,7 +207,7 @@ impl<'a> SubstitutionResolver<'a> {
             }
         });
         if let Some(env_val) = env_result {
-            let result = HoconValue::Scalar(ScalarValue::String(env_val));
+            let result = HoconValue::Scalar(ScalarValue::string(env_val));
             self.cache.insert(key.to_string(), result.clone());
             return Ok(Some(result));
         }
@@ -239,7 +239,7 @@ impl<'a> SubstitutionResolver<'a> {
         }
 
         if resolved.is_empty() {
-            return Ok(HoconValue::Scalar(ScalarValue::Null));
+            return Ok(HoconValue::Scalar(ScalarValue::null()));
         }
         if resolved.len() == 1 {
             return Ok(resolved.into_iter().next().unwrap().0);
@@ -293,7 +293,7 @@ impl<'a> SubstitutionResolver<'a> {
 
         // String concatenation
         let s: String = resolved.iter().map(|(v, _)| stringify_value(v)).collect();
-        Ok(HoconValue::Scalar(ScalarValue::String(s)))
+        Ok(HoconValue::Scalar(ScalarValue::string(s)))
     }
 
     fn resolve_append(
@@ -319,13 +319,7 @@ impl<'a> SubstitutionResolver<'a> {
 
 fn stringify_value(v: &HoconValue) -> String {
     match v {
-        HoconValue::Scalar(s) => match s {
-            ScalarValue::String(s) => s.clone(),
-            ScalarValue::Int(n) => n.to_string(),
-            ScalarValue::Float(f) => f.to_string(),
-            ScalarValue::Bool(b) => b.to_string(),
-            ScalarValue::Null => "null".to_string(),
-        },
+        HoconValue::Scalar(sv) => sv.raw.clone(),
         HoconValue::Array(_) => format!("{:?}", v),
         HoconValue::Object(_) => format!("{:?}", v),
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,4 +1,4 @@
-use crate::value::{HoconValue, ScalarValue};
+use crate::value::{HoconValue, ScalarType, ScalarValue};
 use indexmap::IndexMap;
 use std::fmt;
 
@@ -42,6 +42,39 @@ impl<'de> HoconDeserializer<'de> {
     }
 }
 
+/// Helper: parse raw string as integer type with float truncation fallback.
+fn parse_int_from_scalar<T>(sv: &ScalarValue, type_name: &str) -> Result<T, DeserializeError>
+where
+    T: std::str::FromStr + TryFrom<i64>,
+    <T as std::str::FromStr>::Err: fmt::Display,
+    <T as TryFrom<i64>>::Error: fmt::Display,
+{
+    // Try direct parse
+    if let Ok(n) = sv.raw.parse::<T>() {
+        return Ok(n);
+    }
+    // Float truncation fallback for Number types
+    if sv.value_type == ScalarType::Number {
+        if let Ok(f) = sv.raw.parse::<f64>() {
+            if f.fract() == 0.0 && f.is_finite() {
+                let as_i64 = f as i64;
+                if let Ok(n) = T::try_from(as_i64) {
+                    return Ok(n);
+                }
+            }
+        }
+    }
+    // String type: try parsing as number
+    if sv.value_type == ScalarType::String {
+        if let Ok(n) = sv.raw.parse::<T>() {
+            return Ok(n);
+        }
+    }
+    Err(DeserializeError {
+        message: format!("cannot parse \"{}\" as {}", sv.raw, type_name),
+    })
+}
+
 macro_rules! deserialize_int {
     ($method:ident, $visit:ident, $ty:ty) => {
         fn $method<V: ::serde::de::Visitor<'de>>(
@@ -49,23 +82,8 @@ macro_rules! deserialize_int {
             visitor: V,
         ) -> Result<V::Value, Self::Error> {
             match self.value {
-                HoconValue::Scalar(ScalarValue::Int(n)) => visitor.$visit(*n as $ty),
-                HoconValue::Scalar(ScalarValue::Float(f)) => {
-                    if f.fract() == 0.0 && f.is_finite() {
-                        visitor.$visit(*f as $ty)
-                    } else {
-                        Err(DeserializeError {
-                            message: format!(
-                                "expected {}, got float with fractional part",
-                                stringify!($ty)
-                            ),
-                        })
-                    }
-                }
-                HoconValue::Scalar(ScalarValue::String(s)) => {
-                    let n: $ty = s.parse().map_err(|_| DeserializeError {
-                        message: format!("cannot parse \"{}\" as {}", s, stringify!($ty)),
-                    })?;
+                HoconValue::Scalar(sv) => {
+                    let n: $ty = parse_int_from_scalar(sv, stringify!($ty))?;
                     visitor.$visit(n)
                 }
                 other => Err(DeserializeError {
@@ -84,11 +102,23 @@ impl<'de> ::serde::Deserializer<'de> for HoconDeserializer<'de> {
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
         match self.value {
-            HoconValue::Scalar(ScalarValue::String(s)) => visitor.visit_string(s.clone()),
-            HoconValue::Scalar(ScalarValue::Int(n)) => visitor.visit_i64(*n),
-            HoconValue::Scalar(ScalarValue::Float(f)) => visitor.visit_f64(*f),
-            HoconValue::Scalar(ScalarValue::Bool(b)) => visitor.visit_bool(*b),
-            HoconValue::Scalar(ScalarValue::Null) => visitor.visit_unit(),
+            HoconValue::Scalar(sv) => match sv.value_type {
+                ScalarType::Null => visitor.visit_unit(),
+                ScalarType::Boolean => visitor.visit_bool(sv.raw == "true"),
+                ScalarType::Number => {
+                    // Try i64 first (no dot/exponent), then f64
+                    if !sv.raw.contains('.') && !sv.raw.contains('e') && !sv.raw.contains('E') {
+                        if let Ok(n) = sv.raw.parse::<i64>() {
+                            return visitor.visit_i64(n);
+                        }
+                    }
+                    if let Ok(f) = sv.raw.parse::<f64>() {
+                        return visitor.visit_f64(f);
+                    }
+                    visitor.visit_string(sv.raw.clone())
+                }
+                ScalarType::String => visitor.visit_string(sv.raw.clone()),
+            },
             HoconValue::Object(map) => visitor.visit_map(HoconMapAccess::new(map)),
             HoconValue::Array(items) => visitor.visit_seq(HoconSeqAccess::new(items)),
         }
@@ -99,12 +129,11 @@ impl<'de> ::serde::Deserializer<'de> for HoconDeserializer<'de> {
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
         match self.value {
-            HoconValue::Scalar(ScalarValue::Bool(b)) => visitor.visit_bool(*b),
-            HoconValue::Scalar(ScalarValue::String(s)) => match s.to_lowercase().as_str() {
+            HoconValue::Scalar(sv) => match sv.raw.to_lowercase().as_str() {
                 "true" | "yes" | "on" => visitor.visit_bool(true),
                 "false" | "no" | "off" => visitor.visit_bool(false),
                 _ => Err(DeserializeError {
-                    message: format!("cannot coerce \"{}\" to bool", s),
+                    message: format!("cannot coerce \"{}\" to bool", sv.raw),
                 }),
             },
             other => Err(DeserializeError {
@@ -127,11 +156,9 @@ impl<'de> ::serde::Deserializer<'de> for HoconDeserializer<'de> {
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
         match self.value {
-            HoconValue::Scalar(ScalarValue::Float(f)) => visitor.visit_f32(*f as f32),
-            HoconValue::Scalar(ScalarValue::Int(n)) => visitor.visit_f32(*n as f32),
-            HoconValue::Scalar(ScalarValue::String(s)) => {
-                let f: f32 = s.parse().map_err(|_| DeserializeError {
-                    message: format!("cannot parse \"{}\" as f32", s),
+            HoconValue::Scalar(sv) => {
+                let f: f32 = sv.raw.parse().map_err(|_| DeserializeError {
+                    message: format!("cannot parse \"{}\" as f32", sv.raw),
                 })?;
                 visitor.visit_f32(f)
             }
@@ -146,11 +173,9 @@ impl<'de> ::serde::Deserializer<'de> for HoconDeserializer<'de> {
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
         match self.value {
-            HoconValue::Scalar(ScalarValue::Float(f)) => visitor.visit_f64(*f),
-            HoconValue::Scalar(ScalarValue::Int(n)) => visitor.visit_f64(*n as f64),
-            HoconValue::Scalar(ScalarValue::String(s)) => {
-                let f: f64 = s.parse().map_err(|_| DeserializeError {
-                    message: format!("cannot parse \"{}\" as f64", s),
+            HoconValue::Scalar(sv) => {
+                let f: f64 = sv.raw.parse().map_err(|_| DeserializeError {
+                    message: format!("cannot parse \"{}\" as f64", sv.raw),
                 })?;
                 visitor.visit_f64(f)
             }
@@ -165,12 +190,12 @@ impl<'de> ::serde::Deserializer<'de> for HoconDeserializer<'de> {
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
         match self.value {
-            HoconValue::Scalar(ScalarValue::String(s)) => {
-                let mut chars = s.chars();
+            HoconValue::Scalar(sv) => {
+                let mut chars = sv.raw.chars();
                 match (chars.next(), chars.next()) {
                     (Some(c), None) => visitor.visit_char(c),
                     _ => Err(DeserializeError {
-                        message: format!("expected single char, got \"{}\"", s),
+                        message: format!("expected single char, got \"{}\"", sv.raw),
                     }),
                 }
             }
@@ -192,11 +217,7 @@ impl<'de> ::serde::Deserializer<'de> for HoconDeserializer<'de> {
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
         match self.value {
-            HoconValue::Scalar(ScalarValue::String(s)) => visitor.visit_string(s.clone()),
-            HoconValue::Scalar(ScalarValue::Int(n)) => visitor.visit_string(n.to_string()),
-            HoconValue::Scalar(ScalarValue::Float(f)) => visitor.visit_string(f.to_string()),
-            HoconValue::Scalar(ScalarValue::Bool(b)) => visitor.visit_string(b.to_string()),
-            HoconValue::Scalar(ScalarValue::Null) => visitor.visit_string("null".to_string()),
+            HoconValue::Scalar(sv) => visitor.visit_string(sv.raw.clone()),
             other => Err(DeserializeError {
                 message: format!("expected string, got {:?}", other),
             }),
@@ -226,7 +247,7 @@ impl<'de> ::serde::Deserializer<'de> for HoconDeserializer<'de> {
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
         match self.value {
-            HoconValue::Scalar(ScalarValue::Null) => visitor.visit_none(),
+            HoconValue::Scalar(sv) if sv.value_type == ScalarType::Null => visitor.visit_none(),
             _ => visitor.visit_some(self),
         }
     }
@@ -236,7 +257,7 @@ impl<'de> ::serde::Deserializer<'de> for HoconDeserializer<'de> {
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
         match self.value {
-            HoconValue::Scalar(ScalarValue::Null) => visitor.visit_unit(),
+            HoconValue::Scalar(sv) if sv.value_type == ScalarType::Null => visitor.visit_unit(),
             other => Err(DeserializeError {
                 message: format!("expected null/unit, got {:?}", other),
             }),
@@ -316,8 +337,8 @@ impl<'de> ::serde::Deserializer<'de> for HoconDeserializer<'de> {
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
         match self.value {
-            HoconValue::Scalar(ScalarValue::String(s)) => {
-                visitor.visit_enum(s.as_str().into_deserializer())
+            HoconValue::Scalar(sv) => {
+                visitor.visit_enum(sv.raw.as_str().into_deserializer())
             }
             other => Err(DeserializeError {
                 message: format!("expected string for enum variant, got {:?}", other),

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -56,11 +56,7 @@ where
     // Float truncation fallback for Number types
     if sv.value_type == ScalarType::Number {
         if let Ok(f) = sv.raw.parse::<f64>() {
-            if f.fract() == 0.0
-                && f.is_finite()
-                && f >= i64::MIN as f64
-                && f < (i64::MAX as f64)
-            {
+            if f.fract() == 0.0 && f.is_finite() && f >= i64::MIN as f64 && f < (i64::MAX as f64) {
                 let as_i64 = f as i64;
                 if let Ok(n) = T::try_from(as_i64) {
                     return Ok(n);
@@ -335,9 +331,7 @@ impl<'de> ::serde::Deserializer<'de> for HoconDeserializer<'de> {
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
         match self.value {
-            HoconValue::Scalar(sv) => {
-                visitor.visit_enum(sv.raw.as_str().into_deserializer())
-            }
+            HoconValue::Scalar(sv) => visitor.visit_enum(sv.raw.as_str().into_deserializer()),
             other => Err(DeserializeError {
                 message: format!("expected string for enum variant, got {:?}", other),
             }),

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -56,18 +56,16 @@ where
     // Float truncation fallback for Number types
     if sv.value_type == ScalarType::Number {
         if let Ok(f) = sv.raw.parse::<f64>() {
-            if f.fract() == 0.0 && f.is_finite() {
+            if f.fract() == 0.0
+                && f.is_finite()
+                && f >= i64::MIN as f64
+                && f < (i64::MAX as f64)
+            {
                 let as_i64 = f as i64;
                 if let Ok(n) = T::try_from(as_i64) {
                     return Ok(n);
                 }
             }
-        }
-    }
-    // String type: try parsing as number
-    if sv.value_type == ScalarType::String {
-        if let Ok(n) = sv.raw.parse::<T>() {
-            return Ok(n);
         }
     }
     Err(DeserializeError {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -53,13 +53,21 @@ where
     if let Ok(n) = sv.raw.parse::<T>() {
         return Ok(n);
     }
-    // Float truncation fallback for Number types
+    // Float truncation fallback for Number types — only for float-like literals
     if sv.value_type == ScalarType::Number {
-        if let Ok(f) = sv.raw.parse::<f64>() {
-            if f.fract() == 0.0 && f.is_finite() && f >= i64::MIN as f64 && f < (i64::MAX as f64) {
-                let as_i64 = f as i64;
-                if let Ok(n) = T::try_from(as_i64) {
-                    return Ok(n);
+        let is_float_like =
+            sv.raw.contains('.') || sv.raw.contains('e') || sv.raw.contains('E');
+        if is_float_like {
+            if let Ok(f) = sv.raw.parse::<f64>() {
+                if f.fract() == 0.0
+                    && f.is_finite()
+                    && f >= i64::MIN as f64
+                    && f < (i64::MAX as f64)
+                {
+                    let as_i64 = f as i64;
+                    if let Ok(n) = T::try_from(as_i64) {
+                        return Ok(n);
+                    }
                 }
             }
         }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -55,8 +55,7 @@ where
     }
     // Float truncation fallback for Number types — only for float-like literals
     if sv.value_type == ScalarType::Number {
-        let is_float_like =
-            sv.raw.contains('.') || sv.raw.contains('e') || sv.raw.contains('E');
+        let is_float_like = sv.raw.contains('.') || sv.raw.contains('e') || sv.raw.contains('E');
         if is_float_like {
             if let Ok(f) = sv.raw.parse::<f64>() {
                 if f.fract() == 0.0

--- a/src/value.rs
+++ b/src/value.rs
@@ -18,6 +18,7 @@ pub enum HoconValue {
 }
 
 /// The type tag for a scalar value.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScalarType {
     /// A string value.
@@ -34,6 +35,7 @@ pub enum ScalarType {
 ///
 /// Stores the raw string representation alongside a type tag.
 /// Typed access (i64, f64, bool) is done by parsing `raw` on demand.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScalarValue {
     /// The raw string as it appeared in the source (or was produced by resolution).

--- a/src/value.rs
+++ b/src/value.rs
@@ -17,18 +17,66 @@ pub enum HoconValue {
     Scalar(ScalarValue),
 }
 
-/// A scalar (leaf) value inside a HOCON document.
-#[non_exhaustive]
-#[derive(Debug, Clone, PartialEq)]
-pub enum ScalarValue {
+/// The type tag for a scalar value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScalarType {
     /// A string value.
-    String(String),
-    /// A 64-bit signed integer.
-    Int(i64),
-    /// A 64-bit floating-point number.
-    Float(f64),
+    String,
+    /// A numeric value (integer or floating-point).
+    Number,
     /// A boolean value.
-    Bool(bool),
+    Boolean,
     /// An explicit null.
     Null,
+}
+
+/// A scalar (leaf) value inside a HOCON document.
+///
+/// Stores the raw string representation alongside a type tag.
+/// Typed access (i64, f64, bool) is done by parsing `raw` on demand.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScalarValue {
+    /// The raw string as it appeared in the source (or was produced by resolution).
+    pub raw: String,
+    /// The semantic type of this scalar.
+    pub value_type: ScalarType,
+}
+
+impl ScalarValue {
+    /// Create a new scalar value with explicit type.
+    pub fn new(raw: String, value_type: ScalarType) -> Self {
+        Self { raw, value_type }
+    }
+
+    /// Create a string-typed scalar.
+    pub fn string(raw: String) -> Self {
+        Self {
+            raw,
+            value_type: ScalarType::String,
+        }
+    }
+
+    /// Create a null scalar.
+    pub fn null() -> Self {
+        Self {
+            raw: "null".to_string(),
+            value_type: ScalarType::Null,
+        }
+    }
+
+    /// Create a boolean scalar.
+    pub fn boolean(value: bool) -> Self {
+        Self {
+            raw: if value { "true" } else { "false" }.to_string(),
+            value_type: ScalarType::Boolean,
+        }
+    }
+
+    /// Create a number scalar from a raw string.
+    pub fn number(raw: String) -> Self {
+        Self {
+            raw,
+            value_type: ScalarType::Number,
+        }
+    }
 }

--- a/tests/lightbend_test.rs
+++ b/tests/lightbend_test.rs
@@ -55,6 +55,7 @@ fn hocon_to_json(v: &hocon::HoconValue) -> serde_json::Value {
                 serde_json::Value::String(sv.raw.clone())
             }
             hocon::ScalarType::String => serde_json::Value::String(sv.raw.clone()),
+            _ => serde_json::Value::String(sv.raw.clone()),
         },
         _ => unreachable!("unknown HoconValue variant"),
     }

--- a/tests/lightbend_test.rs
+++ b/tests/lightbend_test.rs
@@ -39,13 +39,22 @@ fn hocon_to_json(v: &hocon::HoconValue) -> serde_json::Value {
         hocon::HoconValue::Array(arr) => {
             serde_json::Value::Array(arr.iter().map(hocon_to_json).collect())
         }
-        hocon::HoconValue::Scalar(s) => match s {
-            hocon::ScalarValue::String(s) => serde_json::Value::String(s.clone()),
-            hocon::ScalarValue::Int(n) => serde_json::json!(*n as f64),
-            hocon::ScalarValue::Float(f) => serde_json::json!(*f),
-            hocon::ScalarValue::Bool(b) => serde_json::Value::Bool(*b),
-            hocon::ScalarValue::Null => serde_json::Value::Null,
-            _ => unreachable!("unknown ScalarValue variant"),
+        hocon::HoconValue::Scalar(sv) => match sv.value_type {
+            hocon::ScalarType::Null => serde_json::Value::Null,
+            hocon::ScalarType::Boolean => serde_json::Value::Bool(sv.raw == "true"),
+            hocon::ScalarType::Number => {
+                // Try i64 first (no dot/exponent), then f64
+                if !sv.raw.contains('.') && !sv.raw.contains('e') && !sv.raw.contains('E') {
+                    if let Ok(n) = sv.raw.parse::<i64>() {
+                        return serde_json::json!(n as f64);
+                    }
+                }
+                if let Ok(f) = sv.raw.parse::<f64>() {
+                    return serde_json::json!(f);
+                }
+                serde_json::Value::String(sv.raw.clone())
+            }
+            hocon::ScalarType::String => serde_json::Value::String(sv.raw.clone()),
         },
         _ => unreachable!("unknown HoconValue variant"),
     }


### PR DESCRIPTION
## Summary

- Replace `ScalarValue` enum (`String/Int/Float/Bool/Null` variants) with struct `{raw: String, value_type: ScalarType}`
- Parser validates number literals but stores raw string, not converted values
- Number detection aligned with Lightbend: first char must be `0-9` or `-` (`.33` is now string)
- `get_string()` returns `raw` for ALL scalar types (Lightbend compatible)
- `get_i64()`/`get_f64()` parse from `raw` on demand with proper overflow checks
- Serde deserializer updated with consolidated `parse_int_from_scalar` helper
- Fixed `get_bytes` regression for bare float numbers
- Fixed f64→i64 saturation on overflow in `get_i64` and serde
- Removed dead code path in serde `parse_int_from_scalar`

## Test plan

- [x] All 142 tests pass, clippy clean
- [x] New test: `.33` preserved as string (`dot_prefix_is_string_not_number`)
- [x] New tests: `get_i64` overflow returns error (`get_i64_error_on_overflow`, `get_i64_error_on_i64_max_plus_one`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)