### PR TITLE
chore(actions): bump GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -19,7 +19,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-set-version
         run: cargo install cargo-set-version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,12 @@ jobs:
             os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
       - name: Cache expected JSON
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             tests/testdata/expected
@@ -49,10 +49,10 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache expected JSON
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             tests/testdata/expected


### PR DESCRIPTION
## Summary

Purely mechanical version bump to satisfy the org-wide GitHub Actions Node.js 24 upgrade deadline (2026-06-02).

- `actions/checkout@v4` → `actions/checkout@v5`
- `actions/cache@v4` → `actions/cache@v5`

## Files changed

- `.github/workflows/test.yml` — 2 bumps (checkout + cache in both `test` and `coverage` jobs)
- `.github/workflows/lint.yml` — 2 bumps (checkout in `clippy` and `fmt` jobs)
- `.github/workflows/publish.yml` — 1 bump (checkout in `publish` job)

## What was NOT touched

- `dtolnay/rust-toolchain@stable` / `@master` (floating refs, intentionally left alone)
- `rust-lang/crates-io-auth-action@v1` (already current)
- `taiki-e/install-action@cargo-llvm-cov` (feature tag, not SemVer)
- `codecov/codecov-action@v5` (already current)
- Rust toolchain versions, matrix specs, workflow logic

No behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)