### PR TITLE
docs: align README spec-compliance claims with docs/spec-compliance.md

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -220,15 +220,13 @@ defaults { size = 20 }  # マージ: color は保持、size は更新
 
 ## 仕様準拠
 
-[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しています。
+[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しています。以下の表は 2026-05-12 時点のスナップショットです — 最新値は [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
 
 | 指標                                  | 状況         |
 | ------------------------------------- | ------------ |
 | 仕様全体（out-of-scope を含む）       | **57.2%**    |
 | In-scope のみ                         | **63.2%**    |
 | Lightbend `equiv01`–`equiv05` テスト  | 5/5 合格     |
-
-ts/rs/go 横断のロールアップ: [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md)。
 
 ## Minimum Supported Rust Version
 
@@ -242,7 +240,7 @@ MSRV は **1.82** です。
 | [go.hocon](https://github.com/o3co/go.hocon) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/go.hocon) | Go 向け HOCON パーサー |
 | [hocon2](https://github.com/o3co/hocon2) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/hocon2) | HOCON → JSON/YAML/TOML/Properties 変換 CLI |
 
-3 実装はすべて同じ Lightbend HOCON 仕様で追跡されています — 実装ごとの準拠率は [横断ロールアップ](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
+3 つのパーサー実装（[ts.hocon](https://github.com/o3co/ts.hocon)、[rs.hocon](https://github.com/o3co/rs.hocon)、[go.hocon](https://github.com/o3co/go.hocon)）はすべて同じ Lightbend HOCON 仕様で追跡されています — 実装ごとの準拠率は [横断ロールアップ](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
 
 ## ベストプラクティス
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@
 [![codecov](https://codecov.io/gh/o3co/rs.hocon/branch/main/graph/badge.svg)](https://codecov.io/gh/o3co/rs.hocon)
 [![License](https://img.shields.io/crates/l/hocon-parser.svg)](LICENSE)
 
-[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md)に完全準拠した Rust パーサー。手書きレキサー、再帰下降パーサー、型付き `Config` API を備え、オプションで Serde 統合に対応。
+[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) の Rust パーサー。手書きレキサー、再帰下降パーサー、型付き `Config` API を備え、オプションで Serde 統合に対応。現在の準拠率は [仕様準拠](#仕様準拠) を参照。
 
 > **[Claude Code](https://claude.ai/claude-code)（Anthropic）による設計・実装。**
 > [GitHub Copilot](https://github.com/features/copilot) および [OpenAI Codex](https://openai.com/index/openai-codex/) によるレビュー。
@@ -220,7 +220,15 @@ defaults { size = 20 }  # マージ: color は保持、size は更新
 
 ## 仕様準拠
 
-[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md)への完全準拠を目標としています。テストスイートには Lightbend 等価テスト（equiv01 - equiv05）を含み、オブジェクトマージ、配列連結、変数参照、その他仕様で定義されたすべての動作を検証しています。
+[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しています。
+
+| 指標                                  | 状況         |
+| ------------------------------------- | ------------ |
+| 仕様全体（out-of-scope を含む）       | **57.2%**    |
+| In-scope のみ                         | **63.2%**    |
+| Lightbend `equiv01`–`equiv05` テスト  | 5/5 合格     |
+
+ts/rs/go 横断のロールアップ: [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md)。
 
 ## Minimum Supported Rust Version
 
@@ -234,7 +242,7 @@ MSRV は **1.82** です。
 | [go.hocon](https://github.com/o3co/go.hocon) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/go.hocon) | Go 向け HOCON パーサー |
 | [hocon2](https://github.com/o3co/hocon2) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/hocon2) | HOCON → JSON/YAML/TOML/Properties 変換 CLI |
 
-すべての実装が Lightbend HOCON 仕様に完全準拠しています。
+3 実装はすべて同じ Lightbend HOCON 仕様で追跡されています — 実装ごとの準拠率は [横断ロールアップ](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
 
 ## ベストプラクティス
 

--- a/README.md
+++ b/README.md
@@ -280,15 +280,13 @@ For typical application configs (loaded once at startup), the parsing cost is ne
 
 ## Spec Compliance
 
-Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md).
+Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md). The table below is a snapshot as of 2026-05-12; see [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for live cross-impl values.
 
 | Metric                                | Status        |
 | ------------------------------------- | ------------- |
 | Spec total (incl. out-of-scope)       | **57.2%**     |
 | In-scope only                         | **63.2%**     |
 | Lightbend `equiv01`–`equiv05` suite   | 5/5 passing   |
-
-Cross-impl roll-up across ts/rs/go: [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md).
 
 ## Minimum Supported Rust Version
 
@@ -302,7 +300,7 @@ The MSRV is **1.82**.
 | [go.hocon](https://github.com/o3co/go.hocon) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/go.hocon) | HOCON parser for Go |
 | [hocon2](https://github.com/o3co/hocon2) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/hocon2) | HOCON → JSON/YAML/TOML/Properties CLI |
 
-All three implementations are tracked against the same Lightbend HOCON spec — see the [cross-impl roll-up](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for per-impl conformance rates.
+The three parser implementations ([ts.hocon](https://github.com/o3co/ts.hocon), [rs.hocon](https://github.com/o3co/rs.hocon), [go.hocon](https://github.com/o3co/go.hocon)) are all tracked against the same Lightbend HOCON spec — see the [cross-impl roll-up](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for per-impl conformance rates.
 
 ## Best Practices
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 [![codecov](https://codecov.io/gh/o3co/rs.hocon/branch/main/graph/badge.svg)](https://codecov.io/gh/o3co/rs.hocon)
 [![License](https://img.shields.io/crates/l/hocon-parser.svg)](LICENSE)
 
-Full [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md)-compliant
+A [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md)
 parser for Rust. Hand-written lexer, recursive-descent parser, and a typed `Config` API
-with optional Serde integration.
+with optional Serde integration. See [Spec Compliance](#spec-compliance) for the current
+conformance rate.
 
 [日本語](README.ja.md)
 
@@ -279,11 +280,15 @@ For typical application configs (loaded once at startup), the parsing cost is ne
 
 ## Spec Compliance
 
-This library targets full compliance with the
-[Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md).
-The test suite includes the Lightbend equivalence tests (equiv01 through equiv05),
-verifying correct handling of object merging, array concatenation, substitutions,
-and all other spec-defined behaviors.
+Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md).
+
+| Metric                                | Status        |
+| ------------------------------------- | ------------- |
+| Spec total (incl. out-of-scope)       | **57.2%**     |
+| In-scope only                         | **63.2%**     |
+| Lightbend `equiv01`–`equiv05` suite   | 5/5 passing   |
+
+Cross-impl roll-up across ts/rs/go: [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md).
 
 ## Minimum Supported Rust Version
 
@@ -297,7 +302,7 @@ The MSRV is **1.82**.
 | [go.hocon](https://github.com/o3co/go.hocon) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/go.hocon) | HOCON parser for Go |
 | [hocon2](https://github.com/o3co/hocon2) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/hocon2) | HOCON → JSON/YAML/TOML/Properties CLI |
 
-All implementations are full Lightbend HOCON spec compliant.
+All three implementations are tracked against the same Lightbend HOCON spec — see the [cross-impl roll-up](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for per-impl conformance rates.
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary

- Replace "Full Lightbend HOCON specification-compliant parser" tagline, "targets full compliance" preamble in the Spec Compliance section, and "All implementations are full Lightbend HOCON spec compliant" footer with the actual conformance rates tracked in [docs/spec-compliance.md](docs/spec-compliance.md): **57.2% spec-total / 63.2% in-scope**.
- The Lightbend equiv01–equiv05 pass-rate remains, now framed as one row in the Spec Compliance table.
- Link to cross-impl roll-up at [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md).
- Same edits applied to README.ja.md.

## Why

`docs/spec-compliance.md` (merged in #59) tracks conformance at 209-item granularity and reports honest rates. The README's "full compliant" wording contradicts that. Resolving by softening the README, not by inflating the spec-compliance numbers.

## Companion PRs

- [o3co/ts.hocon#71](https://github.com/o3co/ts.hocon/pull/71)
- [o3co/go.hocon#58](https://github.com/o3co/go.hocon/pull/58)

## Test plan

- [x] No code changes
- [x] Internal anchor `#spec-compliance` / `#仕様準拠` resolves
- [x] Cross-repo absolute URL to xx.hocon matrix is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)