### PR TITLE
fix: resolve include file() paths relative to CWD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_bytes()` rejects bare float numbers that would silently round.
 - Serde `parse_int_from_scalar`: removed dead code path, restricted f64 fallback to float-like literals.
 - Quoted-key include relativization: `${"a.b".c}` inside included files now resolves correctly.
+- `include file("path")` now resolves relative to the process working directory (or as absolute), not relative to the including file's directory, matching the HOCON spec.
 - `tempfile` dev-dependency pinned to `<3.20` for MSRV 1.82 compatibility.
 
 ### Added

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -38,6 +38,7 @@ pub enum AstNode {
     Include {
         path: String,
         required: bool,
+        is_file: bool,
         pos: Pos,
     },
 }
@@ -373,6 +374,7 @@ impl<'a> Parser<'a> {
         }
 
         let path;
+        let mut is_file = false;
         if self.peek_kind() == TokenKind::QuotedString {
             // Simple: include required("path") or include "path"
             path = self.peek_value().to_string();
@@ -388,6 +390,7 @@ impl<'a> Parser<'a> {
             || file_prefix_consumed
         {
             // file("path") form — possibly with required( already consumed.
+            is_file = true;
             let err_line = self.peek_line();
             let err_col = self.peek_col();
 
@@ -432,6 +435,7 @@ impl<'a> Parser<'a> {
             value: AstNode::Include {
                 path,
                 required,
+                is_file,
                 pos: p.clone(),
             },
             append: false,
@@ -749,12 +753,20 @@ mod tests {
         let node = parse("include \"other.conf\"");
         let f = &fields(&node)[0];
         assert!(f.key.is_empty());
-        assert!(matches!(f.value, AstNode::Include { .. }));
+        if let AstNode::Include { is_file, .. } = &f.value {
+            assert!(!is_file, "bare include should have is_file=false");
+        } else {
+            panic!("expected Include");
+        }
     }
 
     #[test]
     fn parses_include_file_syntax() {
         let node = parse("include file(\"other.conf\")");
-        assert!(matches!(&fields(&node)[0].value, AstNode::Include { .. }));
+        if let AstNode::Include { is_file, .. } = &fields(&node)[0].value {
+            assert!(is_file, "file() include should have is_file=true");
+        } else {
+            panic!("expected Include");
+        }
     }
 }

--- a/src/resolver/include_loader.rs
+++ b/src/resolver/include_loader.rs
@@ -9,14 +9,22 @@ use super::utils::deep_merge_res_obj_into;
 pub(crate) fn load_include(
     include_path: &str,
     required: bool,
+    is_file: bool,
     line: usize,
     col: usize,
     opts: &ResolveOptions,
     _path_prefix: &[String],
 ) -> Result<ResObj, ResolveError> {
-    let base = match &opts.base_dir {
-        Some(dir) => dir.clone(),
-        None => std::env::current_dir().unwrap_or_default(),
+    // file() includes resolve relative to CWD (or as absolute), NOT relative
+    // to the including file's directory.  Bare includes use the including
+    // file's base_dir (falling back to CWD when there is none).
+    let base = if is_file {
+        std::env::current_dir().unwrap_or_default()
+    } else {
+        match &opts.base_dir {
+            Some(dir) => dir.clone(),
+            None => std::env::current_dir().unwrap_or_default(),
+        }
     };
 
     let abs_path = base.join(include_path);

--- a/src/resolver/structure_builder.rs
+++ b/src/resolver/structure_builder.rs
@@ -46,12 +46,14 @@ impl<'a> StructureBuilder<'a> {
             if let AstNode::Include {
                 path: include_path,
                 required,
+                is_file,
                 pos,
             } = &field.value
             {
                 let mut included = load_include(
                     include_path,
                     *required,
+                    *is_file,
                     pos.line,
                     pos.col,
                     self.opts,

--- a/tests/include_test.rs
+++ b/tests/include_test.rs
@@ -101,3 +101,45 @@ fn include_env_fallback_quoted_key_prefix() {
     assert_eq!(config.get_string(r#""a.b".val"#).unwrap(), "ok");
     // _guard drops here, removing the env var
 }
+
+#[test]
+fn file_include_resolves_from_cwd_not_including_dir() {
+    // Create a temp directory with a parent conf that uses `include file(...)`.
+    // The file() path is relative to CWD, so a file that exists in the parent's
+    // directory but NOT in CWD should NOT be found.
+    let dir = tempdir().unwrap();
+    let subdir = dir.path().join("sub");
+    std::fs::create_dir(&subdir).unwrap();
+
+    // child.conf exists only in sub/
+    std::fs::write(subdir.join("child.conf"), "child_key = 1").unwrap();
+
+    // parent.conf in sub/ does:
+    //   - bare include "child.conf"  -> resolves relative to sub/ -> found
+    //   - file("child.conf")         -> resolves relative to CWD -> NOT found (silently skipped)
+    //   - file() with absolute path  -> should work
+    let abs_child = subdir
+        .join("child.conf")
+        .display()
+        .to_string()
+        .replace('\\', "/");
+    let parent_content = format!(
+        concat!(
+            "bare_ok = true\n",
+            "include \"child.conf\"\n",
+            "include file(\"nonexistent-from-cwd.conf\")\n",
+            "include file(\"{}\")\n",
+        ),
+        abs_child
+    );
+    std::fs::write(subdir.join("parent.conf"), &parent_content).unwrap();
+
+    let config = hocon::parse_file(subdir.join("parent.conf")).unwrap();
+
+    // bare include found the child
+    assert_eq!(config.get_i64("child_key").unwrap(), 1);
+    // bare_ok is set
+    assert!(config.get_bool("bare_ok").unwrap());
+    // file("nonexistent-from-cwd.conf") was silently skipped (no error)
+    // file() with absolute path also found the child (child_key still 1)
+}

--- a/tests/include_test.rs
+++ b/tests/include_test.rs
@@ -1,5 +1,9 @@
 use std::path::PathBuf;
+use std::sync::Mutex;
 use tempfile::tempdir;
+
+/// Global lock for tests that change the process-wide CWD.
+static CWD_LOCK: Mutex<()> = Mutex::new(());
 
 fn testdata(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -104,20 +108,29 @@ fn include_env_fallback_quoted_key_prefix() {
 
 #[test]
 fn file_include_resolves_from_cwd_not_including_dir() {
-    // Create a temp directory with a parent conf that uses `include file(...)`.
-    // The file() path is relative to CWD, so a file that exists in the parent's
-    // directory but NOT in CWD should NOT be found.
+    // Prove that `include file("child.conf")` resolves relative to CWD,
+    // NOT relative to the including file's directory.
+    //
+    // Layout:
+    //   tmpdir/child.conf          -> cwd_key = 99   (CWD-level)
+    //   tmpdir/sub/parent.conf     -> includes child.conf via bare + file()
+    //   tmpdir/sub/child.conf      -> child_key = 1   (including-file-level)
+    //
+    // CWD is set to tmpdir.  Therefore:
+    //   bare include "child.conf"  -> resolves relative to sub/ -> child_key = 1
+    //   include file("child.conf") -> resolves relative to CWD  -> cwd_key = 99
+    let _lock = CWD_LOCK.lock().unwrap();
+    let prev_cwd = std::env::current_dir().unwrap();
+
     let dir = tempdir().unwrap();
     let subdir = dir.path().join("sub");
     std::fs::create_dir(&subdir).unwrap();
 
-    // child.conf exists only in sub/
+    // child.conf at CWD level (tmpdir/)
+    std::fs::write(dir.path().join("child.conf"), "cwd_key = 99").unwrap();
+    // child.conf in including file's directory (tmpdir/sub/)
     std::fs::write(subdir.join("child.conf"), "child_key = 1").unwrap();
 
-    // parent.conf in sub/ does:
-    //   - bare include "child.conf"  -> resolves relative to sub/ -> found
-    //   - file("child.conf")         -> resolves relative to CWD -> NOT found (silently skipped)
-    //   - file() with absolute path  -> should work
     let abs_child = subdir
         .join("child.conf")
         .display()
@@ -127,19 +140,23 @@ fn file_include_resolves_from_cwd_not_including_dir() {
         concat!(
             "bare_ok = true\n",
             "include \"child.conf\"\n",
-            "include file(\"nonexistent-from-cwd.conf\")\n",
+            "include file(\"child.conf\")\n",
             "include file(\"{}\")\n",
         ),
         abs_child
     );
     std::fs::write(subdir.join("parent.conf"), &parent_content).unwrap();
 
+    // Set CWD to tmpdir so file("child.conf") picks up the CWD-level file
+    std::env::set_current_dir(dir.path()).unwrap();
     let config = hocon::parse_file(subdir.join("parent.conf")).unwrap();
+    std::env::set_current_dir(&prev_cwd).unwrap();
 
-    // bare include found the child
+    // bare include resolved relative to sub/ -> child_key = 1
     assert_eq!(config.get_i64("child_key").unwrap(), 1);
+    // file("child.conf") resolved relative to CWD (tmpdir/) -> cwd_key = 99
+    assert_eq!(config.get_i64("cwd_key").unwrap(), 99);
     // bare_ok is set
     assert!(config.get_bool("bare_ok").unwrap());
-    // file("nonexistent-from-cwd.conf") was silently skipped (no error)
     // file() with absolute path also found the child (child_key still 1)
 }

--- a/tests/lightbend_test.rs
+++ b/tests/lightbend_test.rs
@@ -407,7 +407,6 @@ fn lightbend_suite_expected_json() {
         "test01-expected.json", // system.* contains env-specific values (HOME, PATH, etc.)
         "test02-expected.json", // empty-key ("".""."") and quoted-key ("a.b.c") bugs
         "test10-expected.json", // ConfigDelayedMerge: c.e missing q field from ${a} merge
-        "file-include-expected.json", // file() include semantics differ from JVM classpath
     ]
     .into_iter()
     .collect();


### PR DESCRIPTION
## Summary

- `include file("path")` now resolves relative to the process working directory (or as absolute), instead of relative to the including file's directory
- Bare `include "path"` retains existing behavior (resolve relative to including file)
- This matches the HOCON spec where `file()` designates an explicit filesystem path

## Changes

- **AST** (`src/parser.rs`): Added `is_file: bool` to `AstNode::Include`
- **Parser** (`src/parser.rs`): Sets `is_file = true` when `file(...)` syntax is detected
- **Structure builder** (`src/resolver/structure_builder.rs`): Passes `is_file` flag through to include loader
- **Include loader** (`src/resolver/include_loader.rs`): When `is_file` is true, resolves from CWD instead of `opts.base_dir`
- **Tests**: New `file_include_resolves_from_cwd_not_including_dir` test; un-skipped `file-include-expected.json` Lightbend conformance test
- **CHANGELOG.md**: Updated [Unreleased] section

## Test plan

- [x] `cargo test` — all 223 tests pass (including new test + Lightbend conformance)
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)