### PR TITLE
fix(s15): numeric_object_to_array + accessor + pairwise-fold concat + serde (closes #79)

### DIFF
--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -569,33 +569,33 @@ same item descriptions verbatim.
 ## S15. Numerically-indexed objects to arrays
 
 - **S15.1** `{"0":"a","1":"b"}` → `["a","b"]` when array context — §Conversion (L1191)
-  tests: tests/integration_test.rs:1243 (s15_1_num_indexed_obj_to_array_pin); tests/integration_test.rs:1254 (s15_1_num_indexed_obj_to_array_spec)
-  status: ❌
-  note: `get_list()` on a numeric-keyed object returns `Err("expected Array")`. Conversion not implemented. Tracked in #79.
-- **S15.2** Conversion is lazy (only on type-required access) — §Conversion (L1204)
-  tests: tests/integration_test.rs:1274 (s15_2_conversion_is_lazy_pin); tests/integration_test.rs:1289 (s15_2_conversion_is_lazy_spec)
-  status: ❌
-  note: No lazy conversion is performed. `get_list()` on a numeric-keyed object errors regardless of whether object access was first attempted. Tracked in #79.
-- **S15.3** Conversion in concatenation when list expected — §Conversion (L1210)
-  tests: tests/integration_test.rs:1310 (s15_3_conversion_in_concatenation_pin); tests/integration_test.rs:1335 (s15_3_conversion_in_concatenation_spec)
-  status: ❌
-  note: real concatenation context `arr = [a] ${obj}` (with `obj = {"0":"x","1":"y"}`) produces a 3-element array whose last element is the un-converted Object — spec L1210 requires conversion + flatten to `["a","x","y"]`. Pin asserts the un-converted last element. Tracked in #79.
-- **S15.4** Empty object NOT converted — §Conversion (L1212)
-  tests: tests/integration_test.rs:1344 (s15_4_empty_object_not_converted)
+  tests: tests/integration_test.rs (s15_1_num_indexed_obj_to_array_spec); tests/s15_fixtures.rs (na01_basic_get_list_returns_two_elements); src/numeric_array.rs (unit tests)
   status: ✅
-  note: `get_list()` on `{}` returns an error (correct — empty object must not be converted). Confirmed conformant by probe; passes because no conversion is implemented at all.
+  note: Implemented in fix/s15-numeric-obj-array (#79). Helper `numeric_object_to_array` in `src/numeric_array.rs` invoked from `Config::get_list` accessor site.
+- **S15.2** Conversion is lazy (only on type-required access) — §Conversion (L1204)
+  tests: tests/integration_test.rs (s15_2_conversion_is_lazy_spec); tests/s15_fixtures.rs (na02_lazy_get_config_still_works_and_get_list_also_works)
+  status: ✅
+  note: Laziness preserved: `get_config`/`get` do not invoke the helper. Conversion fires only from `get_list`. Verified by na02 fixture and spec test.
+- **S15.3** Conversion in concatenation when list expected — §Conversion (L1210)
+  tests: tests/integration_test.rs (s15_3_conversion_in_concatenation_spec); tests/s15_fixtures.rs (na03a, na03b, na03c, na03d)
+  status: ✅
+  note: Resolver pairwise-join in `src/resolver/substitution_resolver.rs::resolve_concat` calls `numeric_object_to_array` when an Object is concat'd with an Array. Multi-piece left-to-right pairwise ordering confirmed by na03d.
+- **S15.4** Empty object NOT converted — §Conversion (L1212)
+  tests: tests/integration_test.rs (s15_4_empty_object_not_converted); tests/s15_fixtures.rs (na04_empty_object_not_converted)
+  status: ✅
+  note: Empty-object guard is now explicit in `numeric_object_to_array` (returns None for empty maps). No longer incidental.
 - **S15.5** Non-integer keys ignored during conversion — §Conversion (L1214)
-  tests: tests/integration_test.rs:1358 (s15_5_non_integer_keys_ignored_pin); tests/integration_test.rs:1370 (s15_5_non_integer_keys_ignored_spec)
-  status: ❌
-  note: Conversion not implemented. The `{"0":"a","foo":"b","1":"c"}` case cannot be exercised. Tracked in #79.
+  tests: tests/integration_test.rs (s15_5_non_integer_keys_ignored_spec); tests/s15_fixtures.rs (na05_non_int_keys_ignored)
+  status: ✅
+  note: Pre-filter regex `^(0|[1-9][0-9]*)$` rejects non-integer keys. Mixed-key objects produce only integer-keyed entries in output.
 - **S15.6** Missing indices compacted in resulting array — §Conversion (L1216)
-  tests: tests/integration_test.rs:1384 (s15_6_missing_indices_compacted_pin); tests/integration_test.rs:1396 (s15_6_missing_indices_compacted_spec)
-  status: ❌
-  note: Conversion not implemented. Tracked in #79.
+  tests: tests/integration_test.rs (s15_6_missing_indices_compacted_spec); tests/s15_fixtures.rs (na06_gaps_compacted)
+  status: ✅
+  note: Gaps eliminated naturally: eligible pairs are sorted and projected to value array, discarding index values.
 - **S15.7** Sorted by integer key value — §Conversion (L1216)
-  tests: tests/integration_test.rs:1412 (s15_7_sorted_by_key_value_pin); tests/integration_test.rs:1424 (s15_7_sorted_by_key_value_spec)
-  status: ❌
-  note: Conversion not implemented. Tracked in #79.
+  tests: tests/integration_test.rs (s15_7_sorted_by_key_value_spec); tests/s15_fixtures.rs (na07_sorted_by_key)
+  status: ✅
+  note: `sort_by_key` on parsed integer keys ensures deterministic order regardless of declaration order.
 
 ## S16. MIME Type
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,8 +137,7 @@ impl Config {
                 // Returns None for empty objects (S15.4) and objects with no
                 // eligible integer keys (S15.12 / na12). In those cases fall
                 // through to the type-mismatch error.
-                numeric_object_to_array(v)
-                    .ok_or_else(|| type_mismatch(path, "Array"))
+                numeric_object_to_array(v).ok_or_else(|| type_mismatch(path, "Array"))
             }
             _ => Err(type_mismatch(path, "Array")),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use crate::error::ConfigError;
+use crate::numeric_array::numeric_object_to_array;
 use crate::value::{HoconValue, ScalarType};
 use indexmap::IndexMap;
 
@@ -123,10 +124,22 @@ impl Config {
     /// Return the array at `path` as a `Vec<HoconValue>`.
     ///
     /// Returns [`ConfigError`] if the path is missing or the value is not an array.
+    ///
+    /// Numerically-indexed objects (S15) are converted to an array on demand:
+    /// `{"0":"a","1":"b"}` returns `["a","b"]`. Empty objects and objects with
+    /// no integer keys are NOT converted — they return a type-mismatch error.
     pub fn get_list(&self, path: &str) -> Result<Vec<HoconValue>, ConfigError> {
         match self.lookup_node(path) {
             None => Err(missing(path)),
             Some(HoconValue::Array(items)) => Ok(items.clone()),
+            Some(v @ HoconValue::Object(_)) => {
+                // S15: attempt numeric-keyed object → array conversion.
+                // Returns None for empty objects (S15.4) and objects with no
+                // eligible integer keys (S15.12 / na12). In those cases fall
+                // through to the type-mismatch error.
+                numeric_object_to_array(v)
+                    .ok_or_else(|| type_mismatch(path, "Array"))
+            }
             _ => Err(type_mismatch(path, "Array")),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@
 pub mod config;
 pub mod error;
 pub(crate) mod lexer;
+pub(crate) mod numeric_array;
 pub(crate) mod parser;
 pub(crate) mod properties;
 pub(crate) mod resolver;

--- a/src/numeric_array.rs
+++ b/src/numeric_array.rs
@@ -52,9 +52,7 @@ pub(crate) fn numeric_object_to_array(value: &HoconValue) -> Option<Vec<HoconVal
     // Collect eligible (parsed_key, value) pairs
     let mut eligible: Vec<(i32, HoconValue)> = map
         .iter()
-        .filter_map(|(k, v)| {
-            parse_eligible_key(k).map(|n| (n, v.clone()))
-        })
+        .filter_map(|(k, v)| parse_eligible_key(k).map(|n| (n, v.clone())))
         .collect();
 
     // No eligible integer keys → None

--- a/src/numeric_array.rs
+++ b/src/numeric_array.rs
@@ -1,0 +1,316 @@
+/// Numerically-indexed object → array conversion (S15).
+///
+/// Implements the `numericObjectToArray` helper per the design spec:
+/// `docs/superpowers/specs/2026-05-16-s15-numeric-obj-array-design.md`
+///
+/// # Contract
+///
+/// ```text
+/// numeric_object_to_array(value) →
+///   if value is not an Object       → None (caller handles type mismatch)
+///   if value is an empty Object     → None (S15.4: empty NOT converted)
+///   if no key parses as non-neg int → None (caller handles type mismatch)
+///   otherwise                       → Array of values, sorted by parsed key
+/// ```
+///
+/// # Integer key parse rule (cross-impl convergence point)
+///
+/// A key `s` is eligible iff it matches the regex `^(0|[1-9][0-9]*)$` AND
+/// the resulting integer fits in i32 (≤ 2_147_483_647).
+///
+/// Rejected forms (even though Rust's `str::parse::<i32>()` would accept them):
+/// - `"+1"` — leading `+` sign
+/// - `"-0"` — leading `-` sign
+/// - `"00"`, `"007"` — leading zeros
+/// - `" 1"`, `"1 "` — whitespace
+/// - `""` — empty
+use crate::value::HoconValue;
+
+/// Attempt to convert a numerically-indexed HOCON object to an array.
+///
+/// Returns `Some(Vec<HoconValue>)` if the object has at least one eligible
+/// integer key. Returns `None` if the value is not an object, is empty, or
+/// has no eligible integer keys.
+///
+/// This function is invoked from two call-sites:
+/// 1. `Config::get_list` — accessor-time conversion (S15.1, S15.5, S15.6, S15.7)
+/// 2. Resolver pairwise-join concat — concat-time conversion (S15.3)
+///
+/// It is deliberately NOT called from `Config::get`, `Config::get_config`, or
+/// any untyped accessor — laziness is preserved per S15.2.
+pub(crate) fn numeric_object_to_array(value: &HoconValue) -> Option<Vec<HoconValue>> {
+    let map = match value {
+        HoconValue::Object(m) => m,
+        _ => return None,
+    };
+
+    // S15.4: empty object → None
+    if map.is_empty() {
+        return None;
+    }
+
+    // Collect eligible (parsed_key, value) pairs
+    let mut eligible: Vec<(i32, HoconValue)> = map
+        .iter()
+        .filter_map(|(k, v)| {
+            parse_eligible_key(k).map(|n| (n, v.clone()))
+        })
+        .collect();
+
+    // No eligible integer keys → None
+    if eligible.is_empty() {
+        return None;
+    }
+
+    // Sort ascending by integer key; compaction is implicit (gaps are discarded)
+    eligible.sort_by_key(|(n, _)| *n);
+
+    Some(eligible.into_iter().map(|(_, v)| v).collect())
+}
+
+/// Parse a key string as an eligible non-negative integer.
+///
+/// Returns `Some(n)` iff the key matches `^(0|[1-9][0-9]*)$` and n ≤ i32::MAX.
+/// Returns `None` otherwise.
+///
+/// The pre-filter (character-by-character check equivalent to the regex) MUST
+/// precede any native `parse::<i32>()` call — Rust accepts `"+1"`, `"-0"`,
+/// and `"00"` which are all rejected by this spec.
+fn parse_eligible_key(s: &str) -> Option<i32> {
+    if s.is_empty() {
+        return None;
+    }
+
+    // Pre-filter: must match ^(0|[1-9][0-9]*)$
+    // - First char: '0' or '1'–'9'
+    // - Remaining chars (if any): all '0'–'9'
+    // - If first char is '0', there must be no remaining chars
+    let mut chars = s.chars();
+    let first = chars.next()?;
+    match first {
+        '0' => {
+            // Valid only if "0" exactly (no trailing digits)
+            if chars.next().is_some() {
+                return None; // "00", "007", etc.
+            }
+        }
+        '1'..='9' => {
+            // Remaining chars must all be digits
+            for c in chars {
+                if !c.is_ascii_digit() {
+                    return None;
+                }
+            }
+        }
+        _ => return None, // '-', '+', ' ', letters, etc.
+    }
+
+    // Pre-filter passed; now parse with range check (i32::MAX = 2_147_483_647)
+    s.parse::<i32>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value::{HoconValue, ScalarValue};
+    use indexmap::IndexMap;
+
+    fn sv(s: &str) -> HoconValue {
+        HoconValue::Scalar(ScalarValue::string(s.to_string()))
+    }
+
+    fn make_obj(pairs: &[(&str, &str)]) -> HoconValue {
+        let mut map = IndexMap::new();
+        for (k, v) in pairs {
+            map.insert(k.to_string(), sv(v));
+        }
+        HoconValue::Object(map)
+    }
+
+    // ── parse_eligible_key unit tests ──────────────────────────────────────────
+
+    #[test]
+    fn eligible_zero() {
+        assert_eq!(parse_eligible_key("0"), Some(0));
+    }
+
+    #[test]
+    fn eligible_positive() {
+        assert_eq!(parse_eligible_key("1"), Some(1));
+        assert_eq!(parse_eligible_key("42"), Some(42));
+        assert_eq!(parse_eligible_key("100"), Some(100));
+    }
+
+    #[test]
+    fn eligible_i32_max() {
+        assert_eq!(parse_eligible_key("2147483647"), Some(2_147_483_647_i32));
+    }
+
+    #[test]
+    fn rejected_leading_zero() {
+        assert_eq!(parse_eligible_key("00"), None);
+        assert_eq!(parse_eligible_key("01"), None);
+        assert_eq!(parse_eligible_key("007"), None);
+    }
+
+    #[test]
+    fn rejected_plus_sign() {
+        assert_eq!(parse_eligible_key("+1"), None);
+        assert_eq!(parse_eligible_key("+0"), None);
+    }
+
+    #[test]
+    fn rejected_minus_sign() {
+        assert_eq!(parse_eligible_key("-1"), None);
+        assert_eq!(parse_eligible_key("-0"), None);
+    }
+
+    #[test]
+    fn rejected_whitespace() {
+        assert_eq!(parse_eligible_key(" 1"), None);
+        assert_eq!(parse_eligible_key("1 "), None);
+    }
+
+    #[test]
+    fn rejected_empty() {
+        assert_eq!(parse_eligible_key(""), None);
+    }
+
+    #[test]
+    fn rejected_overflow() {
+        // 2^31 = 2_147_483_648 > i32::MAX
+        assert_eq!(parse_eligible_key("2147483648"), None);
+        assert_eq!(parse_eligible_key("99999999999"), None);
+    }
+
+    #[test]
+    fn rejected_decimal() {
+        assert_eq!(parse_eligible_key("1.0"), None);
+        assert_eq!(parse_eligible_key("1e2"), None);
+    }
+
+    #[test]
+    fn rejected_hex() {
+        assert_eq!(parse_eligible_key("0x1"), None);
+        assert_eq!(parse_eligible_key("0b10"), None);
+    }
+
+    #[test]
+    fn rejected_alpha() {
+        assert_eq!(parse_eligible_key("foo"), None);
+        assert_eq!(parse_eligible_key("bar"), None);
+    }
+
+    // ── numeric_object_to_array unit tests ────────────────────────────────────
+
+    #[test]
+    fn not_an_object_returns_none() {
+        let v = sv("hello");
+        assert!(numeric_object_to_array(&v).is_none());
+    }
+
+    #[test]
+    fn empty_object_returns_none() {
+        let v = HoconValue::Object(IndexMap::new());
+        assert!(numeric_object_to_array(&v).is_none());
+    }
+
+    #[test]
+    fn no_eligible_keys_returns_none() {
+        // na12: all non-int keys
+        let v = make_obj(&[("foo", "a"), ("bar", "b")]);
+        assert!(numeric_object_to_array(&v).is_none());
+    }
+
+    #[test]
+    fn basic_conversion() {
+        // na01: {"0":"a","1":"b"} → ["a","b"]
+        let v = make_obj(&[("0", "a"), ("1", "b")]);
+        let arr = numeric_object_to_array(&v).expect("should convert");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(extract_raw(&arr[0]), "a");
+        assert_eq!(extract_raw(&arr[1]), "b");
+    }
+
+    #[test]
+    fn non_int_keys_ignored() {
+        // na05: {"0":"a","foo":"b","1":"c"} → ["a","c"]
+        let v = make_obj(&[("0", "a"), ("foo", "b"), ("1", "c")]);
+        let arr = numeric_object_to_array(&v).expect("should convert");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(extract_raw(&arr[0]), "a");
+        assert_eq!(extract_raw(&arr[1]), "c");
+    }
+
+    #[test]
+    fn gaps_compacted() {
+        // na06: {"0":"a","2":"c"} → ["a","c"] (no slot for index 1)
+        let v = make_obj(&[("0", "a"), ("2", "c")]);
+        let arr = numeric_object_to_array(&v).expect("should convert");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(extract_raw(&arr[0]), "a");
+        assert_eq!(extract_raw(&arr[1]), "c");
+    }
+
+    #[test]
+    fn sorted_by_key() {
+        // na07: {"1":"b","0":"a"} → ["a","b"]
+        let v = make_obj(&[("1", "b"), ("0", "a")]);
+        let arr = numeric_object_to_array(&v).expect("should convert");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(extract_raw(&arr[0]), "a");
+        assert_eq!(extract_raw(&arr[1]), "b");
+    }
+
+    #[test]
+    fn leading_zero_rejected_only_canonical_zero_eligible() {
+        // na08: {"00":"a","0":"b"} → ["b"] (only "0" eligible)
+        let v = make_obj(&[("00", "a"), ("0", "b")]);
+        let arr = numeric_object_to_array(&v).expect("should convert");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(extract_raw(&arr[0]), "b");
+    }
+
+    #[test]
+    fn negative_key_rejected() {
+        // na09: {"-1":"a","0":"b"} → ["b"]
+        let v = make_obj(&[("-1", "a"), ("0", "b")]);
+        let arr = numeric_object_to_array(&v).expect("should convert");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(extract_raw(&arr[0]), "b");
+    }
+
+    #[test]
+    fn plus_sign_rejected() {
+        // na10a: {"+1":"a","0":"b"} → ["b"]
+        let v = make_obj(&[("+1", "a"), ("0", "b")]);
+        let arr = numeric_object_to_array(&v).expect("should convert");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(extract_raw(&arr[0]), "b");
+    }
+
+    #[test]
+    fn minus_zero_rejected() {
+        // na10b: {"-0":"a","0":"b"} → ["b"]
+        let v = make_obj(&[("-0", "a"), ("0", "b")]);
+        let arr = numeric_object_to_array(&v).expect("should convert");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(extract_raw(&arr[0]), "b");
+    }
+
+    #[test]
+    fn overflow_rejected() {
+        // na11: {"99999999999":"a","0":"b"} → ["b"]
+        let v = make_obj(&[("99999999999", "a"), ("0", "b")]);
+        let arr = numeric_object_to_array(&v).expect("should convert");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(extract_raw(&arr[0]), "b");
+    }
+
+    fn extract_raw(v: &HoconValue) -> &str {
+        match v {
+            HoconValue::Scalar(sv) => &sv.raw,
+            _ => panic!("expected scalar, got {:?}", v),
+        }
+    }
+}

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -350,9 +350,7 @@ impl<'a> SubstitutionResolver<'a> {
 fn join_pair(left: HoconValue, right: HoconValue) -> Result<HoconValue, ResolveError> {
     match (left, right) {
         // Object + Object → deep-merge (S10.3)
-        (HoconValue::Object(lf), HoconValue::Object(rf)) => {
-            Ok(deep_merge_hocon_objects(lf, rf))
-        }
+        (HoconValue::Object(lf), HoconValue::Object(rf)) => Ok(deep_merge_hocon_objects(lf, rf)),
 
         // Array + Object → S15.3: try numeric-keyed object conversion
         (HoconValue::Array(mut arr), obj @ HoconValue::Object(_)) => {

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -255,68 +255,59 @@ impl<'a> SubstitutionResolver<'a> {
             return Ok(resolved.into_iter().next().unwrap().0);
         }
 
-        // Object concatenation — only skip parser-synthesized separators (not user-authored strings).
-        if resolved
+        // Pairwise left-to-right fold (NORMATIVE per spec §"Multi-piece concat is
+        // left-to-right pairwise").
+        //
+        // Why a fold instead of a single-pass classify-then-dispatch loop:
+        //   A single-pass loop that checks "any array present → array branch" converts
+        //   each Object element independently. When adjacent Objects have overlapping
+        //   numeric keys, independent conversion preserves both values (wrong). The
+        //   spec requires Object+Object to merge first (so the later key wins), then
+        //   convert when a list partner is reached. A pairwise fold matches Lightbend's
+        //   ConfigConcatenation.consolidate semantics exactly.
+        //
+        // Separator handling:
+        //   Separators (parser-synthesized whitespace tokens) are kept in the sequence
+        //   but join_pair treats them as pass-through scalars for non-object/array
+        //   concat. For object and array concat, separators are skipped (is_sep=true).
+        //   This preserves the original behaviour where whitespace contributes to
+        //   string concatenation (e.g. "foo bar") but is discarded for structured types.
+        //
+        // join_pair type-pair cases (separators are folded as scalars):
+        //   Object + Object → deep-merge, skip is_sep between them (S10.3)
+        //   Array  + Object → numeric_object_to_array; if Some concat arrays (S15.3)
+        //   Object + Array  → numeric_object_to_array; if Some concat arrays (S15.3)
+        //   Array  + Array  → array concat
+        //   Scalar + *      → string concat (separator whitespace contributes its raw value)
+
+        // Determine whether we are in an object/array concat (where separators are
+        // skipped) or a scalar concat (where separators contribute their text).
+        let has_structured = resolved
             .iter()
-            .all(|(v, is_sep)| matches!(v, HoconValue::Object(_)) || *is_sep)
-            && resolved
-                .iter()
-                .any(|(v, _)| matches!(v, HoconValue::Object(_)))
-        {
-            let mut merged = IndexMap::new();
-            for (v, is_sep) in resolved {
-                if is_sep {
-                    continue; // skip parser-synthesized separator whitespace
-                }
-                if let HoconValue::Object(fields) = v {
-                    for (k, val) in fields {
-                        if let (
-                            Some(HoconValue::Object(existing)),
-                            HoconValue::Object(new_fields),
-                        ) = (merged.get(&k).cloned(), &val)
-                        {
-                            merged
-                                .insert(k, deep_merge_hocon_objects(existing, new_fields.clone()));
-                        } else {
-                            merged.insert(k, val);
-                        }
-                    }
-                }
+            .any(|(v, _)| matches!(v, HoconValue::Object(_) | HoconValue::Array(_)));
+
+        if has_structured {
+            // Object/array concat: filter separators first, then pairwise fold.
+            let non_sep: Vec<HoconValue> = resolved
+                .into_iter()
+                .filter(|(_, is_sep)| !is_sep)
+                .map(|(v, _)| v)
+                .collect();
+
+            if non_sep.is_empty() {
+                return Ok(HoconValue::Scalar(ScalarValue::null()));
             }
-            return Ok(HoconValue::Object(merged));
+            if non_sep.len() == 1 {
+                return Ok(non_sep.into_iter().next().unwrap());
+            }
+
+            let mut iter = non_sep.into_iter();
+            let first = iter.next().unwrap();
+            return iter.try_fold(first, join_pair).map(Ok)?;
         }
 
-        // Array concatenation (S15.3: numerically-indexed objects convert to array
-        // when joined with a literal array partner).
-        if resolved
-            .iter()
-            .any(|(v, _)| matches!(v, HoconValue::Array(_)))
-        {
-            let mut items = Vec::new();
-            for (v, is_sep) in resolved {
-                if is_sep {
-                    // Skip parser-synthesized separator whitespace (same as object-concat branch).
-                    continue;
-                }
-                match v {
-                    HoconValue::Array(arr) => items.extend(arr),
-                    HoconValue::Object(_) => {
-                        // S15.3: attempt numeric-keyed object → array conversion.
-                        // If it succeeds, extend the result with the converted elements.
-                        // If it fails (empty / no eligible int keys), push the object as-is
-                        // (preserving the existing "mixed concat" error-path behaviour).
-                        match numeric_object_to_array(&v) {
-                            Some(converted) => items.extend(converted),
-                            None => items.push(v),
-                        }
-                    }
-                    other => items.push(other),
-                }
-            }
-            return Ok(HoconValue::Array(items));
-        }
-
-        // String concatenation
+        // Scalar-only concat: include separators so whitespace contributes to the result
+        // (e.g., "foo bar" where the space token is a separator).
         let s: String = resolved.iter().map(|(v, _)| stringify_value(v)).collect();
         Ok(HoconValue::Scalar(ScalarValue::string(s)))
     }
@@ -339,6 +330,79 @@ impl<'a> SubstitutionResolver<'a> {
             items.push(e);
         }
         Ok(HoconValue::Array(items))
+    }
+}
+
+/// Pairwise join for the left-to-right concat fold.
+///
+/// Implements the `join_pair(left, right)` spec pseudocode:
+/// - Object + Object → deep-merge (S10.3)
+/// - Array  + Object → attempt numeric_object_to_array; if Some → array-array concat
+/// - Object + Array  → attempt numeric_object_to_array; if Some → array-array concat
+/// - Array  + Array  → array-array concat
+/// - other pairs     → string concat (scalars coerced to string)
+///
+/// The `Result` wrapper exists so it can be used directly with `try_fold`.
+/// This function currently never produces an `Err` — type-mismatch cases (e.g.
+/// a non-convertible Object next to an Array) push the unconverted Object into
+/// the Array, which preserves the existing "mixed concat" behaviour rather than
+/// erroring, consistent with how the original single-pass loop behaved.
+fn join_pair(left: HoconValue, right: HoconValue) -> Result<HoconValue, ResolveError> {
+    match (left, right) {
+        // Object + Object → deep-merge (S10.3)
+        (HoconValue::Object(lf), HoconValue::Object(rf)) => {
+            Ok(deep_merge_hocon_objects(lf, rf))
+        }
+
+        // Array + Object → S15.3: try numeric-keyed object conversion
+        (HoconValue::Array(mut arr), obj @ HoconValue::Object(_)) => {
+            match numeric_object_to_array(&obj) {
+                Some(converted) => arr.extend(converted),
+                None => arr.push(obj),
+            }
+            Ok(HoconValue::Array(arr))
+        }
+
+        // Object + Array → S15.3 symmetric: try numeric-keyed object conversion
+        (obj @ HoconValue::Object(_), HoconValue::Array(right_arr)) => {
+            match numeric_object_to_array(&obj) {
+                Some(mut converted) => {
+                    converted.extend(right_arr);
+                    Ok(HoconValue::Array(converted))
+                }
+                None => {
+                    let mut arr = vec![obj];
+                    arr.extend(right_arr);
+                    Ok(HoconValue::Array(arr))
+                }
+            }
+        }
+
+        // Array + Array → array concat
+        (HoconValue::Array(mut left_arr), HoconValue::Array(right_arr)) => {
+            left_arr.extend(right_arr);
+            Ok(HoconValue::Array(left_arr))
+        }
+
+        // Array + Scalar → push scalar into array (preserves prior single-pass behaviour
+        // where scalar elements were appended to an in-progress array concat).
+        (HoconValue::Array(mut arr), scalar) => {
+            arr.push(scalar);
+            Ok(HoconValue::Array(arr))
+        }
+
+        // Scalar + Array → prepend array to scalar (push scalar as first element).
+        (scalar, HoconValue::Array(right_arr)) => {
+            let mut arr = vec![scalar];
+            arr.extend(right_arr);
+            Ok(HoconValue::Array(arr))
+        }
+
+        // Scalar pairs → string concat
+        (left, right) => {
+            let s = format!("{}{}", stringify_value(&left), stringify_value(&right));
+            Ok(HoconValue::Scalar(ScalarValue::string(s)))
+        }
     }
 }
 

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -1,4 +1,5 @@
 use crate::error::ResolveError;
+use crate::numeric_array::numeric_object_to_array;
 use crate::value::{HoconValue, ScalarValue};
 use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
@@ -285,15 +286,30 @@ impl<'a> SubstitutionResolver<'a> {
             return Ok(HoconValue::Object(merged));
         }
 
-        // Array concatenation
+        // Array concatenation (S15.3: numerically-indexed objects convert to array
+        // when joined with a literal array partner).
         if resolved
             .iter()
             .any(|(v, _)| matches!(v, HoconValue::Array(_)))
         {
             let mut items = Vec::new();
-            for (v, _) in resolved {
+            for (v, is_sep) in resolved {
+                if is_sep {
+                    // Skip parser-synthesized separator whitespace (same as object-concat branch).
+                    continue;
+                }
                 match v {
                     HoconValue::Array(arr) => items.extend(arr),
+                    HoconValue::Object(_) => {
+                        // S15.3: attempt numeric-keyed object → array conversion.
+                        // If it succeeds, extend the result with the converted elements.
+                        // If it fails (empty / no eligible int keys), push the object as-is
+                        // (preserving the existing "mixed concat" error-path behaviour).
+                        match numeric_object_to_array(&v) {
+                            Some(converted) => items.extend(converted),
+                            None => items.push(v),
+                        }
+                    }
                     other => items.push(other),
                 }
             }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -474,9 +474,9 @@ impl<'de> ::serde::de::SeqAccess<'de> for HoconSeqAccess<'de> {
 // ---------------------------------------------------------------------------
 
 pub(crate) struct HoconOwnedSeqAccess {
-    /// Items stored in reverse so we can pop from the front efficiently.
+    /// Items in their original (forward) order.
     items: Vec<HoconValue>,
-    /// Current index into items (forward iteration).
+    /// Current index into items; advances on each `next_element_seed` call.
     idx: usize,
 }
 
@@ -539,12 +539,8 @@ impl<'de> ::serde::Deserializer<'de> for OwnedHoconDeserializer {
                 }
                 ScalarType::String => visitor.visit_string(sv.raw),
             },
-            HoconValue::Object(map) => {
-                visitor.visit_map(OwnedHoconMapAccess::new(map))
-            }
-            HoconValue::Array(items) => {
-                visitor.visit_seq(HoconOwnedSeqAccess::new(items))
-            }
+            HoconValue::Object(map) => visitor.visit_map(OwnedHoconMapAccess::new(map)),
+            HoconValue::Array(items) => visitor.visit_seq(HoconOwnedSeqAccess::new(items)),
         }
     }
 
@@ -718,6 +714,22 @@ impl<'de> ::serde::Deserializer<'de> for OwnedHoconDeserializer {
         self.deserialize_map(visitor)
     }
 
+    fn deserialize_enum<V: ::serde::de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        // Mirror HoconDeserializer::deserialize_enum (line ~345) so that converted
+        // numeric-keyed-object → array elements can deserialize as string enum variants.
+        match self.value {
+            HoconValue::Scalar(sv) => visitor.visit_enum(sv.raw.as_str().into_deserializer()),
+            other => Err(DeserializeError {
+                message: format!("expected string for enum variant, got {:?}", other),
+            }),
+        }
+    }
+
     fn deserialize_identifier<V: ::serde::de::Visitor<'de>>(
         self,
         visitor: V,
@@ -733,7 +745,7 @@ impl<'de> ::serde::Deserializer<'de> for OwnedHoconDeserializer {
     }
 
     ::serde::forward_to_deserialize_any! {
-        i8 i16 i32 u8 u16 u32 f32 char bytes byte_buf unit_struct enum
+        i8 i16 i32 u8 u16 u32 f32 char bytes byte_buf unit_struct
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,3 +1,4 @@
+use crate::numeric_array::numeric_object_to_array;
 use crate::value::{HoconValue, ScalarType, ScalarValue};
 use indexmap::IndexMap;
 use std::fmt;
@@ -287,6 +288,16 @@ impl<'de> ::serde::Deserializer<'de> for HoconDeserializer<'de> {
     ) -> Result<V::Value, Self::Error> {
         match self.value {
             HoconValue::Array(items) => visitor.visit_seq(HoconSeqAccess::new(items)),
+            // S15 §"Accessor behaviour" L160-161: every typed-array accessor must invoke
+            // numeric_object_to_array. If the object has at least one eligible integer key,
+            // convert and deserialize as a sequence; otherwise fall through to the type-mismatch
+            // error so serde receives a meaningful message.
+            obj @ HoconValue::Object(_) => match numeric_object_to_array(obj) {
+                Some(items) => visitor.visit_seq(HoconOwnedSeqAccess::new(items)),
+                None => Err(DeserializeError {
+                    message: format!("expected array, got {:?}", obj),
+                }),
+            },
             other => Err(DeserializeError {
                 message: format!("expected array, got {:?}", other),
             }),
@@ -454,5 +465,319 @@ impl<'de> ::serde::de::SeqAccess<'de> for HoconSeqAccess<'de> {
             Some(value) => seed.deserialize(HoconDeserializer::new(value)).map(Some),
             None => Ok(None),
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OwnedSeqAccess — for sequences built from owned Vec<HoconValue>
+// (used when numeric_object_to_array produces a fresh Vec)
+// ---------------------------------------------------------------------------
+
+pub(crate) struct HoconOwnedSeqAccess {
+    /// Items stored in reverse so we can pop from the front efficiently.
+    items: Vec<HoconValue>,
+    /// Current index into items (forward iteration).
+    idx: usize,
+}
+
+impl HoconOwnedSeqAccess {
+    fn new(items: Vec<HoconValue>) -> Self {
+        Self { items, idx: 0 }
+    }
+}
+
+impl<'de> ::serde::de::SeqAccess<'de> for HoconOwnedSeqAccess {
+    type Error = DeserializeError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: ::serde::de::DeserializeSeed<'de>,
+    {
+        if self.idx >= self.items.len() {
+            return Ok(None);
+        }
+        // Clone the value at idx so OwnedHoconDeserializer can own it.
+        // The clone is bounded by the element count (typically small: O(n) where n
+        // is the number of numeric keys in the source object).
+        let value = self.items[self.idx].clone();
+        self.idx += 1;
+        seed.deserialize(OwnedHoconDeserializer { value }).map(Some)
+    }
+}
+
+/// A variant of HoconDeserializer that owns its value (no lifetime parameter).
+/// Used exclusively by HoconOwnedSeqAccess to avoid the lifetime issue when
+/// deserializing from an owned Vec<HoconValue>.
+///
+/// This duplicates some deserialize methods from HoconDeserializer; the
+/// duplication is justified by the need to avoid self-referential borrows.
+struct OwnedHoconDeserializer {
+    value: HoconValue,
+}
+
+impl<'de> ::serde::Deserializer<'de> for OwnedHoconDeserializer {
+    type Error = DeserializeError;
+
+    fn deserialize_any<V: ::serde::de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self.value {
+            HoconValue::Scalar(sv) => match sv.value_type {
+                ScalarType::Null => visitor.visit_unit(),
+                ScalarType::Boolean => visitor.visit_bool(sv.raw == "true"),
+                ScalarType::Number => {
+                    if !sv.raw.contains('.') && !sv.raw.contains('e') && !sv.raw.contains('E') {
+                        if let Ok(n) = sv.raw.parse::<i64>() {
+                            return visitor.visit_i64(n);
+                        }
+                    }
+                    if let Ok(f) = sv.raw.parse::<f64>() {
+                        return visitor.visit_f64(f);
+                    }
+                    visitor.visit_string(sv.raw)
+                }
+                ScalarType::String => visitor.visit_string(sv.raw),
+            },
+            HoconValue::Object(map) => {
+                visitor.visit_map(OwnedHoconMapAccess::new(map))
+            }
+            HoconValue::Array(items) => {
+                visitor.visit_seq(HoconOwnedSeqAccess::new(items))
+            }
+        }
+    }
+
+    fn deserialize_string<V: ::serde::de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self.value {
+            HoconValue::Scalar(sv) => visitor.visit_string(sv.raw),
+            other => Err(DeserializeError {
+                message: format!("expected string, got {:?}", other),
+            }),
+        }
+    }
+
+    fn deserialize_str<V: ::serde::de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_string(visitor)
+    }
+
+    fn deserialize_bool<V: ::serde::de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self.value {
+            HoconValue::Scalar(sv) => match sv.raw.to_lowercase().as_str() {
+                "true" | "yes" | "on" => visitor.visit_bool(true),
+                "false" | "no" | "off" => visitor.visit_bool(false),
+                _ => Err(DeserializeError {
+                    message: format!("cannot coerce \"{}\" to bool", sv.raw),
+                }),
+            },
+            other => Err(DeserializeError {
+                message: format!("expected bool, got {:?}", other),
+            }),
+        }
+    }
+
+    fn deserialize_i64<V: ::serde::de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self.value {
+            HoconValue::Scalar(sv) => {
+                let n: i64 = parse_int_from_scalar(&sv, "i64")?;
+                visitor.visit_i64(n)
+            }
+            other => Err(DeserializeError {
+                message: format!("expected i64, got {:?}", other),
+            }),
+        }
+    }
+
+    fn deserialize_u64<V: ::serde::de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self.value {
+            HoconValue::Scalar(sv) => {
+                let n: u64 = parse_int_from_scalar(&sv, "u64")?;
+                visitor.visit_u64(n)
+            }
+            other => Err(DeserializeError {
+                message: format!("expected u64, got {:?}", other),
+            }),
+        }
+    }
+
+    fn deserialize_f64<V: ::serde::de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self.value {
+            HoconValue::Scalar(sv) => {
+                let f: f64 = sv.raw.parse().map_err(|_| DeserializeError {
+                    message: format!("cannot parse \"{}\" as f64", sv.raw),
+                })?;
+                visitor.visit_f64(f)
+            }
+            other => Err(DeserializeError {
+                message: format!("expected f64, got {:?}", other),
+            }),
+        }
+    }
+
+    fn deserialize_seq<V: ::serde::de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self.value {
+            HoconValue::Array(items) => visitor.visit_seq(HoconOwnedSeqAccess::new(items)),
+            obj @ HoconValue::Object(_) => match numeric_object_to_array(&obj) {
+                Some(items) => visitor.visit_seq(HoconOwnedSeqAccess::new(items)),
+                None => Err(DeserializeError {
+                    message: format!("expected array, got {:?}", obj),
+                }),
+            },
+            other => Err(DeserializeError {
+                message: format!("expected array, got {:?}", other),
+            }),
+        }
+    }
+
+    fn deserialize_option<V: ::serde::de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match &self.value {
+            HoconValue::Scalar(sv) if sv.value_type == ScalarType::Null => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
+    }
+
+    fn deserialize_unit<V: ::serde::de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self.value {
+            HoconValue::Scalar(sv) if sv.value_type == ScalarType::Null => visitor.visit_unit(),
+            other => Err(DeserializeError {
+                message: format!("expected null/unit, got {:?}", other),
+            }),
+        }
+    }
+
+    fn deserialize_newtype_struct<V: ::serde::de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_tuple<V: ::serde::de::Visitor<'de>>(
+        self,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V: ::serde::de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V: ::serde::de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        match self.value {
+            HoconValue::Object(map) => visitor.visit_map(OwnedHoconMapAccess::new(map)),
+            other => Err(DeserializeError {
+                message: format!("expected object, got {:?}", other),
+            }),
+        }
+    }
+
+    fn deserialize_struct<V: ::serde::de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_identifier<V: ::serde::de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_string(visitor)
+    }
+
+    fn deserialize_ignored_any<V: ::serde::de::Visitor<'de>>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        visitor.visit_unit()
+    }
+
+    ::serde::forward_to_deserialize_any! {
+        i8 i16 i32 u8 u16 u32 f32 char bytes byte_buf unit_struct enum
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OwnedMapAccess — MapAccess that owns its IndexMap (used by OwnedHoconDeserializer)
+// ---------------------------------------------------------------------------
+
+pub(crate) struct OwnedHoconMapAccess {
+    iter: indexmap::map::IntoIter<String, HoconValue>,
+    current_value: Option<HoconValue>,
+}
+
+impl OwnedHoconMapAccess {
+    fn new(map: IndexMap<String, HoconValue>) -> Self {
+        Self {
+            iter: map.into_iter(),
+            current_value: None,
+        }
+    }
+}
+
+impl<'de> ::serde::de::MapAccess<'de> for OwnedHoconMapAccess {
+    type Error = DeserializeError;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: ::serde::de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((key, value)) => {
+                self.current_value = Some(value);
+                seed.deserialize(key.into_deserializer()).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: ::serde::de::DeserializeSeed<'de>,
+    {
+        let value = self.current_value.take().ok_or_else(|| DeserializeError {
+            message: "next_value_seed called before next_key_seed".into(),
+        })?;
+        seed.deserialize(OwnedHoconDeserializer { value })
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1078,34 +1078,9 @@ fn s13_13_optional_undefined_in_string_concat_is_empty() {
 
 // --- S13.14: optional undefined in array/object concat (spec L637) --------------
 // Array: [1] ${?missing} [2] → [1, 2]
-// BUG: rs.hocon currently produces [1, " ", " ", 2] (whitespace strings).
+// Fixed as a side effect of the S15.3 array-concat separator-skip fix (fix/s15-numeric-obj-array).
+// The is_sep whitespace tokens are now discarded in the array-concat branch, eliminating artefacts.
 #[test]
-fn s13_14_optional_undefined_in_array_concat_pin() {
-    let cfg = hocon::parse_with_env("x = [1] ${?missing} [2]", &std::collections::HashMap::new())
-        .expect("parse failed");
-    let items = cfg.get_list("x").unwrap();
-    // [pin] snapshot current (broken) shape: numeric 1, two whitespace scalar
-    // artefacts, numeric 2. Asserting values (not just length) catches partial
-    // fixes that change the count without removing the artefacts.
-    assert_eq!(
-        items.len(),
-        4,
-        "[pin] array concat must currently produce 4 elements"
-    );
-    assert!(matches!(&items[0], hocon::HoconValue::Scalar(s) if s.raw == "1"));
-    assert!(
-        matches!(&items[1], hocon::HoconValue::Scalar(s) if s.value_type == hocon::ScalarType::String),
-        "[pin] items[1] must be a whitespace scalar artefact"
-    );
-    assert!(
-        matches!(&items[2], hocon::HoconValue::Scalar(s) if s.value_type == hocon::ScalarType::String),
-        "[pin] items[2] must be a whitespace scalar artefact"
-    );
-    assert!(matches!(&items[3], hocon::HoconValue::Scalar(s) if s.raw == "2"));
-}
-
-#[test]
-#[ignore = "spec violation: optional undefined in array concat must yield empty array per HOCON L637, see #75"]
 fn s13_14_optional_undefined_in_array_concat_spec() {
     let cfg = hocon::parse_with_env("x = [1] ${?missing} [2]", &std::collections::HashMap::new())
         .expect("parse failed");
@@ -1237,24 +1212,10 @@ fn s14b_1_array_root_include_is_error() {
 
 // --- S15.1: numeric-keyed object → array when array context (spec L1191) ----------
 //
-// [pin] rs.hocon does not implement numeric-indexed object to array conversion.
-// get_list() on {"0":"a","1":"b"} currently errors with "expected Array".
-#[test]
-fn s15_1_num_indexed_obj_to_array_pin() {
-    let cfg = hocon::parse_with_env(r#"v = {"0":"a","1":"b"}"#, &HashMap::new()).unwrap();
-    // [pin] Buggy: get_list errors with "expected Array" because no conversion path
-    // exists. Asserting the *specific* error message — not just `is_err()` — so a
-    // future fix that errors for an unrelated reason (e.g. validator change) breaks
-    // this pin instead of silently passing.
-    let err = cfg.get_list("v").unwrap_err();
-    assert!(
-        err.message.contains("expected Array"),
-        "[pin] get_list must currently error with \"expected Array\", got {:?}",
-        err
-    );
-}
-
-#[ignore = "spec violation: numeric-indexed object must convert to array when array type requested per HOCON L1191, see #79"]
+// Implemented in fix/s15-numeric-obj-array (closes #79).
+// Helper: src/numeric_array.rs::numeric_object_to_array
+// Accessor site: src/config.rs::Config::get_list
+// Extended fixture tests: tests/s15_fixtures.rs
 #[test]
 fn s15_1_num_indexed_obj_to_array_spec() {
     let cfg = hocon::parse_with_env(r#"v = {"0":"a","1":"b"}"#, &HashMap::new()).unwrap();
@@ -1274,26 +1235,8 @@ fn s15_1_num_indexed_obj_to_array_spec() {
 
 // --- S15.2: conversion is lazy — only when array type is requested (spec L1204) ---
 //
-// [pin] No lazy conversion is implemented. get_list on a numeric-keyed object errors.
-#[test]
-fn s15_2_conversion_is_lazy_pin() {
-    let cfg = hocon::parse_with_env(r#"v = {"0":"a","1":"b"}"#, &HashMap::new()).unwrap();
-    // [pin] Buggy: get_config succeeds (object stays object) but get_list fails with
-    // "expected Array" (no conversion path). Tight assertion on the specific error
-    // message so an unrelated regression flips this pin.
-    assert!(
-        cfg.get_config("v").is_ok(),
-        "[pin] get_config must succeed — object is not eagerly converted"
-    );
-    let err = cfg.get_list("v").unwrap_err();
-    assert!(
-        err.message.contains("expected Array"),
-        "[pin] get_list must currently error with \"expected Array\", got {:?}",
-        err
-    );
-}
-
-#[ignore = "spec violation: numeric-indexed object must be convertible to array lazily when array type is requested per HOCON L1204, see #79"]
+// Laziness is preserved: get_config/get on a numeric-keyed object returns the object
+// as-is; conversion only triggers from get_list (accessor-time, not parse/resolve time).
 #[test]
 fn s15_2_conversion_is_lazy_spec() {
     let cfg = hocon::parse_with_env(r#"v = {"0":"a","1":"b"}"#, &HashMap::new()).unwrap();
@@ -1311,36 +1254,8 @@ fn s15_2_conversion_is_lazy_spec() {
 
 // --- S15.3: conversion in concatenation when list expected (spec L1210) -----------
 //
-// Spec: when a numerically-indexed object participates in concatenation where a
-// list is expected (e.g. adjacent to a literal array), it must convert to its
-// array form and flatten in. Probe shows rs.hocon currently puts the object
-// into the resulting array as-is (no conversion), plus a whitespace artefact —
-// pin asserts the buggy element layout so a future fix flips the assertion.
-#[test]
-fn s15_3_conversion_in_concatenation_pin() {
-    // Real concatenation context: literal array adjacent to a substitution-resolved
-    // numeric-keyed object. Spec L1210 says obj must convert to ["x","y"], producing
-    // ["a","x","y"]. Probe (2026-05-12) shows we get 3 elements but the last is the
-    // un-converted Object, not the flattened strings.
-    let cfg = hocon::parse_with_env(
-        r#"obj = {"0":"x","1":"y"}
-arr = [a] ${obj}"#,
-        &HashMap::new(),
-    )
-    .unwrap();
-    let items = cfg
-        .get_list("arr")
-        .expect("concat produces an array (list literal present)");
-    // [pin] Buggy: last element is the un-converted object, not flattened strings.
-    let last = items.last().expect("non-empty array");
-    assert!(
-        matches!(last, hocon::HoconValue::Object(_)),
-        "[pin] last element must currently be the un-converted Object, got {:?}",
-        last
-    );
-}
-
-#[ignore = "spec violation: numeric-indexed object must convert to array in concatenation when list expected per HOCON L1210, see #79"]
+// Resolver pairwise-join site: src/resolver/substitution_resolver.rs::resolve_concat
+// When one side is Array and the other is Object, numeric_object_to_array fires.
 #[test]
 fn s15_3_conversion_in_concatenation_spec() {
     let cfg = hocon::parse_with_env(
@@ -1369,10 +1284,8 @@ arr = [a] ${obj}"#,
 
 // --- S15.4: empty object NOT converted (spec L1212) --------------------------------
 //
-// The spec says: "the conversion should not occur if the object is empty or has no
-// keys which parse as positive integers." Verified: get_list on {} currently errors —
-// which is the correct result (no conversion is done). Since the feature is absent,
-// this case happens to match spec intent. Marked ✅ with a note.
+// numeric_object_to_array returns None for empty objects; get_list then errors.
+// Now backed by explicit empty-guard rather than incidental pass.
 #[test]
 fn s15_4_empty_object_not_converted() {
     let cfg = hocon::parse_with_env(r#"v = {}"#, &HashMap::new()).unwrap();
@@ -1386,21 +1299,7 @@ fn s15_4_empty_object_not_converted() {
 
 // --- S15.5: non-integer keys ignored during conversion (spec L1214) ----------------
 //
-// [pin] Conversion is not implemented at all. Test pins the "no conversion" behavior.
-#[test]
-fn s15_5_non_integer_keys_ignored_pin() {
-    let cfg = hocon::parse_with_env(r#"v = {"0":"a","foo":"b","1":"c"}"#, &HashMap::new()).unwrap();
-    // [pin] Buggy: no conversion; get_list errors with "expected Array". "foo" key
-    // is not dropped on array access. Tight assertion on the specific error message.
-    let err = cfg.get_list("v").unwrap_err();
-    assert!(
-        err.message.contains("expected Array"),
-        "[pin] get_list must currently error with \"expected Array\", got {:?}",
-        err
-    );
-}
-
-#[ignore = "spec violation: non-integer keys must be ignored when converting numeric-indexed object to array per HOCON L1214, see #79"]
+// Eligible filter in numeric_object_to_array: only ^(0|[1-9][0-9]*)$ keys count.
 #[test]
 fn s15_5_non_integer_keys_ignored_spec() {
     let cfg = hocon::parse_with_env(r#"v = {"0":"a","foo":"b","1":"c"}"#, &HashMap::new()).unwrap();
@@ -1417,21 +1316,7 @@ fn s15_5_non_integer_keys_ignored_spec() {
 
 // --- S15.6: missing indices compacted in resulting array (spec L1216) --------------
 //
-// [pin] Conversion not implemented; test pins "no conversion" behavior.
-#[test]
-fn s15_6_missing_indices_compacted_pin() {
-    // Keys "0" and "2" — index "1" is absent. Result must be ["a","c"] (2 elements, 0→a, 1→c).
-    let cfg = hocon::parse_with_env(r#"v = {"0":"a","2":"c"}"#, &HashMap::new()).unwrap();
-    // [pin] Buggy: get_list errors with "expected Array" — no conversion path.
-    let err = cfg.get_list("v").unwrap_err();
-    assert!(
-        err.message.contains("expected Array"),
-        "[pin] get_list must currently error with \"expected Array\", got {:?}",
-        err
-    );
-}
-
-#[ignore = "spec violation: missing integer indices must be compacted when converting object to array per HOCON L1216, see #79"]
+// Gaps are naturally eliminated by sorting eligible (key, value) pairs and projecting.
 #[test]
 fn s15_6_missing_indices_compacted_spec() {
     let cfg = hocon::parse_with_env(r#"v = {"0":"a","2":"c"}"#, &HashMap::new()).unwrap();
@@ -1447,21 +1332,7 @@ fn s15_6_missing_indices_compacted_spec() {
 
 // --- S15.7: sorted by integer key value (spec L1216) --------------------------------
 //
-// [pin] Conversion not implemented; test pins "no conversion" behavior.
-#[test]
-fn s15_7_sorted_by_key_value_pin() {
-    // Keys given out of order: "2" before "0". Sorted array must be ["a","c"].
-    let cfg = hocon::parse_with_env(r#"v = {"2":"c","0":"a"}"#, &HashMap::new()).unwrap();
-    // [pin] Buggy: get_list errors with "expected Array" — no conversion path.
-    let err = cfg.get_list("v").unwrap_err();
-    assert!(
-        err.message.contains("expected Array"),
-        "[pin] get_list must currently error with \"expected Array\", got {:?}",
-        err
-    );
-}
-
-#[ignore = "spec violation: conversion must sort by integer key value per HOCON L1216, see #79"]
+// numeric_object_to_array sorts eligible pairs by parsed integer before projecting.
 #[test]
 fn s15_7_sorted_by_key_value_spec() {
     let cfg = hocon::parse_with_env(r#"v = {"2":"c","0":"a"}"#, &HashMap::new()).unwrap();
@@ -1469,7 +1340,7 @@ fn s15_7_sorted_by_key_value_spec() {
         "out-of-order numeric-keyed object must convert sorted by integer key per HOCON L1216",
     );
     assert_eq!(items.len(), 2, "must produce 2-element array");
-    // After sort by integer key: 0→"a", 2→"c" → [\"a\",\"c\"]
+    // After sort by integer key: 0→"a", 2→"c" → ["a","c"]
     match &items[0] {
         hocon::HoconValue::Scalar(sv) => {
             assert_eq!(sv.raw, "a", "first element must be key-0's value")

--- a/tests/s15_fixtures.rs
+++ b/tests/s15_fixtures.rs
@@ -15,8 +15,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 fn fixture_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/testdata/hocon/numeric-obj-array")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/testdata/hocon/numeric-obj-array")
 }
 
 fn load_fixture(name: &str) -> hocon::Config {
@@ -71,7 +70,12 @@ fn na03a_concat_left_list_produces_three_elements() {
         .get_list("arr")
         .expect("na03a: getList on concat result must succeed");
     // Expected: ["a", "x", "y"]
-    assert_eq!(items.len(), 3, "na03a: expected [\"a\",\"x\",\"y\"] (3 elements), got {:?}", items);
+    assert_eq!(
+        items.len(),
+        3,
+        "na03a: expected [\"a\",\"x\",\"y\"] (3 elements), got {:?}",
+        items
+    );
     assert_eq!(scalar_raw(&items[0]), "a", "na03a: items[0] must be \"a\"");
     assert_eq!(scalar_raw(&items[1]), "x", "na03a: items[1] must be \"x\"");
     assert_eq!(scalar_raw(&items[2]), "y", "na03a: items[2] must be \"y\"");
@@ -86,7 +90,12 @@ fn na03b_concat_right_list_produces_three_elements() {
         .get_list("arr")
         .expect("na03b: getList on concat result must succeed");
     // Expected: ["x", "y", "a"]
-    assert_eq!(items.len(), 3, "na03b: expected [\"x\",\"y\",\"a\"] (3 elements), got {:?}", items);
+    assert_eq!(
+        items.len(),
+        3,
+        "na03b: expected [\"x\",\"y\",\"a\"] (3 elements), got {:?}",
+        items
+    );
     assert_eq!(scalar_raw(&items[0]), "x", "na03b: items[0] must be \"x\"");
     assert_eq!(scalar_raw(&items[1]), "y", "na03b: items[1] must be \"y\"");
     assert_eq!(scalar_raw(&items[2]), "a", "na03b: items[2] must be \"a\"");
@@ -104,7 +113,12 @@ fn na03c_concat_two_objs_produces_merged_object_or_list() {
         .get_list("arr")
         .expect("na03c: getList on merged numeric object must succeed via accessor conversion");
     // {"0":"x","1":"y","2":"z","3":"w"} → ["x","y","z","w"]
-    assert_eq!(items.len(), 4, "na03c: expected 4 elements, got {:?}", items);
+    assert_eq!(
+        items.len(),
+        4,
+        "na03c: expected 4 elements, got {:?}",
+        items
+    );
     assert_eq!(scalar_raw(&items[0]), "x");
     assert_eq!(scalar_raw(&items[1]), "y");
     assert_eq!(scalar_raw(&items[2]), "z");
@@ -124,7 +138,8 @@ fn na03d_concat_multi_piece_left_to_right_pairwise() {
         .get_list("arr")
         .expect("na03d: getList on multi-piece concat must succeed");
     assert_eq!(
-        items.len(), 5,
+        items.len(),
+        5,
         "na03d: NORMATIVE multi-piece: expected [\"x\",\"y\",\"z\",\"w\",\"a\"], got {:?}",
         items
     );
@@ -152,11 +167,16 @@ fn na03e_multi_piece_overlap_pairwise_fold() {
         .get_list("arr")
         .expect("na03e: getList on multi-piece overlap concat must succeed");
     assert_eq!(
-        items.len(), 3,
+        items.len(),
+        3,
         "na03e: NORMATIVE pairwise fold: expected [\"z\",\"y\",\"a\"], got {:?}",
         items
     );
-    assert_eq!(scalar_raw(&items[0]), "z", "na03e: items[0] must be \"z\" (later obj2 key wins)");
+    assert_eq!(
+        scalar_raw(&items[0]),
+        "z",
+        "na03e: items[0] must be \"z\" (later obj2 key wins)"
+    );
     assert_eq!(scalar_raw(&items[1]), "y", "na03e: items[1] must be \"y\"");
     assert_eq!(scalar_raw(&items[2]), "a", "na03e: items[2] must be \"a\"");
 }
@@ -180,7 +200,11 @@ fn na05_non_int_keys_ignored() {
     let items = cfg
         .get_list("items")
         .expect("na05: getList must succeed ignoring non-int key \"foo\"");
-    assert_eq!(items.len(), 2, "na05: only keys \"0\" and \"1\" are eligible");
+    assert_eq!(
+        items.len(),
+        2,
+        "na05: only keys \"0\" and \"1\" are eligible"
+    );
     assert_eq!(scalar_raw(&items[0]), "a");
     assert_eq!(scalar_raw(&items[1]), "c");
 }
@@ -193,7 +217,11 @@ fn na06_gaps_compacted() {
     let items = cfg
         .get_list("items")
         .expect("na06: getList on gapped keys must succeed");
-    assert_eq!(items.len(), 2, "na06: keys 0+2 → 2-element array (gap compacted)");
+    assert_eq!(
+        items.len(),
+        2,
+        "na06: keys 0+2 → 2-element array (gap compacted)"
+    );
     assert_eq!(scalar_raw(&items[0]), "a");
     assert_eq!(scalar_raw(&items[1]), "c");
 }

--- a/tests/s15_fixtures.rs
+++ b/tests/s15_fixtures.rs
@@ -1,0 +1,262 @@
+/// S15 cross-impl fixture tests.
+///
+/// Loads each xx.hocon fixture from testdata/hocon/numeric-obj-array/ and
+/// asserts `get_list` returns the spec-canonical o3co result.
+///
+/// Per-fixture notes:
+/// - na04: empty object → getList errors (S15.4 — not converted)
+/// - na08: leading-zero key rejected (E2 divergence from Lightbend)
+/// - na10a: leading-plus key rejected (E3 divergence)
+/// - na10b: leading-minus-zero key rejected (E4 divergence)
+/// - na12: no eligible keys → getList errors
+/// - na03a/na03b: concat-side conversion (tested after resolver wiring)
+/// - na03c/na03d: multi-piece concat (tested after resolver wiring)
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/testdata/hocon/numeric-obj-array")
+}
+
+fn load_fixture(name: &str) -> hocon::Config {
+    let path = fixture_dir().join(name);
+    hocon::parse_file_with_env(&path, &HashMap::new())
+        .unwrap_or_else(|e| panic!("failed to parse {}: {}", name, e))
+}
+
+fn scalar_raw(v: &hocon::HoconValue) -> &str {
+    match v {
+        hocon::HoconValue::Scalar(sv) => &sv.raw,
+        other => panic!("expected Scalar, got {:?}", other),
+    }
+}
+
+// ── na01: basic conversion (S15.1) ────────────────────────────────────────────
+
+#[test]
+fn na01_basic_get_list_returns_two_elements() {
+    let cfg = load_fixture("na01-basic.conf");
+    let items = cfg
+        .get_list("items")
+        .expect("na01: getList on {\"0\":\"a\",\"1\":\"b\"} must succeed");
+    assert_eq!(items.len(), 2, "na01: expected 2 elements");
+    assert_eq!(scalar_raw(&items[0]), "a", "na01: items[0] must be \"a\"");
+    assert_eq!(scalar_raw(&items[1]), "b", "na01: items[1] must be \"b\"");
+}
+
+// ── na02: laziness (S15.2) ────────────────────────────────────────────────────
+
+#[test]
+fn na02_lazy_get_config_still_works_and_get_list_also_works() {
+    let cfg = load_fixture("na02-lazy-getobject.conf");
+    // Object access must NOT be blocked even though the object is numeric-keyed
+    assert!(
+        cfg.get_config("items").is_ok(),
+        "na02: get_config must still succeed (laziness preserved)"
+    );
+    // List access must trigger conversion
+    let items = cfg
+        .get_list("items")
+        .expect("na02: getList must trigger lazy conversion");
+    assert_eq!(items.len(), 2, "na02: expected 2 elements after conversion");
+}
+
+// ── na03a: concat-time conversion, left-literal-array (S15.3) ─────────────────
+
+#[test]
+fn na03a_concat_left_list_produces_three_elements() {
+    let cfg = load_fixture("na03a-concat-left-list.conf");
+    let items = cfg
+        .get_list("arr")
+        .expect("na03a: getList on concat result must succeed");
+    // Expected: ["a", "x", "y"]
+    assert_eq!(items.len(), 3, "na03a: expected [\"a\",\"x\",\"y\"] (3 elements), got {:?}", items);
+    assert_eq!(scalar_raw(&items[0]), "a", "na03a: items[0] must be \"a\"");
+    assert_eq!(scalar_raw(&items[1]), "x", "na03a: items[1] must be \"x\"");
+    assert_eq!(scalar_raw(&items[2]), "y", "na03a: items[2] must be \"y\"");
+}
+
+// ── na03b: concat-time conversion, right-literal-array (S15.3 symmetric) ──────
+
+#[test]
+fn na03b_concat_right_list_produces_three_elements() {
+    let cfg = load_fixture("na03b-concat-right-list.conf");
+    let items = cfg
+        .get_list("arr")
+        .expect("na03b: getList on concat result must succeed");
+    // Expected: ["x", "y", "a"]
+    assert_eq!(items.len(), 3, "na03b: expected [\"x\",\"y\",\"a\"] (3 elements), got {:?}", items);
+    assert_eq!(scalar_raw(&items[0]), "x", "na03b: items[0] must be \"x\"");
+    assert_eq!(scalar_raw(&items[1]), "y", "na03b: items[1] must be \"y\"");
+    assert_eq!(scalar_raw(&items[2]), "a", "na03b: items[2] must be \"a\"");
+}
+
+// ── na03c: two-object concat NOT converted at concat time, BUT accessible as list ─
+
+#[test]
+fn na03c_concat_two_objs_produces_merged_object_or_list() {
+    // S10.3: obj+obj → deep-merge object. Accessor-side conversion then fires.
+    // Expected: arr as object {"0":"x","1":"y","2":"z","3":"w"}, but since
+    // all keys are numeric, get_list must succeed via accessor-time conversion.
+    let cfg = load_fixture("na03c-concat-two-objs.conf");
+    let items = cfg
+        .get_list("arr")
+        .expect("na03c: getList on merged numeric object must succeed via accessor conversion");
+    // {"0":"x","1":"y","2":"z","3":"w"} → ["x","y","z","w"]
+    assert_eq!(items.len(), 4, "na03c: expected 4 elements, got {:?}", items);
+    assert_eq!(scalar_raw(&items[0]), "x");
+    assert_eq!(scalar_raw(&items[1]), "y");
+    assert_eq!(scalar_raw(&items[2]), "z");
+    assert_eq!(scalar_raw(&items[3]), "w");
+}
+
+// ── na03d: multi-piece concat, left-to-right pairwise (NORMATIVE) ──────────────
+
+#[test]
+fn na03d_concat_multi_piece_left_to_right_pairwise() {
+    // obj1=${0:x,1:y}, obj2={2:z,3:w}, arr=${obj1} ${obj2} [a]
+    // Step 1: join(obj1, obj2) → {0:x,1:y,2:z,3:w} (object merge)
+    // Step 2: join(merged, [a]) → numericObjectToArray(merged) → [x,y,z,w] ++ [a]
+    // Expected: ["x","y","z","w","a"]
+    let cfg = load_fixture("na03d-concat-multi-piece.conf");
+    let items = cfg
+        .get_list("arr")
+        .expect("na03d: getList on multi-piece concat must succeed");
+    assert_eq!(
+        items.len(), 5,
+        "na03d: NORMATIVE multi-piece: expected [\"x\",\"y\",\"z\",\"w\",\"a\"], got {:?}",
+        items
+    );
+    assert_eq!(scalar_raw(&items[0]), "x");
+    assert_eq!(scalar_raw(&items[1]), "y");
+    assert_eq!(scalar_raw(&items[2]), "z");
+    assert_eq!(scalar_raw(&items[3]), "w");
+    assert_eq!(scalar_raw(&items[4]), "a");
+}
+
+// ── na04: empty object NOT converted (S15.4) ──────────────────────────────────
+
+#[test]
+fn na04_empty_object_not_converted() {
+    let cfg = load_fixture("na04-empty.conf");
+    assert!(
+        cfg.get_list("items").is_err(),
+        "na04: empty object must NOT convert — getList must return an error"
+    );
+}
+
+// ── na05: non-integer keys ignored (S15.5) ────────────────────────────────────
+
+#[test]
+fn na05_non_int_keys_ignored() {
+    let cfg = load_fixture("na05-non-int-keys.conf");
+    let items = cfg
+        .get_list("items")
+        .expect("na05: getList must succeed ignoring non-int key \"foo\"");
+    assert_eq!(items.len(), 2, "na05: only keys \"0\" and \"1\" are eligible");
+    assert_eq!(scalar_raw(&items[0]), "a");
+    assert_eq!(scalar_raw(&items[1]), "c");
+}
+
+// ── na06: gaps compacted (S15.6) ──────────────────────────────────────────────
+
+#[test]
+fn na06_gaps_compacted() {
+    let cfg = load_fixture("na06-gaps.conf");
+    let items = cfg
+        .get_list("items")
+        .expect("na06: getList on gapped keys must succeed");
+    assert_eq!(items.len(), 2, "na06: keys 0+2 → 2-element array (gap compacted)");
+    assert_eq!(scalar_raw(&items[0]), "a");
+    assert_eq!(scalar_raw(&items[1]), "c");
+}
+
+// ── na07: sort by integer key (S15.7) ─────────────────────────────────────────
+
+#[test]
+fn na07_sorted_by_key() {
+    let cfg = load_fixture("na07-sort.conf");
+    let items = cfg
+        .get_list("items")
+        .expect("na07: getList on reversed-key object must succeed");
+    assert_eq!(items.len(), 2, "na07: expected 2 elements");
+    assert_eq!(scalar_raw(&items[0]), "a", "na07: key 0 comes first");
+    assert_eq!(scalar_raw(&items[1]), "b", "na07: key 1 comes second");
+}
+
+// ── na08: leading-zero rejected (E2 — o3co divergence from Lightbend) ─────────
+
+#[test]
+fn na08_leading_zero_rejected_only_canonical_zero_eligible() {
+    // "00" is non-canonical → rejected. Only "0" is eligible → ["b"]
+    let cfg = load_fixture("na08-leading-zero.conf");
+    let items = cfg
+        .get_list("items")
+        .expect("na08: getList must succeed with only key \"0\" eligible");
+    assert_eq!(items.len(), 1, "na08: only \"0\" eligible → 1 element");
+    assert_eq!(scalar_raw(&items[0]), "b");
+}
+
+// ── na09: negative keys rejected (Lightbend-aligned) ─────────────────────────
+
+#[test]
+fn na09_negative_key_rejected() {
+    // "-1" rejected. Only "0" eligible → ["b"]
+    let cfg = load_fixture("na09-negative.conf");
+    let items = cfg
+        .get_list("items")
+        .expect("na09: getList must succeed with only key \"0\" eligible");
+    assert_eq!(items.len(), 1, "na09: only \"0\" eligible → 1 element");
+    assert_eq!(scalar_raw(&items[0]), "b");
+}
+
+// ── na10a: leading-plus rejected (E3 — o3co divergence from Lightbend) ────────
+
+#[test]
+fn na10a_plus_sign_rejected() {
+    // "+1" non-canonical → rejected. Only "0" eligible → ["b"]
+    let cfg = load_fixture("na10a-plus-sign.conf");
+    let items = cfg
+        .get_list("items")
+        .expect("na10a: getList must succeed with only key \"0\" eligible");
+    assert_eq!(items.len(), 1, "na10a: only \"0\" eligible → 1 element");
+    assert_eq!(scalar_raw(&items[0]), "b");
+}
+
+// ── na10b: minus-zero rejected (E4 — o3co divergence from Lightbend) ──────────
+
+#[test]
+fn na10b_minus_zero_rejected() {
+    // "-0" non-canonical → rejected. Only "0" eligible → ["b"]
+    let cfg = load_fixture("na10b-minus-zero.conf");
+    let items = cfg
+        .get_list("items")
+        .expect("na10b: getList must succeed with only key \"0\" eligible");
+    assert_eq!(items.len(), 1, "na10b: only \"0\" eligible → 1 element");
+    assert_eq!(scalar_raw(&items[0]), "b");
+}
+
+// ── na11: overflow rejected ───────────────────────────────────────────────────
+
+#[test]
+fn na11_overflow_key_rejected() {
+    // "99999999999" > i32::MAX → rejected. Only "0" eligible → ["b"]
+    let cfg = load_fixture("na11-overflow.conf");
+    let items = cfg
+        .get_list("items")
+        .expect("na11: getList must succeed with only key \"0\" eligible");
+    assert_eq!(items.len(), 1, "na11: only \"0\" eligible → 1 element");
+    assert_eq!(scalar_raw(&items[0]), "b");
+}
+
+// ── na12: no eligible keys → error ───────────────────────────────────────────
+
+#[test]
+fn na12_no_eligible_keys_errors() {
+    let cfg = load_fixture("na12-no-eligible.conf");
+    assert!(
+        cfg.get_list("items").is_err(),
+        "na12: no integer keys → getList must return an error"
+    );
+}

--- a/tests/s15_fixtures.rs
+++ b/tests/s15_fixtures.rs
@@ -135,6 +135,32 @@ fn na03d_concat_multi_piece_left_to_right_pairwise() {
     assert_eq!(scalar_raw(&items[4]), "a");
 }
 
+// ── na03e: multi-piece concat with overlapping keys (pairwise fold regression guard) ─────
+
+#[test]
+fn na03e_multi_piece_overlap_pairwise_fold() {
+    // obj1={"0":"x","1":"y"}, obj2={"0":"z"}, arr=${obj1} ${obj2} [a]
+    // Step 1: join(obj1, obj2) → object-merge → {"0":"z","1":"y"} (later "0" wins)
+    // Step 2: join(merged, [a]) → numericObjectToArray(merged) → ["z","y"] ++ ["a"]
+    // Expected: ["z","y","a"]
+    //
+    // A single-pass loop that converts each Object element independently produces
+    // wrong ["x","y","z","a"]. This fixture is the regression guard added after
+    // multi-reviewer code review (2026-05-16).
+    let cfg = load_fixture("na03e-multi-piece-overlap.conf");
+    let items = cfg
+        .get_list("arr")
+        .expect("na03e: getList on multi-piece overlap concat must succeed");
+    assert_eq!(
+        items.len(), 3,
+        "na03e: NORMATIVE pairwise fold: expected [\"z\",\"y\",\"a\"], got {:?}",
+        items
+    );
+    assert_eq!(scalar_raw(&items[0]), "z", "na03e: items[0] must be \"z\" (later obj2 key wins)");
+    assert_eq!(scalar_raw(&items[1]), "y", "na03e: items[1] must be \"y\"");
+    assert_eq!(scalar_raw(&items[2]), "a", "na03e: items[2] must be \"a\"");
+}
+
 // ── na04: empty object NOT converted (S15.4) ──────────────────────────────────
 
 #[test]

--- a/tests/serde_test.rs
+++ b/tests/serde_test.rs
@@ -113,3 +113,50 @@ fn deserialize_to_hashmap() {
     assert_eq!(map.get("a"), Some(&1));
     assert_eq!(map.get("b"), Some(&2));
 }
+
+/// S15 §"Accessor behaviour" L160-161: every typed-array accessor must invoke
+/// numeric_object_to_array. `deserialize_seq` is a typed-array accessor, so
+/// Vec<T> deserialization on a numeric-keyed object must succeed.
+#[test]
+fn deserialize_vec_from_numeric_keyed_object() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Cfg {
+        items: Vec<String>,
+    }
+    // Numeric-keyed object: equivalent to a 2-element list ["a", "b"]
+    let config = parse(r#"items = {"0":"a","1":"b"}"#).unwrap();
+    let val: Cfg = config
+        .deserialize()
+        .expect("Vec<String> deserialization on numeric-keyed object must succeed");
+    assert_eq!(val.items, vec!["a", "b"]);
+}
+
+/// Verify that serde Vec<T> deserialization on a non-numeric-keyed object
+/// still fails with an appropriate error (not a panic).
+#[test]
+fn deserialize_vec_from_non_numeric_object_errors() {
+    #[derive(Debug, Deserialize)]
+    struct Cfg {
+        items: Vec<String>,
+    }
+    let config = parse(r#"items = {"foo":"a","bar":"b"}"#).unwrap();
+    assert!(
+        config.deserialize::<Cfg>().is_err(),
+        "Vec<T> deserialization on non-numeric-keyed object must error"
+    );
+}
+
+/// Verify sort + gap-compaction semantics are preserved through serde.
+#[test]
+fn deserialize_vec_from_numeric_keyed_object_sorted_and_compacted() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Cfg {
+        items: Vec<String>,
+    }
+    // Keys out of order and with a gap: {1:b, 0:a, 3:d} → ["a","b","d"]
+    let config = parse(r#"items = {"1":"b","0":"a","3":"d"}"#).unwrap();
+    let val: Cfg = config
+        .deserialize()
+        .expect("Vec<String> deserialization must sort by integer key");
+    assert_eq!(val.items, vec!["a", "b", "d"]);
+}

--- a/tests/spec_phase5.rs
+++ b/tests/spec_phase5.rs
@@ -13,39 +13,12 @@ use std::collections::HashMap;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // S10.2  All arrays → array concatenation  (spec L312)
-// Status: ❌  tracked in #65 (same root as S10.4 / S10.19 — concat not impl'd)
+// Status: ✅  Fixed as a side effect of fix/s15-numeric-obj-array:
+// the is_sep separator-skip in the array-concat branch discards the whitespace
+// artefacts that used to leak between adjacent literal arrays.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Pin: impl currently produces 5 elements with a whitespace string in the middle
-/// instead of a 4-element array.  The space between `[1,2]` and `[3,4]` leaks
-/// as an extra String scalar.
 #[test]
-fn s10_2_pin_array_concat_produces_space_element() {
-    let cfg = hocon::parse_with_env(r#"a = [1,2] [3,4]"#, &HashMap::new()).unwrap();
-    let list = cfg.get_list("a").unwrap();
-    // Currently produces 5 elements (1, 2, " ", 3, 4)
-    assert_eq!(
-        list.len(),
-        5,
-        "[pin] S10.2: expected impl to produce 5 (broken) elements, got {}",
-        list.len()
-    );
-    // The middle element is the whitespace string
-    if let hocon::HoconValue::Scalar(sv) = &list[2] {
-        assert_eq!(
-            sv.raw, " ",
-            "[pin] S10.2: middle element should be the space whitespace scalar"
-        );
-    } else {
-        panic!(
-            "[pin] S10.2: element [2] should be a scalar, got {:?}",
-            list[2]
-        );
-    }
-}
-
-#[test]
-#[ignore = "spec violation per S10.2 (L312): two adjacent arrays must concatenate into one 4-element array; impl inserts whitespace as extra element — tracked in #65"]
 fn s10_2_spec_array_concat() {
     let cfg = hocon::parse_with_env(r#"a = [1,2] [3,4]"#, &HashMap::new()).unwrap();
     let list = cfg.get_list("a").unwrap();
@@ -156,41 +129,11 @@ fn s10_15_spec_quoted_ws_between_arr_substs_is_error() {
 
 // ─────────────────────────────────────────────────────────────────────────────
 // S10.17  Substitution resolving to array participates in array concat (L387)
-// Status: ❌  (same root as S10.2)
+// Status: ✅  Fixed as a side effect of fix/s15-numeric-obj-array (same root
+// as S10.2 fix: is_sep separator-skip in the array-concat branch).
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Pin: `${base} [3,4]` where base resolves to `[1,2]` produces 5 elements
-/// (with whitespace string) instead of 4.
 #[test]
-fn s10_17_pin_subst_array_concat_space_element() {
-    let cfg = hocon::parse_with_env(
-        r#"
-        base = [1,2]
-        combined = ${base} [3,4]
-    "#,
-        &HashMap::new(),
-    )
-    .unwrap();
-    let list = cfg.get_list("combined").unwrap();
-    assert_eq!(
-        list.len(),
-        5,
-        "[pin] S10.17: expected 5 (broken) elements, got {}",
-        list.len()
-    );
-    // Space whitespace is the 3rd element (index 2)
-    if let hocon::HoconValue::Scalar(sv) = &list[2] {
-        assert_eq!(
-            sv.raw, " ",
-            "[pin] S10.17: element[2] should be the whitespace scalar"
-        );
-    } else {
-        panic!("[pin] S10.17: element[2] should be a scalar");
-    }
-}
-
-#[test]
-#[ignore = "spec violation per S10.17 (L387): ${arr} [x] where arr resolves to array must concat into one array; impl inserts whitespace as extra element — tracked in #65"]
 fn s10_17_spec_subst_array_concat() {
     let cfg = hocon::parse_with_env(
         r#"

--- a/tests/testdata/hocon/numeric-obj-array/na01-basic.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na01-basic.conf
@@ -1,0 +1,3 @@
+# S15.1: numerically-keyed object eligible for array conversion when array context is requested.
+# Impl test: getList("items") should return ["a", "b"].
+items = {"0":"a","1":"b"}

--- a/tests/testdata/hocon/numeric-obj-array/na02-lazy-getobject.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na02-lazy-getobject.conf
@@ -1,0 +1,3 @@
+# S15.2: same source as na01 but asserts laziness — get/getObject return the object as-is,
+# no eager conversion at parse/resolve time. Conversion only fires from list-typed accessors.
+items = {"0":"a","1":"b"}

--- a/tests/testdata/hocon/numeric-obj-array/na03a-concat-left-list.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na03a-concat-left-list.conf
@@ -1,0 +1,5 @@
+# S15.3 + concat-time conversion (left-literal-array case).
+# Pairwise join (left=Array, right=Object) → numericObjectToArray(right) → array-array concat.
+# Expected: arr = ["a", "x", "y"].
+obj = {"0":"x","1":"y"}
+arr = [a] ${obj}

--- a/tests/testdata/hocon/numeric-obj-array/na03b-concat-right-list.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na03b-concat-right-list.conf
@@ -1,0 +1,5 @@
+# S15.3 + concat-time conversion (right-literal-array case, symmetric to na03a).
+# Pairwise join (left=Object, right=Array) → numericObjectToArray(left) → array-array concat.
+# Expected: arr = ["x", "y", "a"].
+obj = {"0":"x","1":"y"}
+arr = ${obj} [a]

--- a/tests/testdata/hocon/numeric-obj-array/na03c-concat-two-objs.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na03c-concat-two-objs.conf
@@ -1,0 +1,6 @@
+# Spec §"Two-object concat is NOT array-converted": both sides Object → S10.3 object merge,
+# no concat-time conversion. Subsequent getList on `arr` would trigger accessor-side conversion.
+# Expected resolved tree: arr = {"0":"x","1":"y","2":"z","3":"w"}.
+obj1 = {"0":"x","1":"y"}
+obj2 = {"2":"z","3":"w"}
+arr = ${obj1} ${obj2}

--- a/tests/testdata/hocon/numeric-obj-array/na03d-concat-multi-piece.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na03d-concat-multi-piece.conf
@@ -1,0 +1,7 @@
+# Spec §"Multi-piece concat is left-to-right pairwise (NORMATIVE)".
+# Fold order: join(obj1, obj2) → object-merge {0:x,1:y,2:z,3:w}; join(merged, [a]) →
+# numericObjectToArray triggers (list partner) → array-array concat.
+# Expected: arr = ["x", "y", "z", "w", "a"].
+obj1 = {"0":"x","1":"y"}
+obj2 = {"2":"z","3":"w"}
+arr = ${obj1} ${obj2} [a]

--- a/tests/testdata/hocon/numeric-obj-array/na03e-multi-piece-overlap.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na03e-multi-piece-overlap.conf
@@ -1,0 +1,14 @@
+# Spec §"Multi-piece concat is left-to-right pairwise (NORMATIVE)" — overlapping-keys variant.
+# Pairwise fold: join(obj1, obj2) → object-merge per S10.3 → {0:z, 1:y} (later "0" wins).
+# Then join(merged, [a]) → numericObjectToArray triggers (list partner) → array-array concat.
+# Expected: arr = ["z", "y", "a"].
+#
+# This fixture distinguishes a true left-to-right pairwise fold from a single-pass loop that
+# converts each Object element independently. The disjoint-keys fixture (na03d) cannot detect
+# the divergence — both algorithms produce the same answer when keys do not overlap.
+#
+# Multi-reviewer code review (2026-05-16) caught all 3 impls (ts/rs/go) initially shipping
+# the single-pass loop variant; this fixture is the regression guard added in followup.
+obj1 = {"0":"x","1":"y"}
+obj2 = {"0":"z"}
+arr = ${obj1} ${obj2} [a]

--- a/tests/testdata/hocon/numeric-obj-array/na04-empty.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na04-empty.conf
@@ -1,0 +1,3 @@
+# S15.4: empty object explicitly NOT converted, even when array is requested.
+# Impl test: getList("items") raises a type-mismatch error.
+items = {}

--- a/tests/testdata/hocon/numeric-obj-array/na05-non-int-keys.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na05-non-int-keys.conf
@@ -1,0 +1,3 @@
+# S15.5: non-integer keys ignored during conversion. Eligible keys: "0", "1".
+# Impl test: getList("items") returns ["a", "c"] (not "b").
+items = {"0":"a","foo":"b","1":"c"}

--- a/tests/testdata/hocon/numeric-obj-array/na06-gaps.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na06-gaps.conf
@@ -1,0 +1,3 @@
+# S15.6: missing indices compacted in resulting array (gap between "0" and "2").
+# Impl test: getList("items") returns ["a", "c"] (no undefined slot for index 1).
+items = {"0":"a","2":"c"}

--- a/tests/testdata/hocon/numeric-obj-array/na07-sort.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na07-sort.conf
@@ -1,0 +1,3 @@
+# S15.7: result sorted by integer key value, regardless of declaration order.
+# Impl test: getList("items") returns ["a", "b"].
+items = {"1":"b","0":"a"}

--- a/tests/testdata/hocon/numeric-obj-array/na08-leading-zero.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na08-leading-zero.conf
@@ -1,0 +1,5 @@
+# E2 (extra-spec): leading zeros rejected. "00" is non-canonical → ineligible.
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+# Lightbend behaviour: HashMap collision (both "00" and "0" parse to 0); winning value depends
+# on iteration order — non-deterministic. Documented in expected/.../na08-leading-zero.divergence.md.
+items = {"00":"a","0":"b"}

--- a/tests/testdata/hocon/numeric-obj-array/na09-negative.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na09-negative.conf
@@ -1,0 +1,3 @@
+# Spec §"Integer key parse rule": negative integers ineligible (Lightbend-aligned).
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+items = {"-1":"a","0":"b"}

--- a/tests/testdata/hocon/numeric-obj-array/na10a-plus-sign.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na10a-plus-sign.conf
@@ -1,0 +1,4 @@
+# E3 (extra-spec): leading + rejected. "+1" is non-canonical → ineligible.
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+# Lightbend behaviour: accepts "+1" as 1; result ["b","a"]. Documented in expected/.../na10a-plus-sign.divergence.md.
+items = {"+1":"a","0":"b"}

--- a/tests/testdata/hocon/numeric-obj-array/na10b-minus-zero.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na10b-minus-zero.conf
@@ -1,0 +1,5 @@
+# E4 (extra-spec): leading sign char on zero rejected. "-0" is non-canonical → ineligible.
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+# Lightbend behaviour: HashMap collision ("-0" and "0" both parse to 0); non-deterministic
+# winner. Documented in expected/.../na10b-minus-zero.divergence.md.
+items = {"-0":"a","0":"b"}

--- a/tests/testdata/hocon/numeric-obj-array/na11-overflow.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na11-overflow.conf
@@ -1,0 +1,3 @@
+# Spec §"Integer key parse rule" range: "99999999999" exceeds i32 range, rejected.
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+items = {"99999999999":"a","0":"b"}

--- a/tests/testdata/hocon/numeric-obj-array/na12-no-eligible.conf
+++ b/tests/testdata/hocon/numeric-obj-array/na12-no-eligible.conf
@@ -1,0 +1,3 @@
+# No keys parse as non-negative integers → numericObjectToArray returns None.
+# Impl test: getList("items") raises a type-mismatch error (no conversion possible).
+items = {"foo":"a","bar":"b"}


### PR DESCRIPTION
## Summary

Implements S15 numerically-indexed object → array conversion in rs.hocon (Phase 6 #2 of cross-impl HOCON spec compliance work). Closes #79.

- New helper `numeric_object_to_array` at `src/numeric_array.rs` with canonical-text-strict pre-filter (no regex dep — hand-coded scanner). Rejects `+1`/`-0`/`00` per [extra-spec E2/E3/E4](https://github.com/o3co/xx.hocon/blob/main/docs/extra-spec-conventions.md).
- `Config::get_list` invokes the helper; untyped accessors stay lazy.
- Resolver concat refactored to true left-to-right **pairwise fold** via new `join_pair` helper.
- **Serde fix**: `deserialize_seq` (and `deserialize_any` Object path) now invoke the helper, so `#[derive(Deserialize)] struct Cfg { items: Vec<String> }` against `items = {"0":"a","1":"b"}` works. Required new `HoconOwnedSeqAccess` + `OwnedHoconDeserializer` (all internal, no public API change) to handle the ownership of the converted `Vec`.
- 16 + 1 (na03e) xx.hocon fixtures synced; Phase-4 `_pin` tests deleted, `_spec` un-`#[ignore]`'d.
- Side-effect fix: **S10.2** (literal array + literal array `[1,2] [3,4]`), **S10.17** (`${arr} [b]` substitution array concat), and **S13.14** (optional missing in array concat) — all were `_pin`'d bugs that the `is_sep` separator-skip (required by S15.3) also resolves.

Spec rows flipped: S15.1, S15.2, S15.3, S15.4, S15.5, S15.6, S15.7, S10.2, S10.17, S13.14 → ✅.

## Multi-agent review history

Local `/multi-agent-review` ran on the initial implementation (commit `1bbba95`). Codex + Claude (general-purpose Opus) both caught two issues:

1. **Critical (3/3 repos, Codex)**: single-pass loop variant of multi-piece concat produced wrong results for overlapping numeric keys. Fix commit `27b78dd` refactors to pairwise fold. New xx.hocon fixture `na03e-multi-piece-overlap.conf` (xx.hocon#11) pins Lightbend ground truth `["z","y","a"]`.
2. **Important (Codex + Claude convergent)**: serde `deserialize_seq` didn't invoke the helper. Same fix commit adds it + 3 new serde tests.

## Test plan

- [x] `cargo test --features serde`: 379 passed | 0 failed | 20 ignored (unrelated)
- [x] na03e overlapping-keys → `["z","y","a"]` confirmed
- [x] na03d disjoint-keys still passes (pairwise + single-pass coincide)
- [x] Phase-4 `_pin` deleted, `_spec` un-`#[ignore]`'d
- [x] 3 new serde tests: `Vec<String>` from numeric-keyed object, error case, sort+compaction via serde
- [ ] In-flight Phase-2 sibling PRs in ts.hocon and go.hocon converge on the same xx.hocon ground truth

## Notable design decision

The serde fix added `HoconOwnedSeqAccess` and `OwnedHoconDeserializer` — fully owned-value deserializer variants — to side-step the lifetime constraint that `HoconSeqAccess<'de>` requires `&'de [HoconValue]` but the converted `Vec` from `numeric_object_to_array` is locally constructed. No `unsafe`, no self-referential borrows, no public API change.

## Related

- Phase 6 #2 cluster (cross-impl)
- Sibling PRs: ts.hocon#TBD, go.hocon#TBD
- xx.hocon ground truth: o3co/xx.hocon#10 (16 fixtures + E2/E3/E4) and o3co/xx.hocon#11 (na03e overlap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)