### PR TITLE
test: Phase 4 spec compliance — S15 (numeric-indexed obj→arr) and S17 (null/array type errors)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -225,7 +225,7 @@ defaults { size = 20 }  # マージ: color は保持、size は更新
 | 指標                                  | 状況         |
 | ------------------------------------- | ------------ |
 | 仕様全体（out-of-scope を含む）       | **68.9%**    |
-| In-scope のみ                         | **76.2%**    |
+| In-scope のみ                         | **76.6%**    |
 | Lightbend `equiv01`–`equiv05` テスト  | 5/5 合格     |
 
 ## Minimum Supported Rust Version

--- a/README.ja.md
+++ b/README.ja.md
@@ -224,8 +224,8 @@ defaults { size = 20 }  # マージ: color は保持、size は更新
 
 | 指標                                  | 状況         |
 | ------------------------------------- | ------------ |
-| 仕様全体（out-of-scope を含む）       | **68.9%**    |
-| In-scope のみ                         | **76.6%**    |
+| 仕様全体（out-of-scope を含む）       | **70.1%**    |
+| In-scope のみ                         | **77.9%**    |
 | Lightbend `equiv01`–`equiv05` テスト  | 5/5 合格     |
 
 ## Minimum Supported Rust Version

--- a/README.md
+++ b/README.md
@@ -284,8 +284,8 @@ Conformance against the [Lightbend HOCON specification](https://github.com/light
 
 | Metric                                | Status        |
 | ------------------------------------- | ------------- |
-| Spec total (incl. out-of-scope)       | **68.9%**     |
-| In-scope only                         | **76.6%**     |
+| Spec total (incl. out-of-scope)       | **70.1%**     |
+| In-scope only                         | **77.9%**     |
 | Lightbend `equiv01`–`equiv05` suite   | 5/5 passing   |
 
 ## Minimum Supported Rust Version

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Conformance against the [Lightbend HOCON specification](https://github.com/light
 | Metric                                | Status        |
 | ------------------------------------- | ------------- |
 | Spec total (incl. out-of-scope)       | **68.9%**     |
-| In-scope only                         | **76.2%**     |
+| In-scope only                         | **76.6%**     |
 | Lightbend `equiv01`–`equiv05` suite   | 5/5 passing   |
 
 ## Minimum Supported Rust Version

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -564,26 +564,33 @@ same item descriptions verbatim.
 ## S15. Numerically-indexed objects to arrays
 
 - **S15.1** `{"0":"a","1":"b"}` → `["a","b"]` when array context — §Conversion (L1191)
-  tests: —
-  status: 🤷
+  tests: tests/integration_test.rs:1243 (s15_1_num_indexed_obj_to_array_pin); tests/integration_test.rs:1254 (s15_1_num_indexed_obj_to_array_spec)
+  status: ❌
+  note: `get_list()` on a numeric-keyed object returns `Err("expected Array")`. Conversion not implemented. Tracked in #79.
 - **S15.2** Conversion is lazy (only on type-required access) — §Conversion (L1204)
-  tests: —
-  status: 🤷
+  tests: tests/integration_test.rs:1274 (s15_2_conversion_is_lazy_pin); tests/integration_test.rs:1289 (s15_2_conversion_is_lazy_spec)
+  status: ❌
+  note: No lazy conversion is performed. `get_list()` on a numeric-keyed object errors regardless of whether object access was first attempted. Tracked in #79.
 - **S15.3** Conversion in concatenation when list expected — §Conversion (L1210)
-  tests: —
-  status: 🤷
+  tests: tests/integration_test.rs:1307 (s15_3_conversion_in_concatenation_pin); tests/integration_test.rs:1324 (s15_3_conversion_in_concatenation_spec)
+  status: ❌
+  note: `get_list()` on a substitution-resolved numeric-keyed object (used where array expected) errors. No concatenation conversion. Tracked in #79.
 - **S15.4** Empty object NOT converted — §Conversion (L1212)
-  tests: —
-  status: 🤷
+  tests: tests/integration_test.rs:1344 (s15_4_empty_object_not_converted)
+  status: ✅
+  note: `get_list()` on `{}` returns an error (correct — empty object must not be converted). Confirmed conformant by probe; passes because no conversion is implemented at all.
 - **S15.5** Non-integer keys ignored during conversion — §Conversion (L1214)
-  tests: —
-  status: 🤷
+  tests: tests/integration_test.rs:1358 (s15_5_non_integer_keys_ignored_pin); tests/integration_test.rs:1370 (s15_5_non_integer_keys_ignored_spec)
+  status: ❌
+  note: Conversion not implemented. The `{"0":"a","foo":"b","1":"c"}` case cannot be exercised. Tracked in #79.
 - **S15.6** Missing indices compacted in resulting array — §Conversion (L1216)
-  tests: —
-  status: 🤷
+  tests: tests/integration_test.rs:1384 (s15_6_missing_indices_compacted_pin); tests/integration_test.rs:1396 (s15_6_missing_indices_compacted_spec)
+  status: ❌
+  note: Conversion not implemented. Tracked in #79.
 - **S15.7** Sorted by integer key value — §Conversion (L1216)
-  tests: —
-  status: 🤷
+  tests: tests/integration_test.rs:1412 (s15_7_sorted_by_key_value_pin); tests/integration_test.rs:1424 (s15_7_sorted_by_key_value_spec)
+  status: ❌
+  note: Conversion not implemented. Tracked in #79.
 
 ## S16. MIME Type
 
@@ -607,17 +614,20 @@ same item descriptions verbatim.
   tests: src/config.rs:621 (get_bool_coerces_string_true); src/config.rs:627 (get_bool_coerces_string_false); src/config.rs:633 (get_bool_coerces_yes_no_on_off); tests/integration_test.rs:118 (parse_bool_coercion)
   status: ✅
 - **S17.5** `"null"` → null when null requested — §Automatic type conversions (L1244)
-  tests: —
-  status: 🤷
+  tests: tests/integration_test.rs:1449 (s17_5_null_string_stored_as_string_not_null)
+  status: ➖
+  note: rs.hocon has no `get_null()` typed getter — the "null requested" path does not exist in the API. Internally, quoted `"null"` is correctly stored as `ScalarType::String` (not `Null`), which is consistent with spec intent. Out-of-scope until a null-accessor is added.
 - **S17.6** null → other type: error — §Automatic type conversions (L1252)
-  tests: —
-  status: 🤷
+  tests: tests/integration_test.rs:1470 (s17_6_null_to_numeric_and_bool_errors); tests/integration_test.rs:1483 (s17_6_null_to_string_pin); tests/integration_test.rs:1495 (s17_6_null_to_string_spec)
+  status: ⚠️
+  note: `get_i64` and `get_bool` on null correctly error. `get_string` on null returns `Ok("null")` instead of an error — spec requires an error for all typed getters. Bug tracked in #80.
 - **S17.7** object → other type: error — §Automatic type conversions (L1254)
   tests: src/config.rs:563 (get_string_error_on_object)
   status: ✅
 - **S17.8** array → other (except numeric-indexed): error — §Automatic type conversions (L1255)
-  tests: —
-  status: 🤷
+  tests: tests/integration_test.rs:1505 (s17_8_array_to_other_type_errors)
+  status: ✅
+  note: `get_string`, `get_i64`, `get_bool` all error on array values. `get_list` on a plain array succeeds.
 
 ## S18. Units format
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -572,9 +572,9 @@ same item descriptions verbatim.
   status: ❌
   note: No lazy conversion is performed. `get_list()` on a numeric-keyed object errors regardless of whether object access was first attempted. Tracked in #79.
 - **S15.3** Conversion in concatenation when list expected — §Conversion (L1210)
-  tests: tests/integration_test.rs:1307 (s15_3_conversion_in_concatenation_pin); tests/integration_test.rs:1324 (s15_3_conversion_in_concatenation_spec)
+  tests: tests/integration_test.rs:1310 (s15_3_conversion_in_concatenation_pin); tests/integration_test.rs:1335 (s15_3_conversion_in_concatenation_spec)
   status: ❌
-  note: `get_list()` on a substitution-resolved numeric-keyed object (used where array expected) errors. No concatenation conversion. Tracked in #79.
+  note: real concatenation context `arr = [a] ${obj}` (with `obj = {"0":"x","1":"y"}`) produces a 3-element array whose last element is the un-converted Object — spec L1210 requires conversion + flatten to `["a","x","y"]`. Pin asserts the un-converted last element. Tracked in #79.
 - **S15.4** Empty object NOT converted — §Conversion (L1212)
   tests: tests/integration_test.rs:1344 (s15_4_empty_object_not_converted)
   status: ✅

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1302,20 +1302,30 @@ fn s15_2_conversion_is_lazy_spec() {
 
 // --- S15.3: conversion in concatenation when list expected (spec L1210) -----------
 //
-// [pin] No conversion occurs in concatenation context.
+// Spec: when a numerically-indexed object participates in concatenation where a
+// list is expected (e.g. adjacent to a literal array), it must convert to its
+// array form and flatten in. Probe shows rs.hocon currently puts the object
+// into the resulting array as-is (no conversion), plus a whitespace artefact —
+// pin asserts the buggy element layout so a future fix flips the assertion.
 #[test]
 fn s15_3_conversion_in_concatenation_pin() {
-    // obj = {"0":"x","1":"y"}, arr = [a] ++ obj should convert obj to array and append.
+    // Real concatenation context: literal array adjacent to a substitution-resolved
+    // numeric-keyed object. Spec L1210 says obj must convert to ["x","y"], producing
+    // ["a","x","y"]. Probe (2026-05-12) shows we get 3 elements but the last is the
+    // un-converted Object, not the flattened strings.
     let cfg = hocon::parse_with_env(
         r#"obj = {"0":"x","1":"y"}
-arr = ${obj}"#,
+arr = [a] ${obj}"#,
         &HashMap::new(),
     )
     .unwrap();
-    // [pin] Buggy: get_list on the substitution-resolved value fails (no conversion).
+    let items = cfg.get_list("arr").expect("concat produces an array (list literal present)");
+    // [pin] Buggy: last element is the un-converted object, not flattened strings.
+    let last = items.last().expect("non-empty array");
     assert!(
-        cfg.get_list("arr").is_err(),
-        "[pin] get_list on substitution of numeric-keyed object currently errors — update when fixed"
+        matches!(last, hocon::HoconValue::Object(_)),
+        "[pin] last element must currently be the un-converted Object, got {:?}",
+        last
     );
 }
 
@@ -1324,14 +1334,26 @@ arr = ${obj}"#,
 fn s15_3_conversion_in_concatenation_spec() {
     let cfg = hocon::parse_with_env(
         r#"obj = {"0":"x","1":"y"}
-arr = ${obj}"#,
+arr = [a] ${obj}"#,
         &HashMap::new(),
     )
     .unwrap();
-    assert!(
-        cfg.get_list("arr").is_ok(),
-        "numeric-indexed object must convert to array when array context expected per HOCON L1210"
+    let items = cfg.get_list("arr").expect("concat produces an array");
+    // Spec L1210: obj converts to ["x","y"] and flattens → ["a","x","y"] (3 elements).
+    assert_eq!(
+        items.len(),
+        3,
+        "expected ['a','x','y'] after conversion, got {:?}",
+        items
     );
+    let raws: Vec<&str> = items
+        .iter()
+        .map(|v| match v {
+            hocon::HoconValue::Scalar(s) => s.raw.as_str(),
+            _ => panic!("expected scalar after conversion, got {:?}", v),
+        })
+        .collect();
+    assert_eq!(raws, vec!["a", "x", "y"]);
 }
 
 // --- S15.4: empty object NOT converted (spec L1212) --------------------------------

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1319,7 +1319,9 @@ arr = [a] ${obj}"#,
         &HashMap::new(),
     )
     .unwrap();
-    let items = cfg.get_list("arr").expect("concat produces an array (list literal present)");
+    let items = cfg
+        .get_list("arr")
+        .expect("concat produces an array (list literal present)");
     // [pin] Buggy: last element is the un-converted object, not flattened strings.
     let last = items.last().expect("non-empty array");
     assert!(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1234,3 +1234,291 @@ fn s14b_1_array_root_include_is_error() {
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+// --- S15.1: numeric-keyed object → array when array context (spec L1191) ----------
+//
+// [pin] rs.hocon does not implement numeric-indexed object to array conversion.
+// get_list() on {"0":"a","1":"b"} currently errors with "expected Array".
+#[test]
+fn s15_1_num_indexed_obj_to_array_pin() {
+    let cfg = hocon::parse_with_env(r#"v = {"0":"a","1":"b"}"#, &HashMap::new()).unwrap();
+    // [pin] Buggy: get_list errors instead of converting numeric-keyed object to array.
+    assert!(
+        cfg.get_list("v").is_err(),
+        "[pin] get_list on numeric-keyed object currently errors — update when fixed"
+    );
+}
+
+#[ignore = "spec violation: numeric-indexed object must convert to array when array type requested per HOCON L1191, see #79"]
+#[test]
+fn s15_1_num_indexed_obj_to_array_spec() {
+    let cfg = hocon::parse_with_env(r#"v = {"0":"a","1":"b"}"#, &HashMap::new()).unwrap();
+    let items = cfg
+        .get_list("v")
+        .expect("numeric-keyed object must be convertible to array per HOCON L1191");
+    assert_eq!(items.len(), 2, "converted array must have 2 elements");
+    match &items[0] {
+        hocon::HoconValue::Scalar(sv) => assert_eq!(sv.raw, "a", "first element must be \"a\""),
+        other => panic!("expected Scalar, got {:?}", other),
+    }
+    match &items[1] {
+        hocon::HoconValue::Scalar(sv) => assert_eq!(sv.raw, "b", "second element must be \"b\""),
+        other => panic!("expected Scalar, got {:?}", other),
+    }
+}
+
+// --- S15.2: conversion is lazy — only when array type is requested (spec L1204) ---
+//
+// [pin] No lazy conversion is implemented. get_list on a numeric-keyed object errors.
+#[test]
+fn s15_2_conversion_is_lazy_pin() {
+    let cfg = hocon::parse_with_env(r#"v = {"0":"a","1":"b"}"#, &HashMap::new()).unwrap();
+    // [pin] Buggy: get_config succeeds (object stays object) but get_list fails (no conversion).
+    assert!(
+        cfg.get_config("v").is_ok(),
+        "[pin] get_config must succeed — object is not eagerly converted"
+    );
+    assert!(
+        cfg.get_list("v").is_err(),
+        "[pin] get_list on numeric-keyed object currently errors — update when fixed"
+    );
+}
+
+#[ignore = "spec violation: numeric-indexed object must be convertible to array lazily when array type is requested per HOCON L1204, see #79"]
+#[test]
+fn s15_2_conversion_is_lazy_spec() {
+    let cfg = hocon::parse_with_env(r#"v = {"0":"a","1":"b"}"#, &HashMap::new()).unwrap();
+    // Object access must still work (lazy: not converted until array type is requested).
+    assert!(
+        cfg.get_config("v").is_ok(),
+        "get_config must still succeed before conversion is triggered"
+    );
+    // Array access must trigger conversion.
+    assert!(
+        cfg.get_list("v").is_ok(),
+        "get_list must trigger lazy conversion of numeric-keyed object to array"
+    );
+}
+
+// --- S15.3: conversion in concatenation when list expected (spec L1210) -----------
+//
+// [pin] No conversion occurs in concatenation context.
+#[test]
+fn s15_3_conversion_in_concatenation_pin() {
+    // obj = {"0":"x","1":"y"}, arr = [a] ++ obj should convert obj to array and append.
+    let cfg = hocon::parse_with_env(
+        r#"obj = {"0":"x","1":"y"}
+arr = ${obj}"#,
+        &HashMap::new(),
+    )
+    .unwrap();
+    // [pin] Buggy: get_list on the substitution-resolved value fails (no conversion).
+    assert!(
+        cfg.get_list("arr").is_err(),
+        "[pin] get_list on substitution of numeric-keyed object currently errors — update when fixed"
+    );
+}
+
+#[ignore = "spec violation: numeric-indexed object must convert to array in concatenation when list expected per HOCON L1210, see #79"]
+#[test]
+fn s15_3_conversion_in_concatenation_spec() {
+    let cfg = hocon::parse_with_env(
+        r#"obj = {"0":"x","1":"y"}
+arr = ${obj}"#,
+        &HashMap::new(),
+    )
+    .unwrap();
+    assert!(
+        cfg.get_list("arr").is_ok(),
+        "numeric-indexed object must convert to array when array context expected per HOCON L1210"
+    );
+}
+
+// --- S15.4: empty object NOT converted (spec L1212) --------------------------------
+//
+// The spec says: "the conversion should not occur if the object is empty or has no
+// keys which parse as positive integers." Verified: get_list on {} currently errors —
+// which is the correct result (no conversion is done). Since the feature is absent,
+// this case happens to match spec intent. Marked ✅ with a note.
+#[test]
+fn s15_4_empty_object_not_converted() {
+    let cfg = hocon::parse_with_env(r#"v = {}"#, &HashMap::new()).unwrap();
+    // Empty object must NOT be converted to an array (per HOCON L1212).
+    // get_list should return an error (it is not an array, and must not become one).
+    assert!(
+        cfg.get_list("v").is_err(),
+        "empty object must not be converted to array per HOCON L1212"
+    );
+}
+
+// --- S15.5: non-integer keys ignored during conversion (spec L1214) ----------------
+//
+// [pin] Conversion is not implemented at all. Test pins the "no conversion" behavior.
+#[test]
+fn s15_5_non_integer_keys_ignored_pin() {
+    let cfg =
+        hocon::parse_with_env(r#"v = {"0":"a","foo":"b","1":"c"}"#, &HashMap::new()).unwrap();
+    // [pin] Buggy: no conversion; get_list errors. "foo" key is not dropped on array access.
+    assert!(
+        cfg.get_list("v").is_err(),
+        "[pin] get_list on mixed-key object currently errors — update when fixed"
+    );
+}
+
+#[ignore = "spec violation: non-integer keys must be ignored when converting numeric-indexed object to array per HOCON L1214, see #79"]
+#[test]
+fn s15_5_non_integer_keys_ignored_spec() {
+    let cfg =
+        hocon::parse_with_env(r#"v = {"0":"a","foo":"b","1":"c"}"#, &HashMap::new()).unwrap();
+    // "foo" key is ignored; result must be ["a","c"].
+    let items = cfg
+        .get_list("v")
+        .expect("mixed-key object must convert, ignoring non-integer keys per HOCON L1214");
+    assert_eq!(items.len(), 2, "only integer-keyed entries remain: [\"a\",\"c\"]");
+}
+
+// --- S15.6: missing indices compacted in resulting array (spec L1216) --------------
+//
+// [pin] Conversion not implemented; test pins "no conversion" behavior.
+#[test]
+fn s15_6_missing_indices_compacted_pin() {
+    // Keys "0" and "2" — index "1" is absent. Result must be ["a","c"] (2 elements, 0→a, 1→c).
+    let cfg = hocon::parse_with_env(r#"v = {"0":"a","2":"c"}"#, &HashMap::new()).unwrap();
+    // [pin] Buggy: get_list errors because conversion is not implemented.
+    assert!(
+        cfg.get_list("v").is_err(),
+        "[pin] get_list on sparse numeric-keyed object currently errors — update when fixed"
+    );
+}
+
+#[ignore = "spec violation: missing integer indices must be compacted when converting object to array per HOCON L1216, see #79"]
+#[test]
+fn s15_6_missing_indices_compacted_spec() {
+    let cfg = hocon::parse_with_env(r#"v = {"0":"a","2":"c"}"#, &HashMap::new()).unwrap();
+    let items = cfg
+        .get_list("v")
+        .expect("sparse numeric-keyed object must convert to compacted array per HOCON L1216");
+    assert_eq!(
+        items.len(),
+        2,
+        "gaps eliminated: keys 0+2 → array of 2 elements"
+    );
+}
+
+// --- S15.7: sorted by integer key value (spec L1216) --------------------------------
+//
+// [pin] Conversion not implemented; test pins "no conversion" behavior.
+#[test]
+fn s15_7_sorted_by_key_value_pin() {
+    // Keys given out of order: "2" before "0". Sorted array must be ["a","c"].
+    let cfg = hocon::parse_with_env(r#"v = {"2":"c","0":"a"}"#, &HashMap::new()).unwrap();
+    // [pin] Buggy: get_list errors because conversion is not implemented.
+    assert!(
+        cfg.get_list("v").is_err(),
+        "[pin] get_list on unordered numeric-keyed object currently errors — update when fixed"
+    );
+}
+
+#[ignore = "spec violation: conversion must sort by integer key value per HOCON L1216, see #79"]
+#[test]
+fn s15_7_sorted_by_key_value_spec() {
+    let cfg = hocon::parse_with_env(r#"v = {"2":"c","0":"a"}"#, &HashMap::new()).unwrap();
+    let items = cfg
+        .get_list("v")
+        .expect("out-of-order numeric-keyed object must convert sorted by integer key per HOCON L1216");
+    assert_eq!(items.len(), 2, "must produce 2-element array");
+    // After sort by integer key: 0→"a", 2→"c" → [\"a\",\"c\"]
+    match &items[0] {
+        hocon::HoconValue::Scalar(sv) => assert_eq!(sv.raw, "a", "first element must be key-0's value"),
+        other => panic!("expected Scalar, got {:?}", other),
+    }
+    match &items[1] {
+        hocon::HoconValue::Scalar(sv) => assert_eq!(sv.raw, "c", "second element must be key-2's value"),
+        other => panic!("expected Scalar, got {:?}", other),
+    }
+}
+
+// --- S17.5: "null" string → null when null requested (spec L1244) ------------------
+//
+// The spec says: "the string 'null' should be converted to a null value if the
+// application specifically asks for a null value." rs.hocon has no get_null() API,
+// so this conversion path is not testable at the typed-getter level.
+// The underlying storage correctly distinguishes String "null" from Null scalar.
+// Marked ➖ (out-of-scope for this API surface).
+#[test]
+fn s17_5_null_string_stored_as_string_not_null() {
+    // Verify the internal representation: "null" (quoted) is stored as String, not Null.
+    let cfg = hocon::parse_with_env(r#"v = "null""#, &HashMap::new()).unwrap();
+    match cfg.get("v") {
+        Some(hocon::HoconValue::Scalar(sv)) => {
+            assert_eq!(sv.raw, "null");
+            assert_eq!(
+                sv.value_type,
+                hocon::ScalarType::String,
+                "quoted \"null\" must be stored as String scalar, not Null"
+            );
+        }
+        other => panic!("expected Scalar, got {:?}", other),
+    }
+}
+
+// --- S17.6: null → other type: error (spec L1252) ----------------------------------
+//
+// Partial conformance: get_i64 and get_bool on null correctly error.
+// get_string on null incorrectly returns Ok("null") — bug, see #80.
+#[test]
+fn s17_6_null_to_numeric_and_bool_errors() {
+    let cfg = hocon::parse_with_env(r#"v = null"#, &HashMap::new()).unwrap();
+    assert!(
+        cfg.get_i64("v").is_err(),
+        "null → i64 must error per HOCON L1252"
+    );
+    assert!(
+        cfg.get_bool("v").is_err(),
+        "null → bool must error per HOCON L1252"
+    );
+}
+
+#[test]
+fn s17_6_null_to_string_pin() {
+    let cfg = hocon::parse_with_env(r#"v = null"#, &HashMap::new()).unwrap();
+    // [pin] Buggy: get_string on a null value returns Ok("null") instead of Err.
+    // The spec (L1252) requires null → any type to be an error.
+    assert!(
+        cfg.get_string("v").is_ok(),
+        "[pin] get_string on null currently returns Ok(\"null\") — update when fixed"
+    );
+}
+
+#[ignore = "spec violation: null → string must error per HOCON L1252, but get_string returns Ok(\"null\"), see #80"]
+#[test]
+fn s17_6_null_to_string_spec() {
+    let cfg = hocon::parse_with_env(r#"v = null"#, &HashMap::new()).unwrap();
+    assert!(
+        cfg.get_string("v").is_err(),
+        "null → string must return an error per HOCON L1252"
+    );
+}
+
+// --- S17.8: array → other type (except numeric-indexed): error (spec L1255) --------
+#[test]
+fn s17_8_array_to_other_type_errors() {
+    let cfg = hocon::parse_with_env(r#"v = [1,2,3]"#, &HashMap::new()).unwrap();
+    assert!(
+        cfg.get_string("v").is_err(),
+        "array → string must error per HOCON L1255"
+    );
+    assert!(
+        cfg.get_i64("v").is_err(),
+        "array → i64 must error per HOCON L1255"
+    );
+    assert!(
+        cfg.get_bool("v").is_err(),
+        "array → bool must error per HOCON L1255"
+    );
+    // get_list on a plain array must still succeed (not an error, it IS an array).
+    assert!(
+        cfg.get_list("v").is_ok(),
+        "get_list on an array must succeed"
+    );
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1356,8 +1356,7 @@ fn s15_4_empty_object_not_converted() {
 // [pin] Conversion is not implemented at all. Test pins the "no conversion" behavior.
 #[test]
 fn s15_5_non_integer_keys_ignored_pin() {
-    let cfg =
-        hocon::parse_with_env(r#"v = {"0":"a","foo":"b","1":"c"}"#, &HashMap::new()).unwrap();
+    let cfg = hocon::parse_with_env(r#"v = {"0":"a","foo":"b","1":"c"}"#, &HashMap::new()).unwrap();
     // [pin] Buggy: no conversion; get_list errors. "foo" key is not dropped on array access.
     assert!(
         cfg.get_list("v").is_err(),
@@ -1368,13 +1367,16 @@ fn s15_5_non_integer_keys_ignored_pin() {
 #[ignore = "spec violation: non-integer keys must be ignored when converting numeric-indexed object to array per HOCON L1214, see #79"]
 #[test]
 fn s15_5_non_integer_keys_ignored_spec() {
-    let cfg =
-        hocon::parse_with_env(r#"v = {"0":"a","foo":"b","1":"c"}"#, &HashMap::new()).unwrap();
+    let cfg = hocon::parse_with_env(r#"v = {"0":"a","foo":"b","1":"c"}"#, &HashMap::new()).unwrap();
     // "foo" key is ignored; result must be ["a","c"].
     let items = cfg
         .get_list("v")
         .expect("mixed-key object must convert, ignoring non-integer keys per HOCON L1214");
-    assert_eq!(items.len(), 2, "only integer-keyed entries remain: [\"a\",\"c\"]");
+    assert_eq!(
+        items.len(),
+        2,
+        "only integer-keyed entries remain: [\"a\",\"c\"]"
+    );
 }
 
 // --- S15.6: missing indices compacted in resulting array (spec L1216) --------------
@@ -1423,17 +1425,21 @@ fn s15_7_sorted_by_key_value_pin() {
 #[test]
 fn s15_7_sorted_by_key_value_spec() {
     let cfg = hocon::parse_with_env(r#"v = {"2":"c","0":"a"}"#, &HashMap::new()).unwrap();
-    let items = cfg
-        .get_list("v")
-        .expect("out-of-order numeric-keyed object must convert sorted by integer key per HOCON L1216");
+    let items = cfg.get_list("v").expect(
+        "out-of-order numeric-keyed object must convert sorted by integer key per HOCON L1216",
+    );
     assert_eq!(items.len(), 2, "must produce 2-element array");
     // After sort by integer key: 0→"a", 2→"c" → [\"a\",\"c\"]
     match &items[0] {
-        hocon::HoconValue::Scalar(sv) => assert_eq!(sv.raw, "a", "first element must be key-0's value"),
+        hocon::HoconValue::Scalar(sv) => {
+            assert_eq!(sv.raw, "a", "first element must be key-0's value")
+        }
         other => panic!("expected Scalar, got {:?}", other),
     }
     match &items[1] {
-        hocon::HoconValue::Scalar(sv) => assert_eq!(sv.raw, "c", "second element must be key-2's value"),
+        hocon::HoconValue::Scalar(sv) => {
+            assert_eq!(sv.raw, "c", "second element must be key-2's value")
+        }
         other => panic!("expected Scalar, got {:?}", other),
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1242,10 +1242,15 @@ fn s14b_1_array_root_include_is_error() {
 #[test]
 fn s15_1_num_indexed_obj_to_array_pin() {
     let cfg = hocon::parse_with_env(r#"v = {"0":"a","1":"b"}"#, &HashMap::new()).unwrap();
-    // [pin] Buggy: get_list errors instead of converting numeric-keyed object to array.
+    // [pin] Buggy: get_list errors with "expected Array" because no conversion path
+    // exists. Asserting the *specific* error message — not just `is_err()` — so a
+    // future fix that errors for an unrelated reason (e.g. validator change) breaks
+    // this pin instead of silently passing.
+    let err = cfg.get_list("v").unwrap_err();
     assert!(
-        cfg.get_list("v").is_err(),
-        "[pin] get_list on numeric-keyed object currently errors — update when fixed"
+        err.message.contains("expected Array"),
+        "[pin] get_list must currently error with \"expected Array\", got {:?}",
+        err
     );
 }
 
@@ -1273,14 +1278,18 @@ fn s15_1_num_indexed_obj_to_array_spec() {
 #[test]
 fn s15_2_conversion_is_lazy_pin() {
     let cfg = hocon::parse_with_env(r#"v = {"0":"a","1":"b"}"#, &HashMap::new()).unwrap();
-    // [pin] Buggy: get_config succeeds (object stays object) but get_list fails (no conversion).
+    // [pin] Buggy: get_config succeeds (object stays object) but get_list fails with
+    // "expected Array" (no conversion path). Tight assertion on the specific error
+    // message so an unrelated regression flips this pin.
     assert!(
         cfg.get_config("v").is_ok(),
         "[pin] get_config must succeed — object is not eagerly converted"
     );
+    let err = cfg.get_list("v").unwrap_err();
     assert!(
-        cfg.get_list("v").is_err(),
-        "[pin] get_list on numeric-keyed object currently errors — update when fixed"
+        err.message.contains("expected Array"),
+        "[pin] get_list must currently error with \"expected Array\", got {:?}",
+        err
     );
 }
 
@@ -1381,10 +1390,13 @@ fn s15_4_empty_object_not_converted() {
 #[test]
 fn s15_5_non_integer_keys_ignored_pin() {
     let cfg = hocon::parse_with_env(r#"v = {"0":"a","foo":"b","1":"c"}"#, &HashMap::new()).unwrap();
-    // [pin] Buggy: no conversion; get_list errors. "foo" key is not dropped on array access.
+    // [pin] Buggy: no conversion; get_list errors with "expected Array". "foo" key
+    // is not dropped on array access. Tight assertion on the specific error message.
+    let err = cfg.get_list("v").unwrap_err();
     assert!(
-        cfg.get_list("v").is_err(),
-        "[pin] get_list on mixed-key object currently errors — update when fixed"
+        err.message.contains("expected Array"),
+        "[pin] get_list must currently error with \"expected Array\", got {:?}",
+        err
     );
 }
 
@@ -1410,10 +1422,12 @@ fn s15_5_non_integer_keys_ignored_spec() {
 fn s15_6_missing_indices_compacted_pin() {
     // Keys "0" and "2" — index "1" is absent. Result must be ["a","c"] (2 elements, 0→a, 1→c).
     let cfg = hocon::parse_with_env(r#"v = {"0":"a","2":"c"}"#, &HashMap::new()).unwrap();
-    // [pin] Buggy: get_list errors because conversion is not implemented.
+    // [pin] Buggy: get_list errors with "expected Array" — no conversion path.
+    let err = cfg.get_list("v").unwrap_err();
     assert!(
-        cfg.get_list("v").is_err(),
-        "[pin] get_list on sparse numeric-keyed object currently errors — update when fixed"
+        err.message.contains("expected Array"),
+        "[pin] get_list must currently error with \"expected Array\", got {:?}",
+        err
     );
 }
 
@@ -1438,10 +1452,12 @@ fn s15_6_missing_indices_compacted_spec() {
 fn s15_7_sorted_by_key_value_pin() {
     // Keys given out of order: "2" before "0". Sorted array must be ["a","c"].
     let cfg = hocon::parse_with_env(r#"v = {"2":"c","0":"a"}"#, &HashMap::new()).unwrap();
-    // [pin] Buggy: get_list errors because conversion is not implemented.
+    // [pin] Buggy: get_list errors with "expected Array" — no conversion path.
+    let err = cfg.get_list("v").unwrap_err();
     assert!(
-        cfg.get_list("v").is_err(),
-        "[pin] get_list on unordered numeric-keyed object currently errors — update when fixed"
+        err.message.contains("expected Array"),
+        "[pin] get_list must currently error with \"expected Array\", got {:?}",
+        err
     );
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1062,7 +1062,13 @@ fn s13_9_null_blocks_env_var_lookup_spec() {
 // --- S13.13: optional undefined in string concat → empty string (spec L636) -----
 #[test]
 fn s13_13_optional_undefined_in_string_concat_is_empty() {
-    let cfg = parse(r#"x = "pre"${?missing}"post""#).expect("parse failed");
+    // Use an explicitly empty env so an ambient `missing` env var cannot leak in
+    // and resolve the ${?missing} substitution to a real value.
+    let cfg = hocon::parse_with_env(
+        r#"x = "pre"${?missing}"post""#,
+        &std::collections::HashMap::new(),
+    )
+    .expect("parse failed");
     assert_eq!(
         cfg.get_string("x").unwrap(),
         "prepost",
@@ -1075,7 +1081,8 @@ fn s13_13_optional_undefined_in_string_concat_is_empty() {
 // BUG: rs.hocon currently produces [1, " ", " ", 2] (whitespace strings).
 #[test]
 fn s13_14_optional_undefined_in_array_concat_pin() {
-    let cfg = parse("x = [1] ${?missing} [2]").expect("parse failed");
+    let cfg = hocon::parse_with_env("x = [1] ${?missing} [2]", &std::collections::HashMap::new())
+        .expect("parse failed");
     let items = cfg.get_list("x").unwrap();
     // [pin] snapshot current (broken) shape: numeric 1, two whitespace scalar
     // artefacts, numeric 2. Asserting values (not just length) catches partial
@@ -1100,7 +1107,8 @@ fn s13_14_optional_undefined_in_array_concat_pin() {
 #[test]
 #[ignore = "spec violation: optional undefined in array concat must yield empty array per HOCON L637, see #75"]
 fn s13_14_optional_undefined_in_array_concat_spec() {
-    let cfg = parse("x = [1] ${?missing} [2]").expect("parse failed");
+    let cfg = hocon::parse_with_env("x = [1] ${?missing} [2]", &std::collections::HashMap::new())
+        .expect("parse failed");
     let items = cfg.get_list("x").unwrap();
     assert_eq!(
         items.len(),
@@ -1129,7 +1137,11 @@ fn s13_14_optional_undefined_in_array_concat_spec() {
 // Object: {a:1} ${?missing} {b:2} → {a:1, b:2}  (currently passes)
 #[test]
 fn s13_14_optional_undefined_in_object_concat() {
-    let cfg = parse("x = {a:1} ${?missing} {b:2}").expect("parse failed");
+    let cfg = hocon::parse_with_env(
+        "x = {a:1} ${?missing} {b:2}",
+        &std::collections::HashMap::new(),
+    )
+    .expect("parse failed");
     let sub = cfg.get_config("x").expect("x must be an object");
     assert_eq!(sub.get_i64("a").unwrap(), 1);
     assert_eq!(sub.get_i64("b").unwrap(), 2);
@@ -1155,7 +1167,10 @@ fn s13_16_substitution_in_key_is_rejected() {
 #[test]
 fn s13a_13_optional_self_ref_concat_with_no_prior_pin() {
     // [pin] Current (broken) behaviour: ${?a} sees "foo" instead of undefined.
-    let cfg = parse("a = ${?a}foo").expect("parse failed");
+    // Use empty env so an ambient `a` env var cannot leak in (single-letter env
+    // names like `a` are common on POSIX shells — a real-world flake risk).
+    let cfg = hocon::parse_with_env("a = ${?a}foo", &std::collections::HashMap::new())
+        .expect("parse failed");
     assert_eq!(
         cfg.get_string("a").unwrap(),
         "foofoo",
@@ -1166,7 +1181,8 @@ fn s13a_13_optional_self_ref_concat_with_no_prior_pin() {
 #[test]
 #[ignore = "spec violation: a = ${?a}foo must resolve to \"foo\" when a has no prior value, see #76"]
 fn s13a_13_optional_self_ref_concat_with_no_prior_spec() {
-    let cfg = parse("a = ${?a}foo").expect("parse failed");
+    let cfg = hocon::parse_with_env("a = ${?a}foo", &std::collections::HashMap::new())
+        .expect("parse failed");
     assert_eq!(
         cfg.get_string("a").unwrap(),
         "foo",


### PR DESCRIPTION
## Summary

Phase 4 of HOCON spec test debt: probes, classifies, and pins 10 previously-unknown (🤷) items across S15 and S17.

| Item | Status | Finding |
|------|--------|---------|
| S15.1 | ❌ | `get_list()` on `{"0":"a","1":"b"}` errors — no conversion implemented |
| S15.2 | ❌ | No lazy conversion path exists |
| S15.3 | ❌ | No conversion in concatenation context |
| S15.4 | ✅ | Empty object correctly not converted (errors on `get_list`) |
| S15.5 | ❌ | Cannot test non-integer-key filtering without conversion working |
| S15.6 | ❌ | Cannot test compaction without conversion working |
| S15.7 | ❌ | Cannot test sort-by-integer-key without conversion working |
| S17.5 | ➖ | No `get_null()` API — out-of-scope; sanity test confirms `"null"` stored as `ScalarType::String` |
| S17.6 | ⚠️ | `get_i64`/`get_bool` on null correctly error; `get_string` on null returns `Ok("null")` — bug (#80) |
| S17.8 | ✅ | `get_string`/`get_i64`/`get_bool` on array all error correctly |

## Issues filed

- **#79** — S15.1-S15.3, S15.5-S15.7: numeric-indexed object to array conversion not implemented
- **#80** — S17.6: `get_string` on null must error but returns `Ok("null")`

## Test plan

- [x] All new `_pin` tests pass (assert buggy behavior — will break when fixed)
- [x] All new `_spec` tests are `#[ignore]`-annotated (assert correct behavior — fail when run with `--ignored`, as expected)
- [x] `cargo test --all`: 0 failures across all test crates
- [x] `cargo test -- --ignored` (integration_test): all 18 ignored tests fail as expected
- [x] `docs/spec-compliance.md` updated with test refs, status glyphs, and explanations
- [x] `README.md` and `README.ja.md` in-scope rate updated: 76.2% → 76.6%

🤖 Generated with [Claude Code](https://claude.com/claude-code)