### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-18
+
 ### Changed
 
 - **BREAKING (S8.6)**: `a = -foo`, `a = -bar`, `a = -` and other `-`-not-followed-by-digit inputs are now lex errors. Per HOCON.md L270–276, a leading `-` must begin a number literal (i.e. be followed by a digit). Previously these were silently accepted as unquoted strings (`"-foo"`, `"-"`). The same rule is applied to substitution paths (`${-foo}` rejected) and dotted key segments (`a.-foo = 1` rejected). Mitigation: quote the value (`a = "-foo"`). Note: this is intentionally stricter than Lightbend's reference implementation, which falls back to unquoted on number-parse failure. Digit-leading inputs (e.g. `123abc`, `01`, `1e+x`) are unaffected — rs.hocon's token model has no separate `Number` kind, so the resolved value continues to match Lightbend's value-concat output for the common cases (see `docs/spec-compliance.md` §S8.6 for the remaining gaps tracked under #63).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hocon-parser"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "criterion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hocon-parser"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.82"
 description = "Full Lightbend HOCON specification-compliant parser for Rust"


### PR DESCRIPTION
## Summary

rs.hocon v1.2.0 release. One BREAKING change + new substitution body tokenization + several fixes.

## BREAKING changes

- **S8.6** — `a = -foo` / `a = -bar` / `a = -` no-digit hyphen rejected at lex time, also in substitution paths (`${-foo}`) and dotted key segments (`a.-foo`). Mitigation: quote (`a = "-foo"`).

## Highlights

- Substitution body tokenization via `parse_subst_body` — matches Lightbend `PathParser` + `WhitespaceSaver` semantics
- Unified `TokenKind::Substitution` (optionality in `SubstPayload.optional`)
- `SubstPlaceholder.segments` now carries source positions (`Vec<Segment>`)
- Empty-key substitution `${""}` resolves (closes #38)
- Surrogate codepoint escapes (`\uD800`–`\uDFFF`) rejected at lex time
- Trailing-dot subst path error position fixed
- Cross-impl compliance: 88.8% in-scope (S6.1/6.2/6.4 + S15.1–S15.7 + S8.6 partial cleared in Phase 6 #1/#2/#3c)

## Test plan

- [x] All Phase 6 #1/#2/#3c PRs merged to develop and passed CI individually
- [x] Tag-triggered cargo publish workflow (`.github/workflows/publish.yml`) will run on `v1.2.0` tag push; `cargo-set-version` aligns Cargo.toml automatically if drifted
- [x] Cargo.lock regenerated for new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)