### PR TITLE
test: Phase 5 — clear per-impl 🤷 (17 items)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -220,12 +220,12 @@ defaults { size = 20 }  # マージ: color は保持、size は更新
 
 ## 仕様準拠
 
-[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しています。以下の表は 2026-05-12 時点のスナップショットです — 最新値は [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
+[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しています。以下の表は 2026-05-13 時点のスナップショットです — 最新値は [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
 
 | 指標                                  | 状況         |
 | ------------------------------------- | ------------ |
-| 仕様全体（out-of-scope を含む）       | **70.1%**    |
-| In-scope のみ                         | **77.9%**    |
+| 仕様全体（out-of-scope を含む）       | **75.6%**    |
+| In-scope のみ                         | **84.0%**    |
 | Lightbend `equiv01`–`equiv05` テスト  | 5/5 合格     |
 
 ## Minimum Supported Rust Version

--- a/README.md
+++ b/README.md
@@ -280,12 +280,12 @@ For typical application configs (loaded once at startup), the parsing cost is ne
 
 ## Spec Compliance
 
-Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md). The table below is a snapshot as of 2026-05-12; see [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for live cross-impl values.
+Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md). The table below is a snapshot as of 2026-05-13; see [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for live cross-impl values.
 
 | Metric                                | Status        |
 | ------------------------------------- | ------------- |
-| Spec total (incl. out-of-scope)       | **70.1%**     |
-| In-scope only                         | **77.9%**     |
+| Spec total (incl. out-of-scope)       | **75.6%**     |
+| In-scope only                         | **84.0%**     |
 | Lightbend `equiv01`–`equiv05` suite   | 5/5 passing   |
 
 ## Minimum Supported Rust Version

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -194,8 +194,9 @@ same item descriptions verbatim.
   tests: src/resolver/mod.rs:221 (resolves_string_concat_with_substitution); tests/integration_test.rs:34 (parse_with_substitutions); tests/testdata/hocon/equiv01/unquoted.conf (fixture)
   status: ✅
 - **S10.2** All arrays → array concatenation — §Value concatenation (L312)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s10_2_pin_array_concat_produces_space_element; s10_2_spec_array_concat [#ignore])
+  status: ❌
+  notes: `[1,2] [3,4]` produces a 5-element list with a whitespace String scalar between the two sub-arrays instead of a 4-element concatenated array. Same root cause as S10.4/S10.19 — array/object concatenation not implemented. Tracked in #65.
 - **S10.3** All objects → object merge (concatenation) — §Value concatenation (L314)
   tests: tests/integration_test.rs:261 (test_object_concat_deep_merge); tests/integration_test.rs:158 (test_braced_root_object_concat)
   status: ✅
@@ -233,14 +234,16 @@ same item descriptions verbatim.
   tests: tests/integration_test.rs:786 (s10_14_whitespace_around_obj_subst_ignored); tests/integration_test.rs:798 (s10_14_whitespace_around_arr_subst_ignored)
   status: ✅
 - **S10.15** Quoted whitespace between obj/array substitutions is an error — §Concatenation with whitespace (L442)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s10_15_pin_quoted_ws_between_obj_substs_no_error; s10_15_spec_quoted_ws_between_obj_substs_is_error [#ignore]; s10_15_pin_quoted_ws_between_arr_substs_no_error; s10_15_spec_quoted_ws_between_arr_substs_is_error [#ignore])
+  status: ❌
+  notes: impl does not error; obj subst case stringifies objects into a string containing the debug representation; arr subst case inserts the quoted whitespace as extra array elements. Same concat bug as S10.2/S10.4.
 - **S10.16** Non-newline whitespace in arrays is concat, not separator — §Arrays without commas or newlines (L447)
   tests: tests/testdata/hocon/equiv01/no-commas.conf (fixture)
   status: ✅
 - **S10.17** Substitution resolving to an array participates in array concat (`${arr} [x]`) — §Array and object concatenation (L387)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s10_17_pin_subst_array_concat_space_element; s10_17_spec_subst_array_concat [#ignore])
+  status: ❌
+  notes: `${base} [3,4]` where `base=[1,2]` produces 5 elements with a whitespace scalar between the two arrays instead of 4. Same concat bug as S10.2/S10.4. Tracked in #65.
 - **S10.18** Substitution resolving to an object participates in object merge (`${obj} {x:1}`) — §Array and object concatenation (L388)
   tests: src/resolver/mod.rs:248 (delayed_merge_object_with_substitution)
   status: ✅
@@ -344,8 +347,9 @@ same item descriptions verbatim.
   tests: tests/integration_test.rs:1054 (s13_14_optional_undefined_in_array_concat_pin); tests/integration_test.rs:1066 (s13_14_optional_undefined_in_array_concat_spec); tests/integration_test.rs:1078 (s13_14_optional_undefined_in_object_concat)
   status: ⚠️ (see #75) — array case broken (whitespace artefacts leak as extra elements); object case ✅
 - **S13.15** `foo : ${?bar}${?baz}` skipped only when BOTH undefined — §Substitutions (L640)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s13_15_pin_both_optional_undefined_field_exists; s13_15_spec_both_optional_undefined_field_absent [#ignore]; s13_15_one_defined_field_is_created)
+  status: ❌
+  notes: when both `${?bar}` and `${?baz}` are undefined, `foo` is still created with a null value instead of being dropped. The single-defined sub-case (`bar=hello, foo=${?bar}${?baz}`) correctly produces `foo=hello`.
 - **S13.16** Substitutions only in field values / array elements — §Substitutions (L644)
   tests: tests/integration_test.rs:1087 (s13_16_substitution_in_key_is_rejected)
   status: ✅
@@ -386,11 +390,12 @@ same item descriptions verbatim.
   tests: src/resolver/mod.rs:232 (throws_on_circular_substitution)
   status: ✅
 - **S13a.9** Multi-step cycle `a→b→c→a` → error — §Self-Referential (L862)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s13a_9_multi_step_cycle_is_error)
+  status: ✅
 - **S13a.10** Substitution memoized by instance, not by path — §Self-Referential (L885)
-  tests: — (not externally observable from the black-box parse API; memoization affects evaluation order, not final values)
-  status: 🤷
+  tests: tests/spec_phase5.rs (s13a_10_memoization_same_value)
+  status: ✅
+  notes: the spec-observable outcome is that `a` and `b` must end up equal in the ambiguous `a=1,b=2,a=${b},b=${a}` case. Both end up as 2, satisfying the constraint. Internal memoization is not directly observable from the parse API.
 - **S13a.11** Object can refer to its own descendant (`bar : { foo : 42, baz : ${bar.foo} }`) — §Self-Referential (L806)
   tests: tests/lightbend_test.rs:303 (lightbend_test09_delayed_merge_object); tests/lightbend_test.rs:316 (lightbend_test10_nested_include)
   status: ✅
@@ -401,8 +406,8 @@ same item descriptions verbatim.
   tests: tests/integration_test.rs:1103 (s13a_13_optional_self_ref_concat_with_no_prior_pin); tests/integration_test.rs:1115 (s13a_13_optional_self_ref_concat_with_no_prior_spec)
   status: ❌ (see #76)
 - **S13a.14** Mutually-referring object fields (`bar.a = ${foo.d}; foo.c = ${bar.b}`) resolve lazily without false cycle — §Self-Referential (L825-834)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s13a_14_mutual_refs_no_false_cycle)
+  status: ✅
 
 ### S13b. `+=` field separator
 
@@ -459,8 +464,8 @@ same item descriptions verbatim.
   tests: tests/integration_test.rs:1126 (s14a_6_include_in_dotted_key_is_literal)
   status: ✅
 - **S14a.7** Whitespace allowed between `include` and resource name (incl. newlines) — §Include syntax (L952)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s14a_7_whitespace_before_include_arg; s14a_7_newline_before_include_arg)
+  status: ✅
 - **S14a.8** No value concatenation on include argument — §Include syntax (L957)
   tests: tests/integration_test.rs:1137 (s14a_8_no_concatenation_on_include_arg)
   status: ✅
@@ -468,11 +473,11 @@ same item descriptions verbatim.
   tests: tests/integration_test.rs:1146 (s14a_9_no_substitution_in_include_arg)
   status: ✅
 - **S14a.10** Include argument must be quoted string — §Include syntax (L958)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s14a_10_unquoted_include_arg_rejected)
+  status: ✅
 - **S14a.11** `"include"` (quoted) is just a normal key — §Include syntax (L977)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s14a_11_quoted_include_is_normal_key)
+  status: ✅
 
 ### S14b. Include semantics: merging
 
@@ -638,11 +643,12 @@ same item descriptions verbatim.
   tests: src/config.rs:783 (get_duration_no_space); src/config.rs:867 (get_bytes_no_space)
   status: ✅
 - **S18.3** Unit name letters-only (Unicode L* / `isLetter`) — §Units format (L1287)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s18_3_unit_with_digit_rejected; s18_3_unit_with_hyphen_rejected; s18_3_valid_letter_only_unit_accepted)
+  status: ✅
 - **S18.4** String with no unit → interpreted with default unit — §Units format (L1290)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s18_4_bytes_string_no_unit_uses_default; s18_4_pin_duration_string_no_unit_errors; s18_4_spec_duration_string_no_unit_uses_default [#ignore])
+  status: ⚠️
+  notes: bytes string with no unit correctly uses byte default (`"1024"` → 1024). Duration string with no unit errors instead of using millisecond default — `parse_duration` does not match empty unit string. Number scalars (non-string) work for both getters.
 
 ## S19. Duration format
 
@@ -668,8 +674,9 @@ same item descriptions verbatim.
   tests: src/config.rs:765 (get_duration_days); tests/integration_test.rs:211 (test_duration_missing_units)
   status: ✅
 - **S19.8** Duration unit names are case sensitive (lowercase only) — §Duration format (L1304)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s19_8_pin_uppercase_ms_accepted; s19_8_spec_uppercase_ms_rejected [#ignore]; s19_8_pin_mixed_case_seconds_accepted; s19_8_spec_mixed_case_seconds_rejected [#ignore]; s19_8_lowercase_units_accepted)
+  status: ❌
+  notes: `parse_duration` calls `.to_lowercase()` on the unit string before matching, so `"MS"`, `"Seconds"`, `"NS"` etc. are wrongly accepted. Spec (L1304) requires lowercase only. Lowercase units still work correctly.
 
 ## S20. Period format
 
@@ -714,11 +721,11 @@ same item descriptions verbatim.
   tests: src/config.rs:702 (with_fallback_receiver_wins); tests/integration_test.rs:135 (parse_with_fallback)
   status: ✅
 - **S22.2** Intermediate non-object hides earlier object across files — §Config object merging (L1406)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s22_2_non_object_hides_earlier_object_across_merge)
+  status: ✅
 - **S22.3** Setting key to null clears earlier object value — §Config object merging (L1436)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s22_3_null_clears_earlier_object_in_merge)
+  status: ✅
 
 ## S23. Java properties mapping
 
@@ -726,8 +733,9 @@ same item descriptions verbatim.
   tests: src/properties.rs:91 (handles_dotted_keys)
   status: ✅
 - **S23.2** Empty path elements (leading/trailing) preserved — §Java properties (L1456)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s23_2_trailing_dot_creates_empty_key_segment; s23_2_leading_dot_creates_empty_key_segment)
+  status: ✅
+  notes: `"a."` creates path `["a",""]` (nested object with empty-string key inside `a`). `".a"` creates path `["","a"]` (empty-string root key containing `a`). The empty-string root key `""` is accessible via path `".a"` through `split_config_path`.
 - **S23.3** Properties values are always strings — §Java properties (L1471)
   tests: src/properties.rs:109 (values_are_always_strings)
   status: ✅
@@ -767,8 +775,8 @@ same item descriptions verbatim.
   tests: src/resolver/mod.rs:190 (resolves_env_var_fallback); tests/integration_test.rs:46 (parse_with_env_fallback); tests/include_test.rs:85 (include_env_fallback_quoted_key_prefix)
   status: ✅
 - **S26.2** Empty env var preserved as empty string (not undefined) — §Substitution fallback (L1558)
-  tests: —
-  status: 🤷
+  tests: tests/spec_phase5.rs (s26_2_empty_env_var_preserved_as_empty_string)
+  status: ✅
 - **S26.3** Env var SecurityException → treated as not present — §Substitution fallback (L1560)
   out-of-scope: `SecurityException` is a JVM-specific exception type; non-JVM runtimes have no equivalent guard at this layer.
   tests: —

--- a/tests/spec_phase5.rs
+++ b/tests/spec_phase5.rs
@@ -621,7 +621,8 @@ fn s23_2_trailing_dot_creates_empty_key_segment() {
     let props = dir.join("trail.properties");
     std::fs::write(&props, "a. = trailing_dot\n").unwrap();
 
-    let hocon_input = format!("include \"{}\"\n", props.to_str().unwrap());
+    let props_str = props.to_str().unwrap().replace('\\', "/");
+    let hocon_input = format!("include \"{}\"\n", props_str);
     let r = hocon::parse_with_env(&hocon_input, &HashMap::new());
     // impl succeeds and creates a nested object under "a"
     assert!(
@@ -645,7 +646,8 @@ fn s23_2_leading_dot_creates_empty_key_segment() {
     let props = dir.join("lead.properties");
     std::fs::write(&props, ".a = leading_dot\n").unwrap();
 
-    let hocon_input = format!("include \"{}\"\n", props.to_str().unwrap());
+    let props_str = props.to_str().unwrap().replace('\\', "/");
+    let hocon_input = format!("include \"{}\"\n", props_str);
     let r = hocon::parse_with_env(&hocon_input, &HashMap::new());
     assert!(
         r.is_ok(),

--- a/tests/spec_phase5.rs
+++ b/tests/spec_phase5.rs
@@ -353,6 +353,7 @@ fn s14a_7_whitespace_before_include_arg() {
         42,
         "S14a.7: extra spaces allowed"
     );
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
@@ -371,6 +372,7 @@ fn s14a_7_newline_before_include_arg() {
         99,
         "S14a.7: newline between include and arg allowed"
     );
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -630,12 +632,20 @@ fn s23_2_trailing_dot_creates_empty_key_segment() {
         "S23.2: properties with trailing dot key must parse"
     );
     let cfg = r.unwrap();
-    // "a" is an object (not a scalar), the empty-string key lives inside it
-    // get_config("a") should succeed
+    // "a" is an object (not a scalar), the empty-string key lives inside it.
+    // get_config("a") should succeed AND the value must be retrievable via the
+    // trailing-dot accessor "a." (which split_config_path treats as path
+    // ["a", ""] — the empty trailing segment maps to the empty-string key).
     assert!(
         cfg.get_config("a").is_ok(),
         "S23.2: 'a' must be an object (trailing dot creates nested obj with empty key)"
     );
+    assert_eq!(
+        cfg.get_string("a.").unwrap(),
+        "trailing_dot",
+        "S23.2: 'a.' in properties must create path [\"a\", \"\"] accessible as 'a.'"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
@@ -662,6 +672,7 @@ fn s23_2_leading_dot_creates_empty_key_segment() {
         "leading_dot",
         "S23.2: '.a' in properties must create path [\"\", \"a\"] accessible as '.a'"
     );
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/spec_phase5.rs
+++ b/tests/spec_phase5.rs
@@ -1,0 +1,681 @@
+/// Phase 5 spec-compliance tests — per-impl 🤷 mop-up (17 items).
+///
+/// Items covered:
+///   S10.2, S10.15, S10.17
+///   S13.15, S13a.9, S13a.10, S13a.14
+///   S14a.7, S14a.10, S14a.11
+///   S18.3, S18.4
+///   S19.8
+///   S22.2, S22.3
+///   S23.2
+///   S26.2
+use std::collections::HashMap;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S10.2  All arrays → array concatenation  (spec L312)
+// Status: ❌  tracked in #65 (same root as S10.4 / S10.19 — concat not impl'd)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Pin: impl currently produces 5 elements with a whitespace string in the middle
+/// instead of a 4-element array.  The space between `[1,2]` and `[3,4]` leaks
+/// as an extra String scalar.
+#[test]
+fn s10_2_pin_array_concat_produces_space_element() {
+    let cfg = hocon::parse_with_env(r#"a = [1,2] [3,4]"#, &HashMap::new()).unwrap();
+    let list = cfg.get_list("a").unwrap();
+    // Currently produces 5 elements (1, 2, " ", 3, 4)
+    assert_eq!(
+        list.len(),
+        5,
+        "[pin] S10.2: expected impl to produce 5 (broken) elements, got {}",
+        list.len()
+    );
+    // The middle element is the whitespace string
+    if let hocon::HoconValue::Scalar(sv) = &list[2] {
+        assert_eq!(
+            sv.raw, " ",
+            "[pin] S10.2: middle element should be the space whitespace scalar"
+        );
+    } else {
+        panic!(
+            "[pin] S10.2: element [2] should be a scalar, got {:?}",
+            list[2]
+        );
+    }
+}
+
+#[test]
+#[ignore = "spec violation per S10.2 (L312): two adjacent arrays must concatenate into one 4-element array; impl inserts whitespace as extra element — tracked in #65"]
+fn s10_2_spec_array_concat() {
+    let cfg = hocon::parse_with_env(r#"a = [1,2] [3,4]"#, &HashMap::new()).unwrap();
+    let list = cfg.get_list("a").unwrap();
+    assert_eq!(
+        list.len(),
+        4,
+        "S10.2: [1,2] [3,4] must concat to a 4-element array"
+    );
+    // Elements should be 1, 2, 3, 4 in order
+    if let hocon::HoconValue::Scalar(sv) = &list[0] {
+        assert_eq!(sv.raw, "1");
+    }
+    if let hocon::HoconValue::Scalar(sv) = &list[3] {
+        assert_eq!(sv.raw, "4");
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S10.15  Quoted whitespace between obj/array substitutions is an error (L442)
+// Status: ❌
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Pin: impl does not error; for the object case it stringifies the objects and
+/// concatenates them with the quoted whitespace into a string value.
+#[test]
+fn s10_15_pin_quoted_ws_between_obj_substs_no_error() {
+    let r = hocon::parse_with_env(
+        r#"
+        a = {x:1}
+        b = {y:2}
+        c = ${a} " " ${b}
+    "#,
+        &HashMap::new(),
+    );
+    // impl succeeds (does not error)
+    assert!(
+        r.is_ok(),
+        "[pin] S10.15: impl currently succeeds (should error per spec L442)"
+    );
+    let cfg = r.unwrap();
+    // c becomes a string containing the debug repr of the objects
+    let c = cfg.get_string("c").unwrap();
+    assert!(
+        c.contains("Object"),
+        "[pin] S10.15: c should be a string with 'Object' in it (impl stringifies obj), got {:?}",
+        c
+    );
+}
+
+#[test]
+#[ignore = "spec violation per S10.15 (L442): quoted whitespace between object/array substitutions must be an error; impl currently stringifies instead"]
+fn s10_15_spec_quoted_ws_between_obj_substs_is_error() {
+    let r = hocon::parse_with_env(
+        r#"
+        a = {x:1}
+        b = {y:2}
+        c = ${a} " " ${b}
+    "#,
+        &HashMap::new(),
+    );
+    assert!(
+        r.is_err(),
+        "S10.15: quoted whitespace between object substitutions must produce an error (spec L442)"
+    );
+}
+
+/// Pin: for array case, impl does not error; inserts whitespace as extra elements.
+#[test]
+fn s10_15_pin_quoted_ws_between_arr_substs_no_error() {
+    let r = hocon::parse_with_env(
+        r#"
+        a = [1]
+        b = [2]
+        c = ${a} " " ${b}
+    "#,
+        &HashMap::new(),
+    );
+    assert!(
+        r.is_ok(),
+        "[pin] S10.15: impl currently succeeds for array case (should error per spec L442)"
+    );
+    let cfg = r.unwrap();
+    let list = cfg.get_list("c").unwrap();
+    // impl inserts the quoted " " as a separate string element along with unquoted spaces
+    assert!(
+        list.len() > 2,
+        "[pin] S10.15: c list should have more than 2 elements due to whitespace leak, got {}",
+        list.len()
+    );
+}
+
+#[test]
+#[ignore = "spec violation per S10.15 (L442): quoted whitespace between array substitutions must be an error; impl inserts whitespace as extra elements instead"]
+fn s10_15_spec_quoted_ws_between_arr_substs_is_error() {
+    let r = hocon::parse_with_env(
+        r#"
+        a = [1]
+        b = [2]
+        c = ${a} " " ${b}
+    "#,
+        &HashMap::new(),
+    );
+    assert!(
+        r.is_err(),
+        "S10.15: quoted whitespace between array substitutions must produce an error (spec L442)"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S10.17  Substitution resolving to array participates in array concat (L387)
+// Status: ❌  (same root as S10.2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Pin: `${base} [3,4]` where base resolves to `[1,2]` produces 5 elements
+/// (with whitespace string) instead of 4.
+#[test]
+fn s10_17_pin_subst_array_concat_space_element() {
+    let cfg = hocon::parse_with_env(
+        r#"
+        base = [1,2]
+        combined = ${base} [3,4]
+    "#,
+        &HashMap::new(),
+    )
+    .unwrap();
+    let list = cfg.get_list("combined").unwrap();
+    assert_eq!(
+        list.len(),
+        5,
+        "[pin] S10.17: expected 5 (broken) elements, got {}",
+        list.len()
+    );
+    // Space whitespace is the 3rd element (index 2)
+    if let hocon::HoconValue::Scalar(sv) = &list[2] {
+        assert_eq!(
+            sv.raw, " ",
+            "[pin] S10.17: element[2] should be the whitespace scalar"
+        );
+    } else {
+        panic!("[pin] S10.17: element[2] should be a scalar");
+    }
+}
+
+#[test]
+#[ignore = "spec violation per S10.17 (L387): ${arr} [x] where arr resolves to array must concat into one array; impl inserts whitespace as extra element — tracked in #65"]
+fn s10_17_spec_subst_array_concat() {
+    let cfg = hocon::parse_with_env(
+        r#"
+        base = [1,2]
+        combined = ${base} [3,4]
+    "#,
+        &HashMap::new(),
+    )
+    .unwrap();
+    let list = cfg.get_list("combined").unwrap();
+    assert_eq!(
+        list.len(),
+        4,
+        "S10.17: ${{base}} [3,4] must produce a 4-element array"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S13.15  foo:${?bar}${?baz} skipped only when BOTH undefined (L640)
+// Status: ❌
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Pin: when both bar and baz are undefined, foo is still created (null value).
+#[test]
+fn s13_15_pin_both_optional_undefined_field_exists() {
+    let cfg = hocon::parse_with_env(r#"foo = ${?bar}${?baz}"#, &HashMap::new()).unwrap();
+    // impl creates the field with a null value instead of dropping it
+    let opt = cfg.get_string_option("foo");
+    assert!(
+        opt.is_some(),
+        "[pin] S13.15: impl currently creates 'foo' even when both substs are undefined"
+    );
+    // The value is null (returned as "null" by get_string)
+    assert_eq!(
+        cfg.get_string("foo").unwrap(),
+        "null",
+        "[pin] S13.15: foo should be the null sentinel when both optional substs are undefined"
+    );
+}
+
+#[test]
+#[ignore = "spec violation per S13.15 (L640): foo:${?bar}${?baz} must not create field 'foo' when both bar and baz are undefined; impl creates null-valued field instead"]
+fn s13_15_spec_both_optional_undefined_field_absent() {
+    let cfg = hocon::parse_with_env(r#"foo = ${?bar}${?baz}"#, &HashMap::new()).unwrap();
+    assert!(
+        cfg.get_string_option("foo").is_none(),
+        "S13.15: 'foo' must not exist when both ${{?bar}} and ${{?baz}} are undefined (spec L640)"
+    );
+}
+
+/// Positive: when only one is undefined, field IS created (with the defined one's value).
+#[test]
+fn s13_15_one_defined_field_is_created() {
+    let cfg = hocon::parse_with_env(
+        r#"bar = hello
+foo = ${?bar}${?baz}"#,
+        &HashMap::new(),
+    )
+    .unwrap();
+    assert_eq!(
+        cfg.get_string("foo").unwrap(),
+        "hello",
+        "S13.15: when bar is defined, foo must be created with bar's value"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S13a.9  Multi-step cycle a→b→c→a → error  (L862)
+// Status: ✅
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn s13a_9_multi_step_cycle_is_error() {
+    let r = hocon::parse_with_env(
+        r#"
+        a = ${b}
+        b = ${c}
+        c = ${a}
+    "#,
+        &HashMap::new(),
+    );
+    assert!(
+        r.is_err(),
+        "S13a.9: three-step cycle a→b→c→a must produce an error (spec L862)"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S13a.10  Substitution memoized by instance, not by path  (L885)
+// Status: ✅  (observable outcome: a and b end up equal)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The spec (L883) says for the undefined-order case `a=1,b=2,a=${b},b=${a}`,
+/// both a and b must end up with the SAME value (memoization guarantee).
+/// The implementation resolves this correctly (both become 2).
+#[test]
+fn s13a_10_memoization_same_value() {
+    let cfg = hocon::parse_with_env(
+        r#"
+        a = 1
+        b = 2
+        a = ${b}
+        b = ${a}
+    "#,
+        &HashMap::new(),
+    )
+    .unwrap();
+    let a = cfg.get_i64("a").unwrap();
+    let b = cfg.get_i64("b").unwrap();
+    assert_eq!(
+        a, b,
+        "S13a.10: a and b must resolve to the same value (memoization); got a={}, b={}",
+        a, b
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S13a.14  Mutually-referring object fields resolve lazily without false cycle
+//          (L825-834)
+// Status: ✅
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn s13a_14_mutual_refs_no_false_cycle() {
+    // From spec example L830-835:
+    //   bar.a should be 4  (resolves ${foo.d} → 4 after foo.d override)
+    //   foo.c should be 3  (resolves ${bar.b} → 3 after bar.b override)
+    let cfg = hocon::parse_with_env(
+        r#"
+        bar : { a : ${foo.d}, b : 1 }
+        bar.b = 3
+        foo : { c : ${bar.b}, d : 2 }
+        foo.d = 4
+    "#,
+        &HashMap::new(),
+    )
+    .unwrap();
+    assert_eq!(cfg.get_i64("bar.a").unwrap(), 4, "S13a.14: bar.a must be 4");
+    assert_eq!(cfg.get_i64("foo.c").unwrap(), 3, "S13a.14: foo.c must be 3");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S14a.7  Whitespace (including newlines) between `include` and resource (L952)
+// Status: ✅
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn s14a_7_whitespace_before_include_arg() {
+    let dir = std::env::temp_dir().join("hocon_s14a7_ws");
+    std::fs::create_dir_all(&dir).unwrap();
+    let inc = dir.join("inc.conf");
+    std::fs::write(&inc, r#"x = 42"#).unwrap();
+    let inc_path = inc.to_str().unwrap().replace('\\', "/");
+
+    // Extra spaces between include keyword and quoted arg
+    let input = format!("include   \"{}\"\n", inc_path);
+    let cfg = hocon::parse_with_env(&input, &HashMap::new()).unwrap();
+    assert_eq!(
+        cfg.get_i64("x").unwrap(),
+        42,
+        "S14a.7: extra spaces allowed"
+    );
+}
+
+#[test]
+fn s14a_7_newline_before_include_arg() {
+    let dir = std::env::temp_dir().join("hocon_s14a7_nl");
+    std::fs::create_dir_all(&dir).unwrap();
+    let inc = dir.join("inc.conf");
+    std::fs::write(&inc, r#"x = 99"#).unwrap();
+    let inc_path = inc.to_str().unwrap().replace('\\', "/");
+
+    // Newline between include keyword and quoted arg (spec L952 says newlines allowed)
+    let input = format!("include\n\"{}\"\n", inc_path);
+    let cfg = hocon::parse_with_env(&input, &HashMap::new()).unwrap();
+    assert_eq!(
+        cfg.get_i64("x").unwrap(),
+        99,
+        "S14a.7: newline between include and arg allowed"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S14a.10  Include argument must be a quoted string  (L958)
+// Status: ✅
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn s14a_10_unquoted_include_arg_rejected() {
+    let r = hocon::parse_with_env(r#"include some_file.conf"#, &HashMap::new());
+    assert!(
+        r.is_err(),
+        "S14a.10: unquoted include argument must be rejected (spec L958)"
+    );
+    let err = r.unwrap_err().to_string();
+    assert!(
+        err.contains("expected include path") || err.contains("Unquoted"),
+        "S14a.10: error message should mention unquoted; got: {}",
+        err
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S14a.11  `"include"` (quoted) is just a normal key  (L977)
+// Status: ✅
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn s14a_11_quoted_include_is_normal_key() {
+    let cfg = hocon::parse_with_env(r#""include" = 42"#, &HashMap::new()).unwrap();
+    assert_eq!(
+        cfg.get_i64("include").unwrap(),
+        42,
+        "S14a.11: quoted 'include' must be treated as a normal key (spec L977)"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S18.3  Unit name letters-only (Unicode L* / isLetter)  (L1287)
+// Status: ✅  (impl rejects units containing digits or hyphens)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn s18_3_unit_with_digit_rejected() {
+    let cfg = hocon::parse_with_env(r#"t = "100 ms2""#, &HashMap::new()).unwrap();
+    assert!(
+        cfg.get_duration("t").is_err(),
+        "S18.3: unit 'ms2' (contains digit) must be rejected per spec L1287"
+    );
+}
+
+#[test]
+fn s18_3_unit_with_hyphen_rejected() {
+    let cfg = hocon::parse_with_env(r#"t = "100 milli-seconds""#, &HashMap::new()).unwrap();
+    assert!(
+        cfg.get_duration("t").is_err(),
+        "S18.3: unit 'milli-seconds' (contains hyphen) must be rejected per spec L1287"
+    );
+}
+
+#[test]
+fn s18_3_valid_letter_only_unit_accepted() {
+    let cfg = hocon::parse_with_env(r#"t = "100 ms""#, &HashMap::new()).unwrap();
+    assert!(
+        cfg.get_duration("t").is_ok(),
+        "S18.3: unit 'ms' (letters only) must be accepted"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S18.4  String with no unit → interpreted with default unit  (L1290)
+// Status: ⚠️  — bytes ✅, duration ❌
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Bytes: string "1024" with no unit → 1024 bytes (default unit = bytes). ✅
+#[test]
+fn s18_4_bytes_string_no_unit_uses_default() {
+    let cfg = hocon::parse_with_env(r#"s = "1024""#, &HashMap::new()).unwrap();
+    assert_eq!(
+        cfg.get_bytes("s").unwrap(),
+        1024,
+        "S18.4: bytes string with no unit must use default (bytes)"
+    );
+}
+
+/// Duration pin: string "500" with no unit currently errors (does not use default ms).
+#[test]
+fn s18_4_pin_duration_string_no_unit_errors() {
+    let cfg = hocon::parse_with_env(r#"t = "500""#, &HashMap::new()).unwrap();
+    assert!(
+        cfg.get_duration("t").is_err(),
+        "[pin] S18.4: impl currently errors on duration string without unit (should use default ms per spec L1290)"
+    );
+    let err = cfg.get_duration("t").unwrap_err().to_string();
+    assert!(
+        err.contains("invalid duration"),
+        "[pin] S18.4: error message should contain 'invalid duration'; got: {}",
+        err
+    );
+}
+
+#[test]
+#[ignore = "spec violation per S18.4 (L1290): duration string '500' with no unit must be interpreted as milliseconds (default unit); impl errors instead"]
+fn s18_4_spec_duration_string_no_unit_uses_default() {
+    let cfg = hocon::parse_with_env(r#"t = "500""#, &HashMap::new()).unwrap();
+    assert_eq!(
+        cfg.get_duration("t").unwrap(),
+        std::time::Duration::from_millis(500),
+        "S18.4: string '500' without unit must default to milliseconds"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S19.8  Duration unit names are case sensitive (lowercase only)  (L1304)
+// Status: ❌  — impl lowercases the unit before matching, so uppercase passes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Pin: impl currently accepts uppercase "MS" as milliseconds.
+#[test]
+fn s19_8_pin_uppercase_ms_accepted() {
+    let cfg = hocon::parse_with_env(r#"t = "100 MS""#, &HashMap::new()).unwrap();
+    // impl succeeds — pin that it does succeed (wrong behavior)
+    assert!(
+        cfg.get_duration("t").is_ok(),
+        "[pin] S19.8: impl currently accepts uppercase 'MS' (should reject per spec L1304)"
+    );
+}
+
+#[test]
+#[ignore = "spec violation per S19.8 (L1304): duration unit names are case sensitive and must be lowercase; impl lowercases unit before matching, so 'MS', 'Seconds', 'NS' etc. are wrongly accepted"]
+fn s19_8_spec_uppercase_ms_rejected() {
+    let cfg = hocon::parse_with_env(r#"t = "100 MS""#, &HashMap::new()).unwrap();
+    assert!(
+        cfg.get_duration("t").is_err(),
+        "S19.8: uppercase 'MS' must be rejected (only lowercase duration units allowed)"
+    );
+}
+
+#[test]
+fn s19_8_pin_mixed_case_seconds_accepted() {
+    let cfg = hocon::parse_with_env(r#"t = "100 Seconds""#, &HashMap::new()).unwrap();
+    assert!(
+        cfg.get_duration("t").is_ok(),
+        "[pin] S19.8: impl currently accepts 'Seconds' (should reject per spec L1304)"
+    );
+}
+
+#[test]
+#[ignore = "spec violation per S19.8 (L1304): 'Seconds' (mixed case) must be rejected; impl accepts it due to .to_lowercase() in parse_duration"]
+fn s19_8_spec_mixed_case_seconds_rejected() {
+    let cfg = hocon::parse_with_env(r#"t = "100 Seconds""#, &HashMap::new()).unwrap();
+    assert!(
+        cfg.get_duration("t").is_err(),
+        "S19.8: 'Seconds' must be rejected (spec requires lowercase only)"
+    );
+}
+
+/// Correct lowercase units still work.
+#[test]
+fn s19_8_lowercase_units_accepted() {
+    let cfg = hocon::parse_with_env(r#"t = "100 ms""#, &HashMap::new()).unwrap();
+    assert!(
+        cfg.get_duration("t").is_ok(),
+        "S19.8: lowercase 'ms' must be accepted"
+    );
+    let cfg2 = hocon::parse_with_env(r#"t = "100 ns""#, &HashMap::new()).unwrap();
+    assert!(
+        cfg2.get_duration("t").is_ok(),
+        "S19.8: lowercase 'ns' must be accepted"
+    );
+    let cfg3 = hocon::parse_with_env(r#"t = "30 seconds""#, &HashMap::new()).unwrap();
+    assert!(
+        cfg3.get_duration("t").is_ok(),
+        "S19.8: lowercase 'seconds' must be accepted"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S22.2  Intermediate non-object hides earlier object across files  (L1406)
+// Status: ✅
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// From spec L1410-1417: merge A={a:{x:1}}, B={a:42}, C={a:{y:2}} in priority order
+/// (A highest). Because B=42 is paired with C={y:2} and 42 simply wins, the two
+/// objects are not adjacent and their merge is lost.
+/// Result: {a:{x:1}}.
+#[test]
+fn s22_2_non_object_hides_earlier_object_across_merge() {
+    let cfg_a = hocon::parse_with_env(r#"a { x = 1 }"#, &HashMap::new()).unwrap();
+    let cfg_b = hocon::parse_with_env(r#"a = 42"#, &HashMap::new()).unwrap();
+    let cfg_c = hocon::parse_with_env(r#"a { y = 2 }"#, &HashMap::new()).unwrap();
+
+    // Merge: cfg_a highest priority, cfg_b middle, cfg_c lowest
+    let mid = cfg_b.with_fallback(&cfg_c);
+    let merged = cfg_a.with_fallback(&mid);
+
+    // a.x from cfg_a is accessible
+    assert_eq!(
+        merged.get_i64("a.x").unwrap(),
+        1,
+        "S22.2: a.x from the highest-priority object must be present"
+    );
+    // a.y from cfg_c must NOT be accessible (hidden by cfg_b's non-object 42)
+    assert!(
+        merged.get_i64("a.y").is_err(),
+        "S22.2: a.y must not be accessible — cfg_b's a=42 hides cfg_c's a.y (spec L1406)"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S22.3  Setting key to null clears earlier object value  (L1436)
+// Status: ✅
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Spec L1436: setting a key to null clears earlier object values when merging.
+/// Merge A={a:null} over B={a:{x:1}} → a is null, a.x is not accessible.
+#[test]
+fn s22_3_null_clears_earlier_object_in_merge() {
+    let cfg_a = hocon::parse_with_env(r#"a = null"#, &HashMap::new()).unwrap();
+    let cfg_b = hocon::parse_with_env(r#"a { x = 1 }"#, &HashMap::new()).unwrap();
+
+    let merged = cfg_a.with_fallback(&cfg_b);
+
+    // a.x must not be accessible — null cleared the object
+    assert!(
+        merged.get_i64("a.x").is_err(),
+        "S22.3: a.x must not be accessible after a=null clears the earlier object (spec L1436)"
+    );
+    // a itself is null (get_string returns "null" due to S17.6 bug, which is separate)
+    assert!(
+        merged.get_string("a").is_ok(),
+        "S22.3: a is still present as null value"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S23.2  Empty path elements (leading/trailing) preserved in properties  (L1456)
+// Status: ✅
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Spec L1456: "a." splits to ["a", ""] — the trailing empty segment is preserved.
+/// Verified via include of a .properties file.
+#[test]
+fn s23_2_trailing_dot_creates_empty_key_segment() {
+    let dir = std::env::temp_dir().join("hocon_s23_2_trail");
+    std::fs::create_dir_all(&dir).unwrap();
+    // "a. = v" → key "a." splits to ["a", ""] → a."" = v
+    let props = dir.join("trail.properties");
+    std::fs::write(&props, "a. = trailing_dot\n").unwrap();
+
+    let hocon_input = format!("include \"{}\"\n", props.to_str().unwrap());
+    let r = hocon::parse_with_env(&hocon_input, &HashMap::new());
+    // impl succeeds and creates a nested object under "a"
+    assert!(
+        r.is_ok(),
+        "S23.2: properties with trailing dot key must parse"
+    );
+    let cfg = r.unwrap();
+    // "a" is an object (not a scalar), the empty-string key lives inside it
+    // get_config("a") should succeed
+    assert!(
+        cfg.get_config("a").is_ok(),
+        "S23.2: 'a' must be an object (trailing dot creates nested obj with empty key)"
+    );
+}
+
+#[test]
+fn s23_2_leading_dot_creates_empty_key_segment() {
+    let dir = std::env::temp_dir().join("hocon_s23_2_lead");
+    std::fs::create_dir_all(&dir).unwrap();
+    // ".a = v" → key ".a" splits to ["", "a"] → ""."a" = v
+    let props = dir.join("lead.properties");
+    std::fs::write(&props, ".a = leading_dot\n").unwrap();
+
+    let hocon_input = format!("include \"{}\"\n", props.to_str().unwrap());
+    let r = hocon::parse_with_env(&hocon_input, &HashMap::new());
+    assert!(
+        r.is_ok(),
+        "S23.2: properties with leading dot key must parse"
+    );
+    let cfg = r.unwrap();
+    // The empty-string root key is present in the internal map.
+    // The accessor path ".a" (dot-prefixed) reaches the value because split_config_path
+    // treats the leading dot as a path separator producing ["", "a"].
+    assert_eq!(
+        cfg.get_string(".a").unwrap(),
+        "leading_dot",
+        "S23.2: '.a' in properties must create path [\"\", \"a\"] accessible as '.a'"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S26.2  Empty env var preserved as empty string (not undefined)  (L1558)
+// Status: ✅
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn s26_2_empty_env_var_preserved_as_empty_string() {
+    let mut env = HashMap::new();
+    env.insert("MY_VAR".to_string(), "".to_string());
+
+    let cfg = hocon::parse_with_env(r#"v = ${MY_VAR}"#, &env).unwrap();
+    let val = cfg.get_string("v").unwrap();
+    assert_eq!(
+        val, "",
+        "S26.2: env var set to empty string must remain as empty string (not undefined) — spec L1558"
+    );
+}


### PR DESCRIPTION
## Summary

Clears all 17 previously-unverified (🤷) spec items in `docs/spec-compliance.md` by probing each against the current implementation and writing tests in `tests/spec_phase5.rs`.

### Classification results (17 items, reconciled to match `docs/spec-compliance.md`)

| Status | Count | Items |
|--------|-------|-------|
| ✅ Pass | 11 | S13a.9, S13a.10, S13a.14, S14a.7, S14a.10, S14a.11, S18.3, S22.2, S22.3, S23.2, S26.2 |
| ⚠️ Acceptable | 1 | S18.4 (bare integer interpreted as ms — partial; some forms error) |
| ❌ Fail (pinned) | 5 | S10.2, S10.15, S10.17, S13.15, S19.8 |
| ➖ Out of scope | 0 | — |

### Spec compliance rates (as of 2026-05-13)

| Metric | Before | After |
|--------|--------|-------|
| Spec-total (incl. out-of-scope) | 70.1% | **75.6%** |
| In-scope only | 77.9% | **84.0%** |

Cross-language rollup: https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md

### Key bugs pinned (not fixed — test-only scope)

- **S10.2** (`src/` fix needed): Adjacent array concat `[1,2] [3,4]` produces 5-element list with whitespace scalar between the arrays.
- **S10.15**: Quoted whitespace between obj/array substitutions should be an error per spec, but impl silently merges.
- **S10.17**: Substitution resolving to an array does not participate in array concat (`${arr} [x]`).
- **S13.15**: `foo : ${?bar}${?baz}` skip semantics — impl differs from "skipped only when BOTH undefined".
- **S18.4**: `get_duration("500")` (bare integer, no unit = milliseconds per spec) returns `Err` instead of `500ms` — partial; tracked as ⚠️ because some forms work.
- **S19.8**: `parse_duration` calls `.to_lowercase()` before unit matching (`src/config.rs:417`), so `MS`, `Seconds`, `NS` etc. are wrongly accepted (spec requires lowercase-only).

### Deferred minor findings (from multi-agent review)

- Codex P2: Windows path normalization in S23.2 include tests — fixed in commit `ca4dff4` before PR creation.

### Copilot review (1st round)

Addressed in commit (see latest push):
- Temp dir cleanup in 4 include tests (`s14a_7_*` and `s23_2_*`) — `remove_dir_all` added at end of each test, matching `tests/integration_test.rs` pattern.
- S23.2 trailing-dot test tightened to assert `cfg.get_string("a.").unwrap() == "trailing_dot"`, not just that `get_config("a")` succeeds.
- This PR description's classification table reconciled to match `docs/spec-compliance.md` statuses (was inconsistent: some items appeared in both ✅ and ❌, S26.2/S23.2 were misplaced as ⚠️).

## Test plan

- [x] `cargo test --test spec_phase5` — 26 pass, 8 ignored
- [x] `cargo test` (full suite) — no regressions
- [x] `cargo fmt` clean
- [x] Ignored tests carry `#[ignore = "spec violation per SXX.Y …"]` labels linking to spec line

🤖 Generated with [Claude Code](https://claude.com/claude-code)