### PR TITLE
ci: upgrade codecov-action to v5 with token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,5 +67,5 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: o3co/rs.hocon
+          slug: ${{ github.repository }}
           fail_ci_if_error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,9 @@ jobs:
         run: make testdata
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: cargo llvm-cov --features serde --lcov --output-path lcov.info
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: o3co/rs.hocon
+          fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Upgrade `codecov/codecov-action` from v4 to v5
- Add `CODECOV_TOKEN` secret, `slug`, and `fail_ci_if_error: false`
- v4+ requires token for uploads — this was causing coverage to show as "unknown"

## Test plan
- [ ] CI passes and coverage uploads successfully to Codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)