### PR TITLE
fix(lexer): expand whitespace recognition to HOCON spec set (S6.1/6.2/6.4)

### DIFF
--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -107,17 +107,17 @@ same item descriptions verbatim.
 ## S6. Whitespace
 
 - **S6.1** Unicode Zs/Zl/Zp category characters are whitespace — §Whitespace (L170)
-  tests: src/lexer.rs:931 (s6_1_em_space_separates_tokens_spec [#ignore]); src/lexer.rs:957 (s6_1_line_separator_separates_tokens_spec [#ignore]); pin tests at src/lexer.rs:915 and src/lexer.rs:944
-  status: ❌ ([#62](https://github.com/o3co/rs.hocon/issues/62)) — lexer only recognises ASCII space/tab/CR; Unicode Zs/Zl/Zp chars leak into unquoted runs
+  tests: src/lexer.rs (s6_1_em_space_separates_tokens_spec); src/lexer.rs (s6_1_line_separator_separates_tokens_spec)
+  status: ✅ (fixed in fix/s6-whitespace-expansion, [#62](https://github.com/o3co/rs.hocon/issues/62)) — is_hocon_whitespace covers all Zs/Zl/Zp members
 - **S6.2** Non-breaking spaces (0x00A0, 0x2007, 0x202F) are whitespace — §Whitespace (L171)
-  tests: src/lexer.rs:987 (s6_2_nbsp_separates_tokens_spec [#ignore]); src/lexer.rs:1001 (s6_2_figure_space_separates_tokens_spec [#ignore]); src/lexer.rs:1015 (s6_2_narrow_nbsp_separates_tokens_spec [#ignore]); pin test at src/lexer.rs:974
-  status: ❌ ([#62](https://github.com/o3co/rs.hocon/issues/62)) — NBSP / figure space / narrow NBSP are not recognised as whitespace
+  tests: src/lexer.rs (s6_2_nbsp_separates_tokens_spec); src/lexer.rs (s6_2_figure_space_separates_tokens_spec); src/lexer.rs (s6_2_narrow_nbsp_separates_tokens_spec)
+  status: ✅ (fixed in fix/s6-whitespace-expansion, [#62](https://github.com/o3co/rs.hocon/issues/62)) — NBSP variants included in is_hocon_whitespace
 - **S6.3** BOM (0xFEFF) treated as whitespace — §Whitespace (L173)
-  tests: src/lexer.rs:846 (strips_utf8_bom); tests/testdata/hocon/bom.conf (fixture)
-  status: ✅
+  tests: src/lexer.rs (strips_utf8_bom); src/lexer.rs (s6_3_bom_midstream_is_whitespace); tests/testdata/hocon/bom.conf (fixture)
+  status: ✅ (broadened in fix/s6-whitespace-expansion) — BOM now treated as whitespace anywhere, not just at start of input
 - **S6.4** ASCII control whitespace (tab, vtab, FF, CR, FS, GS, RS, US) — §Whitespace (L174)
-  tests: src/lexer.rs:1033 (s6_4_tab_is_whitespace); src/lexer.rs:1046 (s6_4_cr_is_whitespace); src/lexer.rs:1075 (s6_4_vtab_is_whitespace_spec [#ignore]); src/lexer.rs:1089 (s6_4_ff_is_whitespace_spec [#ignore]); src/lexer.rs:1105 (s6_4_fs_gs_rs_us_are_whitespace_spec [#ignore]); pin test at src/lexer.rs:1061
-  status: ⚠️ ([#62](https://github.com/o3co/rs.hocon/issues/62)) — 2 of 8 sub-rules pass: tab (0x09) ✅ and CR (0x0D) ✅; vtab (0x0B), FF (0x0C), FS–US (0x1C–0x1F) are not recognised as whitespace
+  tests: src/lexer.rs (s6_4_tab_is_whitespace); src/lexer.rs (s6_4_cr_is_whitespace); src/lexer.rs (s6_4_vtab_is_whitespace_spec); src/lexer.rs (s6_4_ff_is_whitespace_spec); src/lexer.rs (s6_4_fs_gs_rs_us_are_whitespace_spec)
+  status: ✅ (fixed in fix/s6-whitespace-expansion, [#62](https://github.com/o3co/rs.hocon/issues/62)) — all 8 ASCII control whitespace chars covered by is_hocon_whitespace
 - **S6.5** "newline" means specifically 0x000A (LF) — §Whitespace (L183)
   tests: src/lexer.rs:814 (tokenizes_newlines)
   status: ✅

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -107,19 +107,19 @@ same item descriptions verbatim.
 ## S6. Whitespace
 
 - **S6.1** Unicode Zs/Zl/Zp category characters are whitespace — §Whitespace (L170)
-  tests: src/lexer.rs (s6_1_em_space_separates_tokens_spec); src/lexer.rs (s6_1_line_separator_separates_tokens_spec)
-  status: ✅ (fixed in fix/s6-whitespace-expansion, [#62](https://github.com/o3co/rs.hocon/issues/62)) — is_hocon_whitespace covers all Zs/Zl/Zp members
+  tests: src/lexer.rs:954 (s6_1_em_space_separates_tokens_spec); src/lexer.rs:967 (s6_1_line_separator_separates_tokens_spec)
+  status: ✅ (fixed in #84, [#62](https://github.com/o3co/rs.hocon/issues/62)) — is_hocon_whitespace covers all Zs/Zl/Zp members
 - **S6.2** Non-breaking spaces (0x00A0, 0x2007, 0x202F) are whitespace — §Whitespace (L171)
-  tests: src/lexer.rs (s6_2_nbsp_separates_tokens_spec); src/lexer.rs (s6_2_figure_space_separates_tokens_spec); src/lexer.rs (s6_2_narrow_nbsp_separates_tokens_spec)
-  status: ✅ (fixed in fix/s6-whitespace-expansion, [#62](https://github.com/o3co/rs.hocon/issues/62)) — NBSP variants included in is_hocon_whitespace
+  tests: src/lexer.rs:984 (s6_2_nbsp_separates_tokens_spec); src/lexer.rs:997 (s6_2_figure_space_separates_tokens_spec); src/lexer.rs:1010 (s6_2_narrow_nbsp_separates_tokens_spec)
+  status: ✅ (fixed in #84, [#62](https://github.com/o3co/rs.hocon/issues/62)) — NBSP variants included in is_hocon_whitespace
 - **S6.3** BOM (0xFEFF) treated as whitespace — §Whitespace (L173)
-  tests: src/lexer.rs (strips_utf8_bom); src/lexer.rs (s6_3_bom_midstream_is_whitespace); tests/testdata/hocon/bom.conf (fixture)
-  status: ✅ (broadened in fix/s6-whitespace-expansion) — BOM now treated as whitespace anywhere, not just at start of input
+  tests: src/lexer.rs:887 (strips_utf8_bom); src/lexer.rs:1123 (s6_3_bom_midstream_is_whitespace); tests/testdata/hocon/bom.conf (fixture)
+  status: ✅ (broadened in #84) — BOM now treated as whitespace anywhere, not just at start of input
 - **S6.4** ASCII control whitespace (tab, vtab, FF, CR, FS, GS, RS, US) — §Whitespace (L174)
-  tests: src/lexer.rs (s6_4_tab_is_whitespace); src/lexer.rs (s6_4_cr_is_whitespace); src/lexer.rs (s6_4_vtab_is_whitespace_spec); src/lexer.rs (s6_4_ff_is_whitespace_spec); src/lexer.rs (s6_4_fs_gs_rs_us_are_whitespace_spec)
-  status: ✅ (fixed in fix/s6-whitespace-expansion, [#62](https://github.com/o3co/rs.hocon/issues/62)) — all 8 ASCII control whitespace chars covered by is_hocon_whitespace
+  tests: src/lexer.rs:1027 (s6_4_tab_is_whitespace); src/lexer.rs:1040 (s6_4_cr_is_whitespace); src/lexer.rs:1055 (s6_4_vtab_is_whitespace_spec); src/lexer.rs:1068 (s6_4_ff_is_whitespace_spec); src/lexer.rs:1083 (s6_4_fs_gs_rs_us_are_whitespace_spec)
+  status: ✅ (fixed in #84, [#62](https://github.com/o3co/rs.hocon/issues/62)) — all 8 ASCII control whitespace chars covered by is_hocon_whitespace
 - **S6.5** "newline" means specifically 0x000A (LF) — §Whitespace (L183)
-  tests: src/lexer.rs:814 (tokenizes_newlines)
+  tests: src/lexer.rs:855 (tokenizes_newlines)
   status: ✅
 
 ## S7. Duplicate keys and object merging

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1066,7 +1066,6 @@ mod tests {
 
     // Spec-correct test: vtab (0x0B) must be whitespace.
     #[test]
-    #[ignore = "spec violation: vtab (0x0B) not treated as whitespace, see #62"]
     fn s6_4_vtab_is_whitespace_spec() {
         let tokens = tokenize("a\x0Bb").unwrap();
         let unquoted: Vec<_> = tokens
@@ -1080,7 +1079,6 @@ mod tests {
 
     // Spec-correct test: form feed (0x0C) must be whitespace.
     #[test]
-    #[ignore = "spec violation: FF (0x0C) not treated as whitespace, see #62"]
     fn s6_4_ff_is_whitespace_spec() {
         let tokens = tokenize("a\x0Cb").unwrap();
         let unquoted: Vec<_> = tokens
@@ -1096,7 +1094,6 @@ mod tests {
     // These are grouped because they share the same root cause (not in the
     // lexer's whitespace check) and the same fix will address all four.
     #[test]
-    #[ignore = "spec violation: FS/GS/RS/US (0x1C-0x1F) not treated as whitespace, see #62"]
     fn s6_4_fs_gs_rs_us_are_whitespace_spec() {
         for (label, ch) in [
             ("FS (0x1C)", '\x1C'),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1113,6 +1113,38 @@ mod tests {
         }
     }
 
+    // --- S6.3 (broadened): BOM mid-stream is whitespace ----------------------
+    // Spec L173: BOM (U+FEFF) is whitespace, not a start-of-input marker.
+    // Currently the lexer strips BOM only at char index 0 (src/lexer.rs:55).
+    // A BOM mid-stream leaks into the unquoted run instead of acting as a
+    // token separator.
+    //
+    // Pin test: BOM mid-stream absorbed into unquoted (current wrong behavior).
+    #[test]
+    fn s6_3_bom_midstream_absorbed_into_unquoted_pin() {
+        // BOM (U+FEFF) mid-stream: currently folds into the unquoted token.
+        let tokens = tokenize("a\u{FEFF}b").unwrap();
+        let unquoted: Vec<_> = tokens
+            .iter()
+            .filter(|t| t.kind == TokenKind::Unquoted)
+            .collect();
+        assert_eq!(unquoted.len(), 1);
+        assert!(unquoted[0].value.contains('\u{FEFF}'));
+    }
+
+    // Spec-correct test: BOM mid-stream must separate two unquoted tokens.
+    #[test]
+    fn s6_3_bom_midstream_is_whitespace() {
+        let tokens = tokenize("a\u{FEFF}b").unwrap();
+        let unquoted: Vec<_> = tokens
+            .iter()
+            .filter(|t| t.kind == TokenKind::Unquoted)
+            .collect();
+        assert_eq!(unquoted.len(), 2, "BOM mid-stream should separate two tokens");
+        assert_eq!(unquoted[0].value, "a");
+        assert_eq!(unquoted[1].value, "b");
+    }
+
     // --- S8.6: unquoted string cannot begin with 0-9 or - -------------------
     // Spec L270: unquoted strings must not start with a digit (0–9) or hyphen (-).
     // rs.hocon's is_unquoted_start() does not exclude these characters, so

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -927,7 +927,6 @@ mod tests {
 
     // Spec-correct test: em space must separate two unquoted tokens.
     #[test]
-    #[ignore = "spec violation: em space (U+2003, Zs) not treated as whitespace, see #62"]
     fn s6_1_em_space_separates_tokens_spec() {
         let tokens = tokenize("a\u{2003}b").unwrap();
         let unquoted: Vec<_> = tokens
@@ -953,7 +952,6 @@ mod tests {
 
     // Spec-correct test: line separator (U+2028, Zl) must be whitespace.
     #[test]
-    #[ignore = "spec violation: line separator (U+2028, Zl) not treated as whitespace, see #62"]
     fn s6_1_line_separator_separates_tokens_spec() {
         let tokens = tokenize("a\u{2028}b").unwrap();
         let unquoted: Vec<_> = tokens

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -947,24 +947,8 @@ mod tests {
     // --- S6.1: Unicode Zs / Zl / Zp category chars are whitespace -----------
     // Spec L170: the lexer must treat any Unicode whitespace category character
     // (Zs, Zl, Zp) as a token separator, not as unquoted string content.
-    // rs.hocon's lexer (L68) only recognises ASCII space, tab, and CR, so these
-    // characters leak into unquoted runs instead.
+    // All Zs/Zl/Zp members are covered by is_hocon_whitespace.
     //
-    // Pin test: current (incorrect) behaviour — em space absorbed into unquoted.
-    #[test]
-    fn s6_1_em_space_absorbed_into_unquoted_pin() {
-        // Em space U+2003 (Zs category). Currently the lexer folds it into the
-        // unquoted token instead of treating it as a separator.
-        let tokens = tokenize("a\u{2003}b").unwrap();
-        let unquoted: Vec<_> = tokens
-            .iter()
-            .filter(|t| t.kind == TokenKind::Unquoted)
-            .collect();
-        // Current wrong behaviour: one token containing the em space.
-        assert_eq!(unquoted.len(), 1);
-        assert!(unquoted[0].value.contains('\u{2003}'));
-    }
-
     // Spec-correct test: em space must separate two unquoted tokens.
     #[test]
     fn s6_1_em_space_separates_tokens_spec() {
@@ -976,18 +960,6 @@ mod tests {
         assert_eq!(unquoted.len(), 2, "em space should separate two tokens");
         assert_eq!(unquoted[0].value, "a");
         assert_eq!(unquoted[1].value, "b");
-    }
-
-    // Pin test: line separator U+2028 (Zl category) absorbed into unquoted.
-    #[test]
-    fn s6_1_line_separator_absorbed_into_unquoted_pin() {
-        let tokens = tokenize("a\u{2028}b").unwrap();
-        let unquoted: Vec<_> = tokens
-            .iter()
-            .filter(|t| t.kind == TokenKind::Unquoted)
-            .collect();
-        assert_eq!(unquoted.len(), 1);
-        assert!(unquoted[0].value.contains('\u{2028}'));
     }
 
     // Spec-correct test: line separator (U+2028, Zl) must be whitespace.
@@ -1005,19 +977,7 @@ mod tests {
 
     // --- S6.2: non-breaking spaces are whitespace ----------------------------
     // Spec L171: U+00A0 (NBSP), U+2007 (figure space), U+202F (narrow NBSP)
-    // must be treated as whitespace. Currently the lexer folds them into unquoted.
-
-    // Pin test: NBSP absorbed into unquoted.
-    #[test]
-    fn s6_2_nbsp_absorbed_into_unquoted_pin() {
-        let tokens = tokenize("a\u{00A0}b").unwrap();
-        let unquoted: Vec<_> = tokens
-            .iter()
-            .filter(|t| t.kind == TokenKind::Unquoted)
-            .collect();
-        assert_eq!(unquoted.len(), 1);
-        assert!(unquoted[0].value.contains('\u{00A0}'));
-    }
+    // must be treated as whitespace. All three are in is_hocon_whitespace.
 
     // Spec-correct test: NBSP (U+00A0) must separate tokens.
     #[test]
@@ -1061,12 +1021,11 @@ mod tests {
     // --- S6.4: ASCII control whitespace --------------------------------------
     // Spec L174 lists 8 chars that are whitespace: tab (0x09), vtab (0x0B),
     // FF (0x0C), CR (0x0D), FS (0x1C), GS (0x1D), RS (0x1E), US (0x1F).
-    // rs.hocon's lexer handles tab and CR (L68) but NOT vtab, FF, or FS–US.
+    // All 8 are now covered by is_hocon_whitespace.
 
-    // Tab and CR — these already pass (covered by existing code path).
     #[test]
     fn s6_4_tab_is_whitespace() {
-        // Tab (0x09): already in the lexer's whitespace check.
+        // Tab (0x09): in the HOCON whitespace set.
         let tokens = tokenize("a\tb").unwrap();
         let unquoted: Vec<_> = tokens
             .iter()
@@ -1079,8 +1038,8 @@ mod tests {
 
     #[test]
     fn s6_4_cr_is_whitespace() {
-        // CR (0x0D): already in the lexer's whitespace check.
-        // CR alone (without LF) acts as inline whitespace, not a newline emitter.
+        // CR (0x0D): in the HOCON whitespace set.
+        // CR alone (without LF) acts as inter-token whitespace, not a newline emitter.
         let tokens = tokenize("a\rb").unwrap();
         let unquoted: Vec<_> = tokens
             .iter()
@@ -1089,19 +1048,6 @@ mod tests {
         assert_eq!(unquoted.len(), 2);
         assert_eq!(unquoted[0].value, "a");
         assert_eq!(unquoted[1].value, "b");
-    }
-
-    // Vtab and FF — pin tests for current (wrong) behavior.
-    #[test]
-    fn s6_4_vtab_absorbed_into_unquoted_pin() {
-        // Vtab (0x0B) is not in the whitespace check; it leaks into unquoted.
-        let tokens = tokenize("a\x0Bb").unwrap();
-        let unquoted: Vec<_> = tokens
-            .iter()
-            .filter(|t| t.kind == TokenKind::Unquoted)
-            .collect();
-        assert_eq!(unquoted.len(), 1);
-        assert!(unquoted[0].value.contains('\x0B'));
     }
 
     // Spec-correct test: vtab (0x0B) must be whitespace.
@@ -1168,23 +1114,10 @@ mod tests {
 
     // --- S6.3 (broadened): BOM mid-stream is whitespace ----------------------
     // Spec L173: BOM (U+FEFF) is whitespace, not a start-of-input marker.
-    // Currently the lexer strips BOM only at char index 0 (src/lexer.rs:55).
-    // A BOM mid-stream leaks into the unquoted run instead of acting as a
-    // token separator.
+    // The lexer still strips BOM at char index 0 (harmless redundancy), and
+    // BOM mid-stream is now consumed as inter-token whitespace via
+    // is_hocon_whitespace.
     //
-    // Pin test: BOM mid-stream absorbed into unquoted (current wrong behavior).
-    #[test]
-    fn s6_3_bom_midstream_absorbed_into_unquoted_pin() {
-        // BOM (U+FEFF) mid-stream: currently folds into the unquoted token.
-        let tokens = tokenize("a\u{FEFF}b").unwrap();
-        let unquoted: Vec<_> = tokens
-            .iter()
-            .filter(|t| t.kind == TokenKind::Unquoted)
-            .collect();
-        assert_eq!(unquoted.len(), 1);
-        assert!(unquoted[0].value.contains('\u{FEFF}'));
-    }
-
     // Spec-correct test: BOM mid-stream must separate two unquoted tokens.
     #[test]
     fn s6_3_bom_midstream_is_whitespace() {
@@ -1193,7 +1126,11 @@ mod tests {
             .iter()
             .filter(|t| t.kind == TokenKind::Unquoted)
             .collect();
-        assert_eq!(unquoted.len(), 2, "BOM mid-stream should separate two tokens");
+        assert_eq!(
+            unquoted.len(),
+            2,
+            "BOM mid-stream should separate two tokens"
+        );
         assert_eq!(unquoted[0].value, "a");
         assert_eq!(unquoted[1].value, "b");
     }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1113,6 +1113,19 @@ mod tests {
         }
     }
 
+    // --- LF regression guard: LF must still emit Newline token ---------------
+    // After predicate centralization, is_hocon_whitespace returns true for LF.
+    // The newline branch must check BEFORE the whitespace skip so LF still
+    // produces TokenKind::Newline (per spec §D, design invariant).
+    #[test]
+    fn s6_lf_still_emits_newline_token() {
+        let tokens = tokenize("a\nb").unwrap();
+        assert!(
+            tokens.iter().any(|t| matches!(t.kind, TokenKind::Newline)),
+            "LF must still emit a Newline token after whitespace predicate centralization"
+        );
+    }
+
     // --- S6.3 (broadened): BOM mid-stream is whitespace ----------------------
     // Spec L173: BOM (U+FEFF) is whitespace, not a start-of-input marker.
     // Currently the lexer strips BOM only at char index 0 (src/lexer.rs:55).

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -981,7 +981,6 @@ mod tests {
 
     // Spec-correct test: NBSP (U+00A0) must separate tokens.
     #[test]
-    #[ignore = "spec violation: NBSP (U+00A0) not treated as whitespace, see #62"]
     fn s6_2_nbsp_separates_tokens_spec() {
         let tokens = tokenize("a\u{00A0}b").unwrap();
         let unquoted: Vec<_> = tokens
@@ -995,7 +994,6 @@ mod tests {
 
     // Spec-correct test: figure space (U+2007) must separate tokens.
     #[test]
-    #[ignore = "spec violation: figure space (U+2007) not treated as whitespace, see #62"]
     fn s6_2_figure_space_separates_tokens_spec() {
         let tokens = tokenize("a\u{2007}b").unwrap();
         let unquoted: Vec<_> = tokens
@@ -1009,7 +1007,6 @@ mod tests {
 
     // Spec-correct test: narrow NBSP (U+202F) must separate tokens.
     #[test]
-    #[ignore = "spec violation: narrow NBSP (U+202F) not treated as whitespace, see #62"]
     fn s6_2_narrow_nbsp_separates_tokens_spec() {
         let tokens = tokenize("a\u{202F}b").unwrap();
         let unquoted: Vec<_> = tokens

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -43,6 +43,45 @@ pub struct Token {
     pub subst: Option<SubstPayload>,
 }
 
+/// Returns true for every character in the HOCON whitespace set.
+///
+/// The set is defined by Lightbend HOCON.md §Whitespace (L165-184) as:
+///   Java Character.isWhitespace set
+///   ∪ { U+00A0, U+2007, U+202F }  (NBSP variants Java excludes)
+///   ∪ { U+FEFF }                  (BOM)
+///
+/// Expanded:
+///   ASCII:  0x09 (TAB), 0x0A (LF), 0x0B (VTAB), 0x0C (FF), 0x0D (CR),
+///           0x1C (FS), 0x1D (GS), 0x1E (RS), 0x1F (US)
+///   Zs:     0x20, 0x00A0, 0x1680, 0x2000-0x200A, 0x202F, 0x205F, 0x3000
+///   Zl:     0x2028
+///   Zp:     0x2029
+///   BOM:    0xFEFF
+///
+/// NOTE: U+000A (LF) is included here because it is in the Java
+/// Character.isWhitespace set.  Callers that need to distinguish newline from
+/// inter-token whitespace must call is_hocon_newline first.
+fn is_hocon_whitespace(ch: char) -> bool {
+    matches!(ch,
+        '\t' | '\n' | '\u{000B}' | '\u{000C}' | '\r'
+      | '\u{001C}'..='\u{001F}'
+      | ' ' | '\u{00A0}' | '\u{FEFF}'
+      | '\u{1680}'
+      | '\u{2000}'..='\u{200A}'
+      | '\u{2028}' | '\u{2029}' | '\u{202F}' | '\u{205F}'
+      | '\u{3000}'
+    )
+}
+
+/// Returns true if `ch` is the HOCON newline character (ASCII LF, U+000A only).
+///
+/// Per HOCON.md L182-184: "newline refers only and specifically to ASCII
+/// newline 0x000A".  Unicode line/paragraph separators (U+2028, U+2029) are
+/// whitespace but NOT newlines.
+fn is_hocon_newline(ch: char) -> bool {
+    ch == '\n'
+}
+
 pub fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
     let chars: Vec<char> = input.chars().collect();
     let mut tokens = Vec::new();
@@ -64,16 +103,9 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
         let sc = col;
         let ch = chars[pos];
 
-        // Whitespace (not newline)
-        if ch == ' ' || ch == '\t' || ch == '\r' {
-            pos += 1;
-            col += 1;
-            had_space = true;
-            continue;
-        }
-
-        // Newline
-        if ch == '\n' {
+        // Newline (must be checked before general whitespace because
+        // is_hocon_whitespace also returns true for LF — see spec §D).
+        if is_hocon_newline(ch) {
             pos += 1;
             line += 1;
             col = 1;
@@ -92,6 +124,14 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
                 });
                 had_space = false;
             }
+            continue;
+        }
+
+        // Whitespace (not newline) — full HOCON_WS set per spec L165-184.
+        if is_hocon_whitespace(ch) {
+            pos += 1;
+            col += 1;
+            had_space = true;
             continue;
         }
 
@@ -424,16 +464,16 @@ fn read_quoted_body(
 }
 
 /// Returns true if `ch` is a valid unquoted character inside a `${...}` body.
-/// Forbidden: whitespace (space/tab), `"`, `\`, `{`, `}`, `[`, `]`, `:`, `=`, `,`,
-///            `+`, `#`, `` ` ``, `^`, `?`, `!`, `@`, `*`, `&`, `$`, `.`, newline, CR.
+/// Forbidden: any HOCON whitespace (full set per is_hocon_whitespace), `"`, `\`,
+///            `{`, `}`, `[`, `]`, `:`, `=`, `,`, `+`, `#`, `` ` ``, `^`, `?`,
+///            `!`, `@`, `*`, `&`, `$`, `.`.
 fn is_unquoted_subst_char(ch: char) -> bool {
+    if is_hocon_whitespace(ch) {
+        return false;
+    }
     !matches!(
         ch,
-        ' ' | '\t'
-            | '\n'
-            | '\r'
-            | '"'
-            | '\\'
+        '"' | '\\'
             | '{'
             | '}'
             | '['
@@ -565,13 +605,15 @@ fn parse_subst_body(
                 *pos += 1;
                 *col += 1;
             }
-            ' ' | '\t' => {
-                // WS: buffer into pending_ws
+            ch if is_hocon_whitespace(ch) && !is_hocon_newline(ch) => {
+                // Inter-token whitespace (full HOCON_WS minus LF): buffer into
+                // pending_ws; column advances but line is unchanged.
                 pending_ws.push(ch);
                 *pos += 1;
                 *col += 1;
             }
-            '\n' | '\r' => {
+            '\n' => {
+                // LF inside ${...} is not allowed (unterminated substitution).
                 return Err(ParseError {
                     message: "unterminated substitution".into(),
                     line: start_line,
@@ -619,6 +661,9 @@ fn parse_subst_body(
 }
 
 fn is_unquoted_start(ch: char) -> bool {
+    if is_hocon_whitespace(ch) {
+        return false;
+    }
     !matches!(
         ch,
         '{' | '}'
@@ -629,10 +674,6 @@ fn is_unquoted_start(ch: char) -> bool {
             | '='
             | '+'
             | '#'
-            | '\n'
-            | '\r'
-            | '\t'
-            | ' '
             | '"'
             | '$'
             | '?'
@@ -646,6 +687,9 @@ fn is_unquoted_start(ch: char) -> bool {
 }
 
 fn is_unquoted_continue(ch: char, next_fn: impl Fn() -> char) -> bool {
+    if is_hocon_whitespace(ch) {
+        return false;
+    }
     if matches!(
         ch,
         '{' | '}'
@@ -654,13 +698,9 @@ fn is_unquoted_continue(ch: char, next_fn: impl Fn() -> char) -> bool {
             | ','
             | ':'
             | '='
-            | '\n'
-            | '\r'
-            | '\t'
             | '#'
             | '"'
             | '$'
-            | ' '
             | '?'
             | '!'
             | '@'


### PR DESCRIPTION
## Summary

Expand HOCON lexer whitespace recognition to match the [Lightbend HOCON.md §Whitespace](https://github.com/lightbend/config/blob/main/HOCON.md#whitespace) (L165–184). Part of [Phase 6 #1](https://github.com/o3co/xx.hocon/blob/develop/docs/compliance-matrix.md) of the cross-impl compliance program.

## Compliance lift (in-scope)

- S6.1 ❌ → ✅ — Unicode Zs/Zl/Zp category characters recognized as whitespace
- S6.2 ❌ → ✅ — Non-breaking spaces (U+00A0, U+2007, U+202F) recognized
- S6.4 ⚠️ → ✅ — All 8 non-newline ASCII control whitespace chars (U+0009, U+000B–U+000D, U+001C–U+001F) recognized
- S6.3 — broadened: BOM (U+FEFF) now whitespace anywhere, not only at start-of-input

Expected lift: **84.0% → ~85.3%** (closes [#62](https://github.com/o3co/rs.hocon/issues/62))

## Behavior changes (intentional, 3-way convergent across ts/rs/go)

1. **BOM mid-stream is whitespace** — was: stripped only at start-of-input. Spec L173 says BOM "must also be treated as whitespace" with no positional qualifier.
2. **CR (`\r`) inside `\${...}`** — was: "unterminated substitution" error alongside LF. Now consumed as inter-segment whitespace per spec L182–184 ("newline refers only and specifically to ASCII newline 0x000A"). LF still terminates substitution body as error.

## Implementation

- Added module-private \`is_hocon_whitespace(ch)\` + \`is_hocon_newline(ch)\` predicates matching the spec set exactly (hardcoded, not delegated to Rust \`char::is_whitespace\` which includes NEL U+0085 and excludes U+001C–U+001F).
- Newline check runs before whitespace skip in the main lexer loop (spec §D invariant — LF must still emit \`Newline\` token).
- All four call sites route through the new predicate: main loop, \`parse_subst_body\`, \`is_unquoted_subst_char\`, \`is_unquoted_start\`, \`is_unquoted_continue\`.

## Design references

- Cross-impl design spec + per-impl plan in xx.hocon \`.claude/superpowers/\` (Codex-reviewed, multi-agent-reviewed)
- Lightbend HOCON.md §Whitespace L165–184

## Test plan

- [x] RED commits demonstrate failure before predicate implementation (verified per-commit by reviewer)
- [x] LF regression guard test confirms LF still emits \`Newline\` token after predicate centralization
- [x] BOM mid-stream regression test (S6.3 broadening verification)
- [x] \`make test\` green (8 suites, 0 failed)
- [x] \`cargo clippy --lib\` clean