### PR TITLE
docs: add library stance and cross-language conformance notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ with optional Serde integration.
 
 [日本語](README.ja.md)
 
+**Library stance** — This library is a HOCON config loader. Its purpose is reading `.hocon` config files and providing typed access via the `Config` API (`get_string`, `get_i64`, `get_f64`, `get_bool`, `get_duration`, `get_bytes`). It is not a low-level parser API; internal types like `ScalarValue` may change between minor versions.
+
+**Cross-language conformance** — This implementation is tested against shared expected-JSON fixtures from [o3co/xx.hocon](https://github.com/o3co/xx.hocon) alongside [ts.hocon](https://github.com/o3co/ts.hocon) and [go.hocon](https://github.com/o3co/go.hocon), ensuring all three implementations meet the same Lightbend HOCON specification.
+
 ## Quick Start
 
 ### 1. Install


### PR DESCRIPTION
## Summary
- Add a **library stance** note clarifying that rs.hocon is a config loader (not a low-level parser API) and that internal types like `ScalarValue` may change between minor versions.
- Add a **cross-language conformance** note explaining that this implementation is tested against shared expected-JSON fixtures from xx.hocon alongside ts.hocon and go.hocon.

Both notes are placed near the top of the README, between the intro paragraph and Quick Start.

## Test plan
- [ ] Verify README renders correctly on GitHub

Generated with [Claude Code](https://claude.ai/claude-code)