### PR TITLE
fix(s13c): ${X[]} env-var list expansion + #[non_exhaustive]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,15 +27,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`SubstPayload` and `AstNode::Substitution` are now `#[non_exhaustive]`** (API
-  discipline). A new `list_suffix: bool` field was added in this release; annotating
-  these types `#[non_exhaustive]` ensures that future new fields on these types will
-  not be breaking changes for downstream crates that pattern-match or construct them.
-  **This is not a current breaking change**: `SubstPayload` and `AstNode` are in the
-  public API surface but were not previously `#[non_exhaustive]`; adding the
-  annotation is itself a minor change. Downstream code that fully destructures
-  `SubstPayload` struct literals must add `..` or update field lists from this
-  version onward.
+- **BREAKING (rare)**: `SubstPayload` gains a new public field `list_suffix: bool`
+  and is now `#[non_exhaustive]`. `SubstPayload` IS publicly re-exported from
+  the crate root (see `lib.rs`), so downstream crates that constructed it via
+  struct literal or pattern-matched all fields exhaustively need to update.
+  Migration: add `list_suffix: false` to existing struct literals (or use
+  `Default` once it's added in a future release), and add `..` to exhaustive
+  patterns. Most consumers should be unaffected — `SubstPayload` is primarily
+  an internal pipeline value produced by the lexer and consumed by the resolver.
+
+  `AstNode::Substitution` also gains `list_suffix: bool` and is now
+  `#[non_exhaustive]`, but the `parser` module is `pub(crate)` so this is NOT
+  a public-API change. (Internal callers in `structure_builder.rs` are updated
+  in this same commit.)
+
+  Rationale for taking `#[non_exhaustive]` in this release: future field
+  additions on these types would otherwise each be breaking; installing the
+  discipline now (in the same minor release that adds the first such field)
+  amortizes the migration cost to a single update.
 
 ## [1.2.0] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **S13c — `${X[]}` / `${?X[]}` env-var list expansion** (Phase 6 #3g): substitution
+  bodies now accept a literal `[]` suffix signalling env-var-list expansion. The lexer
+  `parse_subst_body` recognises the `[]` suffix (E7: ASCII space/tab before `[` is
+  tolerated); the resolver's new `resolve_env_list` helper scans `NAME_0`, `NAME_1`, …
+  until the first absent key and returns an `Array` of strings. Empty-string elements
+  are preserved (stop on absent key, not empty value). Required substitution with no
+  `_0` element raises `ResolveError`; optional form drops the key.
+  - **E6 compliance** (config-defined wins): when the substitution path resolves to a
+    config value, the `[]` suffix is a no-op — env vars `NAME_*` are not consulted.
+  - **E7 compliance** (whitespace before `[]`): `${X []}` and `${X\t[]}` parse
+    identically to `${X[]}`.
+  - **S13c.5 enforcement**: scalar env fallback (`NAME` without suffix) is suppressed
+    when `list_suffix=true` — only `NAME_0`, `NAME_1`, … are consulted.
+  - Conformance tests: `tests/env_var_list_test.rs` with fixtures ev01–ev11 from
+    `xx.hocon/testdata/hocon/env-var-list/`.
+
+### Changed
+
+- **`SubstPayload` and `AstNode::Substitution` are now `#[non_exhaustive]`** (API
+  discipline). A new `list_suffix: bool` field was added in this release; annotating
+  these types `#[non_exhaustive]` ensures that future new fields on these types will
+  not be breaking changes for downstream crates that pattern-match or construct them.
+  **This is not a current breaking change**: `SubstPayload` and `AstNode` are in the
+  public API surface but were not previously `#[non_exhaustive]`; adding the
+  annotation is itself a minor change. Downstream code that fully destructures
+  `SubstPayload` struct literals must add `..` or update field lists from this
+  version onward.
+
 ## [1.2.0] - 2026-05-18
 
 ### Changed

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -424,20 +424,20 @@ same item descriptions verbatim.
 ### S13c. List values from environment variables
 
 - **S13c.1** `${X[]}` looks up `X_0`, `X_1`, ... env vars — §List values from env (L900)
-  tests: —
-  status: ❌ — not implemented; src/lexer.rs:429 (`is_unquoted_subst_char`) rejects `[` / `]` inside `${...}` body, so `${X[]}` is unparseable
+  tests: `tests/env_var_list_test.rs::s13c_ev01_basic`, `s13c_ev02_stops_at_gap`
+  status: ✅ — implemented in Phase 6 #3g (2026-05-18); lexer `'[' =>` arm in `parse_subst_body` + `resolve_env_list` helper
 - **S13c.2** Stops at first missing index — §List values from env (L905)
-  tests: —
-  status: ❌ — not implemented (see S13c.1)
+  tests: `tests/env_var_list_test.rs::s13c_ev02_stops_at_gap`
+  status: ✅
 - **S13c.3** `${X[]}` no elements → required error — §List values from env (L910)
-  tests: —
-  status: ❌ — not implemented (see S13c.1)
+  tests: `tests/env_var_list_test.rs::s13c_ev03_required_no_elements_errors`
+  status: ✅
 - **S13c.4** `${?X[]}` no elements → undefined / removed — §List values from env (L912)
-  tests: —
-  status: ❌ — not implemented (see S13c.1)
+  tests: `tests/env_var_list_test.rs::s13c_ev04_optional_no_elements`
+  status: ✅
 - **S13c.5** `[]` suffix supported only for env vars (not config / sys props) — §List values from env (L902)
-  tests: —
-  status: ❌ — not implemented (see S13c.1); the constraint is moot when the `[]` suffix itself is rejected by the lexer
+  tests: `tests/env_var_list_test.rs::s13c_s5_required_no_scalar_fallback`, `s13c_s5_optional_no_scalar_fallback`
+  status: ✅ — scalar env fallback is suppressed when `list_suffix=true`; config-lookup returns early (E6)
 
 ## S14. Includes
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -796,6 +796,6 @@ rs.hocon status per-item:
 - **E6** `${X[]}` config-defined wins — `[]` suffix is a no-op when X is a config key
   tests: `tests/env_var_list_test.rs::s13c_ev05_config_defined_wins`
   status: ✅ — config lookup returns early before `list_suffix` branch; env vars `X_0`, `X_1`, … are not consulted (Phase 6 #3g, 2026-05-18)
-- **E7** Whitespace between path expression and `[]` is allowed (`${X []}` / `${?X []}`)
-  tests: `tests/env_var_list_test.rs::s13c_ev09_whitespace_before_suffix`, `tests/lexer_test.rs::lex_subst_list_suffix_e7_space`, `lex_subst_list_suffix_e7_tab`
-  status: ✅ — `pending_ws` buffer in `parse_subst_body` `'['` arm discards horizontal WS before `[]` (Phase 6 #3g, 2026-05-18)
+- **E7** ASCII SPACE (0x20) or TAB (0x09) between path expression and `[]` is allowed (`${X []}` / `${?X []}`); wider whitespace (NBSP, CR, Zs, Zl, BOM, …) is REJECTED to match the narrow extra-spec convention
+  tests: `tests/env_var_list_test.rs::s13c_ev09_whitespace_before_suffix`, `tests/lexer_test.rs::lex_subst_list_suffix_e7_space`, `lex_subst_list_suffix_e7_tab`; negatives via `tests/env_var_list_test.rs::s13c_lex_nbsp_before_suffix_errors`, `_cr_before_suffix_errors`, `_zs_em_space_before_suffix_errors`
+  status: ✅ — `parse_subst_body` `'['` arm validates `pending_ws` against `{' ', '\t'}` and rejects other HOCON whitespace (Phase 6 #3g, 2026-05-18; tightened in Copilot review fix on rs.hocon#88)

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -784,3 +784,18 @@ same item descriptions verbatim.
 - **S26.4** Env vars always become strings (with auto type conversion) — §Substitution fallback (L1563)
   tests: src/resolver/mod.rs:172 (uses_env_var_when_present)
   status: ✅
+
+---
+
+## Extra-spec conventions (E-items)
+
+Cross-implementation behaviors not enumerated by the Lightbend HOCON spec, tracked in
+[`xx.hocon/docs/extra-spec-conventions.md`](https://github.com/o3co/xx.hocon/blob/main/docs/extra-spec-conventions.md).
+rs.hocon status per-item:
+
+- **E6** `${X[]}` config-defined wins — `[]` suffix is a no-op when X is a config key
+  tests: `tests/env_var_list_test.rs::s13c_ev05_config_defined_wins`
+  status: ✅ — config lookup returns early before `list_suffix` branch; env vars `X_0`, `X_1`, … are not consulted (Phase 6 #3g, 2026-05-18)
+- **E7** Whitespace between path expression and `[]` is allowed (`${X []}` / `${?X []}`)
+  tests: `tests/env_var_list_test.rs::s13c_ev09_whitespace_before_suffix`, `tests/lexer_test.rs::lex_subst_list_suffix_e7_space`, `lex_subst_list_suffix_e7_tab`
+  status: ✅ — `pending_ws` buffer in `parse_subst_body` `'['` arm discards horizontal WS before `[]` (Phase 6 #3g, 2026-05-18)

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -548,7 +548,10 @@ fn parse_literal_brackets(
     *col += 1;
     // Next char must be `]` (no whitespace inside the brackets).
     if *pos >= chars.len() || chars[*pos] != ']' {
-        let got = chars.get(*pos).map(|c| c.escape_debug().to_string()).unwrap_or_else(|| "EOF".into());
+        let got = chars
+            .get(*pos)
+            .map(|c| c.escape_debug().to_string())
+            .unwrap_or_else(|| "EOF".into());
         return Err(ParseError {
             message: format!(
                 "expected ']' after '[' in substitution list suffix, got {}",
@@ -795,7 +798,11 @@ fn parse_subst_body(
         });
     }
 
-    Ok(SubstPayload { segments, optional, list_suffix })
+    Ok(SubstPayload {
+        segments,
+        optional,
+        list_suffix,
+    })
 }
 
 fn is_unquoted_start(ch: char) -> bool {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -25,10 +25,19 @@ pub struct Segment {
     pub col: usize,
 }
 
+/// Payload carried by a `${...}` or `${?...}` substitution token.
+///
+/// `#[non_exhaustive]` ensures that adding new fields here (e.g. future spec
+/// extensions) does not break downstream crates that pattern-match or
+/// construct this struct.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct SubstPayload {
     pub segments: Vec<Segment>,
     pub optional: bool,
+    /// True when the substitution body carries a `[]` suffix, signalling
+    /// env-var-list expansion (`${X[]}` / `${?X[]}`).
+    pub list_suffix: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -713,7 +722,7 @@ fn parse_subst_body(
         });
     }
 
-    Ok(SubstPayload { segments, optional })
+    Ok(SubstPayload { segments, optional, list_suffix: false })
 }
 
 fn is_unquoted_start(ch: char) -> bool {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -710,25 +710,44 @@ fn parse_subst_body(
             }
             '[' => {
                 // S13c: `[]` suffix — end of path expression, start of list-suffix.
-                // E7: pending_ws (horizontal WS before `[`) is discarded here.
-                // Error if no segment has been started yet (e.g. `${[]}` / `${ []}`).
-                if !cur_started && segments.is_empty() {
+                // Two convergent multi-impl checks (mirrors go.hocon + ts.hocon fixes):
+                //
+                //   (a) Empty-segment guard: error if no segment has been started AND
+                //       either there are no segments yet (`${[]}` / `${ []}`) or a
+                //       trailing dot was just consumed (`${X.[]}` / `${X . []}`).
+                //       Both reduce to `!cur_started` — uniform error.
+                //   (b) E7 narrow: pending_ws may contain only ASCII SPACE (0x20) or
+                //       TAB (0x09). Wider HOCON whitespace (NBSP, CR, Zs, BOM, …) is
+                //       accumulated by the broader inter-token WS arm below (S6 set)
+                //       but is rejected here for the `[` boundary per extra-spec E7
+                //       ("narrow allow-list intentionally avoids semantic surprise").
+                if !cur_started {
                     return Err(ParseError {
                         message: "empty segment before '[]' suffix in substitution".into(),
                         line: start_line,
                         col: *col,
                     });
                 }
-                // Flush any in-progress unquoted segment (same as the `}` path).
-                if cur_started {
-                    segments.push(Segment {
-                        text: std::mem::take(&mut cur_text),
-                        line: cur_line,
-                        col: cur_col,
-                    });
-                    cur_started = false;
+                for w in pending_ws.chars() {
+                    if w != ' ' && w != '\t' {
+                        return Err(ParseError {
+                            message: format!(
+                                "only ASCII space or tab allowed between substitution path and '[]' suffix (got {:?}, HOCON extra-spec E7)",
+                                w
+                            ),
+                            line: start_line,
+                            col: *col,
+                        });
+                    }
                 }
-                // Discard pending_ws (E7: horizontal WS between path and `[`).
+                // Flush in-progress unquoted segment (same as the `}` path).
+                segments.push(Segment {
+                    text: std::mem::take(&mut cur_text),
+                    line: cur_line,
+                    col: cur_col,
+                });
+                cur_started = false;
+                // E7-conformant pending_ws is intentionally discarded.
                 pending_ws.clear();
                 // Consume the literal `[]`.
                 parse_literal_brackets(chars, pos, col, start_line, start_col)?;

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -540,7 +540,6 @@ fn parse_literal_brackets(
     pos: &mut usize,
     col: &mut usize,
     start_line: usize,
-    start_col: usize,
 ) -> Result<(), ParseError> {
     // Consume `[`.
     debug_assert!(*pos < chars.len() && chars[*pos] == '[');
@@ -563,7 +562,6 @@ fn parse_literal_brackets(
     }
     *pos += 1;
     *col += 1;
-    let _ = start_col; // used only in the caller's error context
     Ok(())
 }
 
@@ -750,7 +748,7 @@ fn parse_subst_body(
                 // E7-conformant pending_ws is intentionally discarded.
                 pending_ws.clear();
                 // Consume the literal `[]`.
-                parse_literal_brackets(chars, pos, col, start_line, start_col)?;
+                parse_literal_brackets(chars, pos, col, start_line)?;
                 list_suffix = true;
                 // After `[]` the only legal next char is `}`.
                 if *pos >= chars.len() || chars[*pos] != '}' {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -531,6 +531,39 @@ fn is_unquoted_subst_char(ch: char) -> bool {
     )
 }
 
+/// Consume the literal two-character sequence `[]` at the current position.
+///
+/// Called by `parse_subst_body` when the `[` arm fires. Expects `chars[*pos] == '['`
+/// on entry. Strict: no whitespace inside the brackets (`${X[ ]}` is a lex error).
+fn parse_literal_brackets(
+    chars: &[char],
+    pos: &mut usize,
+    col: &mut usize,
+    start_line: usize,
+    start_col: usize,
+) -> Result<(), ParseError> {
+    // Consume `[`.
+    debug_assert!(*pos < chars.len() && chars[*pos] == '[');
+    *pos += 1;
+    *col += 1;
+    // Next char must be `]` (no whitespace inside the brackets).
+    if *pos >= chars.len() || chars[*pos] != ']' {
+        let got = chars.get(*pos).map(|c| c.escape_debug().to_string()).unwrap_or_else(|| "EOF".into());
+        return Err(ParseError {
+            message: format!(
+                "expected ']' after '[' in substitution list suffix, got {}",
+                got
+            ),
+            line: start_line,
+            col: *col,
+        });
+    }
+    *pos += 1;
+    *col += 1;
+    let _ = start_col; // used only in the caller's error context
+    Ok(())
+}
+
 /// Parse the body of a `${...}` substitution (called after `${` has been consumed).
 /// Returns the `SubstPayload` or a `ParseError`.
 fn parse_subst_body(
@@ -562,6 +595,8 @@ fn parse_subst_body(
     let mut segments: Vec<Segment> = Vec::new();
     // Track last-seen DOT position for trailing-dot error reporting.
     let mut last_dot: Option<(usize, usize)> = None;
+    // Set to true when a `[]` suffix is encountered (S13c env-var-list).
+    let mut list_suffix = false;
 
     loop {
         if *pos >= chars.len() {
@@ -670,6 +705,43 @@ fn parse_subst_body(
                 *pos += 1;
                 *col += 1;
             }
+            '[' => {
+                // S13c: `[]` suffix — end of path expression, start of list-suffix.
+                // E7: pending_ws (horizontal WS before `[`) is discarded here.
+                // Error if no segment has been started yet (e.g. `${[]}` / `${ []}`).
+                if !cur_started && segments.is_empty() {
+                    return Err(ParseError {
+                        message: "empty segment before '[]' suffix in substitution".into(),
+                        line: start_line,
+                        col: *col,
+                    });
+                }
+                // Flush any in-progress unquoted segment (same as the `}` path).
+                if cur_started {
+                    segments.push(Segment {
+                        text: std::mem::take(&mut cur_text),
+                        line: cur_line,
+                        col: cur_col,
+                    });
+                    cur_started = false;
+                }
+                // Discard pending_ws (E7: horizontal WS between path and `[`).
+                pending_ws.clear();
+                // Consume the literal `[]`.
+                parse_literal_brackets(chars, pos, col, start_line, start_col)?;
+                list_suffix = true;
+                // After `[]` the only legal next char is `}`.
+                if *pos >= chars.len() || chars[*pos] != '}' {
+                    return Err(ParseError {
+                        message: "expected '}' after '[]' in substitution".into(),
+                        line: start_line,
+                        col: *col,
+                    });
+                }
+                *pos += 1;
+                *col += 1;
+                break;
+            }
             ch if is_hocon_whitespace(ch) && !is_hocon_newline(ch) => {
                 // Inter-token whitespace (full HOCON_WS minus LF): buffer into
                 // pending_ws; column advances but line is unchanged.
@@ -698,7 +770,7 @@ fn parse_subst_body(
         }
     }
 
-    // END validation
+    // END validation (only reached via `}` break; `[]` break already pushes segment).
     if cur_started {
         segments.push(Segment {
             text: cur_text,
@@ -712,8 +784,9 @@ fn parse_subst_body(
             line: start_line,
             col: start_col,
         });
-    } else {
-        // trailing dot: ${foo.} — report at the offending dot position
+    } else if !list_suffix {
+        // trailing dot: ${foo.} — report at the offending dot position.
+        // Not an error when list_suffix=true; the `[]` arm already flushed.
         let (err_line, err_col) = last_dot.unwrap_or((start_line, start_col));
         return Err(ParseError {
             message: "empty segment in path".into(),
@@ -722,7 +795,7 @@ fn parse_subst_body(
         });
     }
 
-    Ok(SubstPayload { segments, optional, list_suffix: false })
+    Ok(SubstPayload { segments, optional, list_suffix })
 }
 
 fn is_unquoted_start(ch: char) -> bool {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -30,9 +30,19 @@ pub enum AstNode {
         nodes: Vec<AstNode>,
         pos: Pos,
     },
+    /// A `${...}` or `${?...}` substitution node.
+    ///
+    /// `#[non_exhaustive]` on the variant means callers that pattern-match
+    /// must use `..` for any fields they do not bind — ensures that adding
+    /// new fields (e.g. `list_suffix`) does not silently break downstream
+    /// exhaustive matches.
+    #[non_exhaustive]
     Substitution {
         segments: Vec<Segment>,
         optional: bool,
+        /// True when the substitution carries a `[]` suffix for env-var-list
+        /// expansion (`${X[]}` / `${?X[]}`).
+        list_suffix: bool,
         pos: Pos,
     },
     Include {
@@ -515,16 +525,17 @@ impl<'a> Parser<'a> {
                     self.parse_array()?
                 }
                 TokenKind::Substitution => {
-                    let (optional, segs) = self
+                    let (optional, segs, list_suffix) = self
                         .tokens
                         .get(self.pos)
                         .and_then(|t| t.subst.as_ref())
-                        .map(|p| (p.optional, p.segments.clone()))
-                        .unwrap_or((false, Vec::new()));
+                        .map(|p| (p.optional, p.segments.clone(), p.list_suffix))
+                        .unwrap_or((false, Vec::new(), false));
                     let (_, _value, line, col) = self.advance_get();
                     AstNode::Substitution {
                         segments: segs,
                         optional,
+                        list_suffix,
                         pos: Pos { line, col },
                     }
                 }

--- a/src/resolver/structure_builder.rs
+++ b/src/resolver/structure_builder.rs
@@ -170,10 +170,13 @@ impl<'a> StructureBuilder<'a> {
             AstNode::Substitution {
                 segments,
                 optional,
+                list_suffix,
                 pos,
+                ..
             } => Ok(ResolverValue::Subst(SubstPlaceholder {
                 segments,
                 optional,
+                list_suffix,
                 line: pos.line,
                 col: pos.col,
                 prefix_len: 0,

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -197,6 +197,17 @@ impl<'a> SubstitutionResolver<'a> {
             return Ok(result);
         }
 
+        // S13c: env-var list expansion — `${X[]}` / `${?X[]}`.
+        // When list_suffix=true and config lookup missed, delegate entirely to
+        // resolve_env_list. The scalar env fallback below is SUPPRESSED (S13c.5).
+        if s.list_suffix {
+            let result = self.resolve_env_list(s, key)?;
+            if let Some(ref r) = result {
+                self.cache.insert(key.to_string(), r.clone());
+            }
+            return Ok(result);
+        }
+
         // Env var fallback — use raw dot-join (no quoting) to match Lightbend behavior
         let env_key = s
             .segments
@@ -228,6 +239,74 @@ impl<'a> SubstitutionResolver<'a> {
 
         Err(ResolveError {
             message: format!("could not resolve substitution: ${{{}}}", key),
+            path: key.to_string(),
+            line: s.line,
+            col: s.col,
+        })
+    }
+
+    /// Resolve env-var-list expansion for `${X[]}` / `${?X[]}` (S13c).
+    ///
+    /// Candidates are tried in order: fully-qualified base first, then bare
+    /// (prefix-stripped) base (matching the scalar env fallback order).
+    /// First candidate whose `<base>_0` key is present in the env wins entirely —
+    /// no cross-base merging. Empty-string values are preserved (ev10).
+    ///
+    /// Returns:
+    /// - `Ok(Some(HoconValue::Array(...)))` — one or more elements found.
+    /// - `Ok(None)` — no elements found AND `s.optional`.
+    /// - `Err(ResolveError)` — no elements found AND `!s.optional`.
+    fn resolve_env_list(
+        &self,
+        s: &SubstPlaceholder,
+        key: &str,
+    ) -> Result<Option<HoconValue>, ResolveError> {
+        // Build candidate base names (same order as scalar env fallback).
+        let full_base = s
+            .segments
+            .iter()
+            .map(|seg| seg.text.as_str())
+            .collect::<Vec<_>>()
+            .join(".");
+        let mut candidates: Vec<String> = vec![full_base];
+        if s.prefix_len > 0 && s.segments.len() > s.prefix_len {
+            let bare_base = s.segments[s.prefix_len..]
+                .iter()
+                .map(|seg| seg.text.as_str())
+                .collect::<Vec<_>>()
+                .join(".");
+            candidates.push(bare_base);
+        }
+
+        for base in &candidates {
+            let probe = format!("{}_0", base);
+            if self.env.contains_key(&probe) {
+                // This base has _0 — scan _0, _1, … until first absent key.
+                let mut elements: Vec<HoconValue> = Vec::new();
+                let mut i: usize = 0;
+                loop {
+                    let k = format!("{}_{}", base, i);
+                    match self.env.get(&k) {
+                        Some(v) => {
+                            elements.push(HoconValue::Scalar(ScalarValue::string(v.clone())));
+                            i += 1;
+                        }
+                        None => break,
+                    }
+                }
+                return Ok(Some(HoconValue::Array(elements)));
+            }
+        }
+
+        // No candidate base had _0.
+        if s.optional {
+            return Ok(None);
+        }
+        Err(ResolveError {
+            message: format!(
+                "could not resolve substitution: ${{{key}}} (no environment variable {}_0 found)",
+                candidates[0]
+            ),
             path: key.to_string(),
             line: s.line,
             col: s.col,

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -93,7 +93,17 @@ impl<'a> SubstitutionResolver<'a> {
         s: &SubstPlaceholder,
         scope: &ResObj,
     ) -> Result<Option<HoconValue>, ResolveError> {
-        let key = segments_to_key(&s.segments);
+        // Cache key includes list_suffix to prevent `${X}` and `${X[]}` collisions:
+        // both resolve via different code paths (scalar fallback vs resolve_env_list)
+        // and can produce different values, so they must occupy distinct cache slots.
+        // Convergent with ts.hocon fix (same bug pattern). go.hocon is unaffected
+        // because its cache is only used for self-ref recovery, not general memo.
+        // Pin: tests/env_var_list_test.rs cache-disambiguation regression.
+        let key = if s.list_suffix {
+            format!("{}[]", segments_to_key(&s.segments))
+        } else {
+            segments_to_key(&s.segments)
+        };
 
         if let Some(cached) = self.cache.get(&key) {
             return Ok(Some(cached.clone()));

--- a/src/resolver/types.rs
+++ b/src/resolver/types.rs
@@ -43,6 +43,8 @@ pub(crate) enum ResolverValue {
 pub(crate) struct SubstPlaceholder {
     pub segments: Vec<Segment>,
     pub optional: bool,
+    /// Propagated from `AstNode::Substitution::list_suffix`; true for `${X[]}` / `${?X[]}`.
+    pub list_suffix: bool,
     pub line: usize,
     pub col: usize,
     pub prefix_len: usize,

--- a/src/resolver/utils.rs
+++ b/src/resolver/utils.rs
@@ -146,6 +146,11 @@ pub(crate) fn segments_to_key(segments: &[Segment]) -> String {
         .iter()
         .map(|seg| {
             let s = &seg.text;
+            // Quote a segment when raw text would create cache-key ambiguity.
+            // Brackets `[` `]` are included so a quoted-segment `${"X[]"}` produces
+            // `"X[]"` while the list-suffix-derived key `X` + `[]` produces `X[]` —
+            // distinct cache slots. Without this, the two collide (Copilot review
+            // on rs.hocon#88 surfaced the regression after the initial C1 fix).
             if s.is_empty()
                 || s.contains('.')
                 || s.contains('"')
@@ -153,6 +158,8 @@ pub(crate) fn segments_to_key(segments: &[Segment]) -> String {
                 || s != s.trim()
                 || s.contains(' ')
                 || s.contains('\t')
+                || s.contains('[')
+                || s.contains(']')
             {
                 let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
                 format!("\"{}\"", escaped)

--- a/tests/env_var_list_test.rs
+++ b/tests/env_var_list_test.rs
@@ -7,6 +7,7 @@
 //!
 //! Env injection uses `parse_file_with_env` (hermetic — no `std::env::set_var`).
 
+use hocon::HoconValue;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -293,4 +294,136 @@ fn s13c_s5_optional_no_scalar_fallback() {
 #[test]
 fn s13c_ev08_self_ref_concat() {
     assert_fixture_matches("ev08-self-append");
+}
+
+// ── Multi-agent-review regressions ───────────────────────────────────────────
+//
+// The following tests pin three bugs caught during /multi-agent-review of this
+// branch (Codex Critical C1 + Important I1/I2; convergent with ts.hocon).
+
+/// C1: `${X}` and `${X[]}` must NOT collide in the substitution cache.
+///
+/// Before the fix, the cache key was `segments_to_key(s.segments)` only, so
+/// whichever form resolved first poisoned the cache for the other. Verified
+/// in both directions to ensure neither path wins by accident.
+#[test]
+fn s13c_cache_disambiguation_scalar_then_list() {
+    let mut env = HashMap::new();
+    env.insert("S13C_CACHE_X".to_string(), "scalar-val".to_string());
+    env.insert("S13C_CACHE_X_0".to_string(), "a".to_string());
+    env.insert("S13C_CACHE_X_1".to_string(), "b".to_string());
+    let cfg = hocon::parse_with_env("a = ${S13C_CACHE_X}\nb = ${S13C_CACHE_X[]}", &env)
+        .expect("parse_with_env");
+    assert_eq!(cfg.get_string("a").unwrap(), "scalar-val");
+    let b = cfg.get_list("b").expect("b should be list");
+    let texts: Vec<String> = b
+        .iter()
+        .map(|v| match v {
+            HoconValue::Scalar(sv) => sv.raw.clone(),
+            _ => panic!("expected scalar element in b"),
+        })
+        .collect();
+    assert_eq!(texts, vec!["a", "b"]);
+}
+
+#[test]
+fn s13c_cache_disambiguation_list_then_scalar() {
+    let mut env = HashMap::new();
+    env.insert("S13C_CACHE2_X".to_string(), "scalar-val".to_string());
+    env.insert("S13C_CACHE2_X_0".to_string(), "a".to_string());
+    env.insert("S13C_CACHE2_X_1".to_string(), "b".to_string());
+    let cfg = hocon::parse_with_env("a = ${S13C_CACHE2_X[]}\nb = ${S13C_CACHE2_X}", &env)
+        .expect("parse_with_env");
+    let a = cfg.get_list("a").expect("a should be list");
+    let texts: Vec<String> = a
+        .iter()
+        .map(|v| match v {
+            HoconValue::Scalar(sv) => sv.raw.clone(),
+            _ => panic!("expected scalar element in a"),
+        })
+        .collect();
+    assert_eq!(texts, vec!["a", "b"]);
+    assert_eq!(cfg.get_string("b").unwrap(), "scalar-val");
+}
+
+/// I1: `${X.[]}` must be rejected as empty-segment-before-suffix.
+///
+/// Before the fix, the `'[' =>` arm only checked `!cur_started && segments.is_empty()`,
+/// which missed the case where a trailing dot just reset cur_started but segments
+/// already had entries from prior segment parsing.
+#[test]
+fn s13c_lex_trailing_dot_before_suffix_errors() {
+    let env = HashMap::new();
+    let err = hocon::parse_with_env("x = ${A.[]}", &env);
+    assert!(err.is_err(), "expected ParseError for ${{A.[]}}, got Ok");
+}
+
+#[test]
+fn s13c_lex_trailing_dot_space_before_suffix_errors() {
+    let env = HashMap::new();
+    let err = hocon::parse_with_env("x = ${A . []}", &env);
+    assert!(err.is_err(), "expected ParseError for ${{A . []}}, got Ok");
+}
+
+/// I2: E7 narrow-allow-list — only ASCII SPACE / TAB allowed before `[]`.
+///
+/// Before the fix, pending_ws accumulated wider HOCON whitespace (NBSP, CR,
+/// Zs, BOM) and the `[` arm discarded it all unconditionally. The new check
+/// rejects any non-{space,tab} char in pending_ws.
+#[test]
+fn s13c_lex_nbsp_before_suffix_errors() {
+    let env = HashMap::new();
+    let err = hocon::parse_with_env("x = ${A\u{00A0}[]}", &env);
+    assert!(
+        err.is_err(),
+        "expected ParseError for ${{A\\u00A0[]}} (NBSP), got Ok"
+    );
+}
+
+#[test]
+fn s13c_lex_cr_before_suffix_errors() {
+    let env = HashMap::new();
+    let err = hocon::parse_with_env("x = ${A\r[]}", &env);
+    assert!(
+        err.is_err(),
+        "expected ParseError for ${{A\\r[]}} (CR), got Ok"
+    );
+}
+
+#[test]
+fn s13c_lex_zs_em_space_before_suffix_errors() {
+    let env = HashMap::new();
+    let err = hocon::parse_with_env("x = ${A\u{2003}[]}", &env);
+    assert!(
+        err.is_err(),
+        "expected ParseError for ${{A\\u2003[]}} (em-space), got Ok"
+    );
+}
+
+/// E7 positive sanity: ASCII space + tab should still pass.
+#[test]
+fn s13c_lex_e7_ascii_space_tab_before_suffix_ok() {
+    let mut env = HashMap::new();
+    env.insert("S13C_E7_OK_0".to_string(), "v".to_string());
+    let cfg = hocon::parse_with_env("x = ${S13C_E7_OK []}", &env)
+        .expect("space before [] should be accepted");
+    assert!(cfg.has("x"));
+    let cfg2 = hocon::parse_with_env("x = ${S13C_E7_OK\t[]}", &env)
+        .expect("tab before [] should be accepted");
+    assert!(cfg2.has("x"));
+}
+
+/// `${"a"[]}` — quoted segment followed by suffix. Sanity-pin positive.
+#[test]
+fn s13c_lex_quoted_segment_with_suffix_ok() {
+    let mut env = HashMap::new();
+    env.insert("a_0".to_string(), "v".to_string());
+    let cfg = hocon::parse_with_env(r#"x = ${"a"[]}"#, &env)
+        .expect("quoted segment + suffix should be accepted");
+    let list = cfg.get_list("x").expect("x should be list");
+    assert_eq!(list.len(), 1);
+    match &list[0] {
+        HoconValue::Scalar(sv) => assert_eq!(sv.raw, "v"),
+        _ => panic!("expected scalar element"),
+    }
 }

--- a/tests/env_var_list_test.rs
+++ b/tests/env_var_list_test.rs
@@ -281,24 +281,16 @@ fn s13c_s5_optional_no_scalar_fallback() {
     );
 }
 
-// ── Unit 9: ev08 tripwire ─────────────────────────────────────────────────────
+// ── Unit 9: ev08 — self-ref concat with list suffix ──────────────────────────
 
-/// ev08 depends on S13a.13 self-ref-lookback fix (cluster 3f, not yet landed).
+/// ev08: `x = ["x"]; x = ${?x} ${?LIST[]}` → `["x","a"]`.
 ///
-/// Today `x = ${?x} ${?LIST[]}` fails to look back at the prior `x = ["x"]`,
-/// so the assertion below panics with a message containing "ev08". When S13a.13
-/// lands, the equality holds, no panic → `#[should_panic]` fires, forcing a
-/// code change. Identical pattern to `s8_6_us13_known_gap_tripwire`.
+/// The plan proposed a `#[should_panic]` tripwire (S13a.13 gap), but rs.hocon's
+/// existing prior_values / self-ref-lookback logic already handles this case
+/// correctly via the concat resolver and `join_pair`. Verified 2026-05-18:
+/// ev08 resolves to `["x","a"]` without the S13a.13 fix. This fixture therefore
+/// ships as a regular ✅ success test, not a tripwire.
 #[test]
-#[should_panic(expected = "ev08")]
-fn s13c_ev08_self_ref_tripwire() {
-    let result = parse_fixture_with_env("ev08-self-append");
-    let got = result
-        .map(|c| config_to_json(&c))
-        .unwrap_or_else(|e| panic!("ev08: parse failed (expected resolve): {:?}", e));
-    let expected = load_expected_json("ev08-self-append");
-    assert_eq!(
-        got, expected,
-        "ev08: depends on S13a.13 self-ref-lookback fix (cluster 3f)"
-    );
+fn s13c_ev08_self_ref_concat() {
+    assert_fixture_matches("ev08-self-append");
 }

--- a/tests/env_var_list_test.rs
+++ b/tests/env_var_list_test.rs
@@ -20,8 +20,7 @@ fn fixture_dir() -> PathBuf {
 fn expected_dir() -> PathBuf {
     // xx.hocon expected outputs sit two repo-siblings up from this crate root:
     //   <agentscope>/repos/rs.hocon  →  <agentscope>/repos/xx.hocon
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../xx.hocon/expected/hocon/env-var-list")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../xx.hocon/expected/hocon/env-var-list")
 }
 
 fn fixture_path(name: &str) -> PathBuf {
@@ -50,7 +49,7 @@ fn parse_env_sidecar(path: &std::path::Path) -> HashMap<String, String> {
         .unwrap_or_else(|e| panic!("failed to read env sidecar {}: {}", path.display(), e));
     let mut map = HashMap::new();
     for line in content.lines() {
-        let trimmed = line.trim_start_matches(|c| c == ' ' || c == '\t');
+        let trimmed = line.trim_start_matches([' ', '\t']);
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
@@ -148,7 +147,7 @@ fn config_to_json(config: &hocon::Config) -> serde_json::Value {
 
 fn parse_fixture_with_env(name: &str) -> Result<hocon::Config, hocon::HoconError> {
     let env = parse_env_sidecar(&env_path(name));
-    hocon::parse_file_with_env(&fixture_path(name), &env)
+    hocon::parse_file_with_env(fixture_path(name), &env)
 }
 
 fn load_expected_json(name: &str) -> serde_json::Value {
@@ -166,7 +165,8 @@ fn assert_fixture_matches(name: &str) {
     let got = config_to_json(&cfg);
     let expected = load_expected_json(name);
     assert_eq!(
-        got, expected,
+        got,
+        expected,
         "s13c {}: output mismatch\n  got:      {}\n  expected: {}",
         name,
         serde_json::to_string_pretty(&got).unwrap(),

--- a/tests/env_var_list_test.rs
+++ b/tests/env_var_list_test.rs
@@ -346,6 +346,61 @@ fn s13c_cache_disambiguation_list_then_scalar() {
     assert_eq!(cfg.get_string("b").unwrap(), "scalar-val");
 }
 
+/// Bracket-quoted cache disambiguation (Copilot rs#88 round-1 finding).
+///
+/// `${"X[]"}` is a quoted segment whose literal text is `X[]`; resolved via
+/// env lookup of the bare key `X[]` (no `_N` suffix expansion). `${X[]}` is the
+/// list-suffix form on bare path `X`; resolved via env scan of `X_0, X_1, …`.
+/// These two MUST occupy distinct cache slots — before the round-2 fix
+/// (`segments_to_key` quote trigger gained `[` and `]`), both produced the
+/// raw cache key `X[]` because `segments_to_key` didn't escape brackets.
+/// Now `${"X[]"}` keys as `"X[]"` (quoted) and `${X[]}` keys as `X[]` (raw +
+/// list_suffix `[]` append). This test pins both directions so the regression
+/// would surface if either the bracket trigger or the `[]` append is removed.
+#[test]
+fn s13c_cache_disambiguation_quoted_brackets_then_list() {
+    let mut env = HashMap::new();
+    env.insert("X[]".to_string(), "literal-bracket-key".to_string());
+    env.insert("X_0".to_string(), "first".to_string());
+    env.insert("X_1".to_string(), "second".to_string());
+    let cfg = hocon::parse_with_env("a = ${\"X[]\"}\nb = ${X[]}", &env).expect("parse_with_env");
+    assert_eq!(cfg.get_string("a").unwrap(), "literal-bracket-key");
+    let b = cfg
+        .get_list("b")
+        .expect("b should be list, not the cached scalar");
+    let texts: Vec<String> = b
+        .iter()
+        .map(|v| match v {
+            HoconValue::Scalar(sv) => sv.raw.clone(),
+            _ => panic!("expected scalar element in b"),
+        })
+        .collect();
+    assert_eq!(texts, vec!["first", "second"]);
+}
+
+#[test]
+fn s13c_cache_disambiguation_list_then_quoted_brackets() {
+    let mut env = HashMap::new();
+    env.insert("X[]".to_string(), "literal-bracket-key".to_string());
+    env.insert("X_0".to_string(), "first".to_string());
+    env.insert("X_1".to_string(), "second".to_string());
+    let cfg = hocon::parse_with_env("a = ${X[]}\nb = ${\"X[]\"}", &env).expect("parse_with_env");
+    let a = cfg.get_list("a").expect("a should be list");
+    let texts: Vec<String> = a
+        .iter()
+        .map(|v| match v {
+            HoconValue::Scalar(sv) => sv.raw.clone(),
+            _ => panic!("expected scalar element in a"),
+        })
+        .collect();
+    assert_eq!(texts, vec!["first", "second"]);
+    assert_eq!(
+        cfg.get_string("b").unwrap(),
+        "literal-bracket-key",
+        "b should be scalar, not the cached list"
+    );
+}
+
 /// `${X.[]}` must be rejected as empty-segment-before-suffix at parse time.
 ///
 /// The empty-segment guard at the `'[' =>` arm fires when `!cur_started` (no

--- a/tests/env_var_list_test.rs
+++ b/tests/env_var_list_test.rs
@@ -2,8 +2,10 @@
 //!
 //! Fixtures loaded from `tests/testdata/hocon/env-var-list/` (synced from
 //! xx.hocon via `make testdata`). Expected JSON from
-//! `tests/testdata/hocon/../../../repos/xx.hocon/expected/hocon/env-var-list/`
-//! is co-located on disk under a path resolved at runtime.
+//! `tests/testdata/expected/env-var-list/` (also synced via `make testdata`).
+//! Both directories are populated by the Makefile's tarball fetch from xx.hocon
+//! main and persisted under the crate root so CI (which only checks out
+//! rs.hocon) can resolve them without depending on a sibling xx.hocon worktree.
 //!
 //! Env injection uses `parse_file_with_env` (hermetic — no `std::env::set_var`).
 
@@ -19,9 +21,9 @@ fn fixture_dir() -> PathBuf {
 }
 
 fn expected_dir() -> PathBuf {
-    // xx.hocon expected outputs sit two repo-siblings up from this crate root:
-    //   <agentscope>/repos/rs.hocon  →  <agentscope>/repos/xx.hocon
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../xx.hocon/expected/hocon/env-var-list")
+    // Synced by `make testdata` from xx.hocon main into a crate-local path so CI
+    // (which only checks out rs.hocon, no sibling xx.hocon worktree) can find it.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/testdata/expected/env-var-list")
 }
 
 fn fixture_path(name: &str) -> PathBuf {

--- a/tests/env_var_list_test.rs
+++ b/tests/env_var_list_test.rs
@@ -1,0 +1,304 @@
+//! S13c — env-var list expansion `${X[]}` / `${?X[]}` conformance tests.
+//!
+//! Fixtures loaded from `tests/testdata/hocon/env-var-list/` (synced from
+//! xx.hocon via `make testdata`). Expected JSON from
+//! `tests/testdata/hocon/../../../repos/xx.hocon/expected/hocon/env-var-list/`
+//! is co-located on disk under a path resolved at runtime.
+//!
+//! Env injection uses `parse_file_with_env` (hermetic — no `std::env::set_var`).
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+// ── Paths ─────────────────────────────────────────────────────────────────────
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/testdata/hocon/env-var-list")
+}
+
+fn expected_dir() -> PathBuf {
+    // xx.hocon expected outputs sit two repo-siblings up from this crate root:
+    //   <agentscope>/repos/rs.hocon  →  <agentscope>/repos/xx.hocon
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../xx.hocon/expected/hocon/env-var-list")
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    fixture_dir().join(format!("{}.conf", name))
+}
+
+fn env_path(name: &str) -> PathBuf {
+    fixture_dir().join(format!("{}.env", name))
+}
+
+fn expected_path(name: &str) -> PathBuf {
+    expected_dir().join(format!("{}-expected.json", name))
+}
+
+// ── Sidecar parser ────────────────────────────────────────────────────────────
+
+/// Parse a KEY=VALUE sidecar file into a `HashMap<String, String>`.
+///
+/// Rules:
+/// - Lines beginning with `#` (after optional leading ASCII space/tab) are comments.
+/// - Blank lines are ignored.
+/// - `KEY=VALUE` — value is everything after the first `=`; value may be empty.
+/// - Keys and values are NOT unquoted / unescaped (fixtures use plain ASCII).
+fn parse_env_sidecar(path: &std::path::Path) -> HashMap<String, String> {
+    let content = fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("failed to read env sidecar {}: {}", path.display(), e));
+    let mut map = HashMap::new();
+    for line in content.lines() {
+        let trimmed = line.trim_start_matches(|c| c == ' ' || c == '\t');
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if let Some(eq) = trimmed.find('=') {
+            let key = trimmed[..eq].to_string();
+            let val = trimmed[eq + 1..].to_string();
+            map.insert(key, val);
+        }
+    }
+    map
+}
+
+// ── JSON helpers (mirrors lightbend_test.rs) ─────────────────────────────────
+
+fn normalize(v: &serde_json::Value) -> serde_json::Value {
+    match v {
+        serde_json::Value::Object(map) => {
+            let mut m = serde_json::Map::new();
+            for (k, val) in map {
+                m.insert(k.clone(), normalize(val));
+            }
+            serde_json::Value::Object(m)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(normalize).collect())
+        }
+        serde_json::Value::Number(n) => {
+            let f = n.as_f64().unwrap_or(0.0);
+            serde_json::json!(f)
+        }
+        other => other.clone(),
+    }
+}
+
+fn hocon_to_json(v: &hocon::HoconValue) -> serde_json::Value {
+    match v {
+        hocon::HoconValue::Object(map) => {
+            let mut m = serde_json::Map::new();
+            for (k, val) in map {
+                m.insert(k.clone(), hocon_to_json(val));
+            }
+            serde_json::Value::Object(m)
+        }
+        hocon::HoconValue::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(hocon_to_json).collect())
+        }
+        hocon::HoconValue::Scalar(sv) => match sv.value_type {
+            hocon::ScalarType::Null => serde_json::Value::Null,
+            hocon::ScalarType::Boolean => serde_json::Value::Bool(sv.raw == "true"),
+            hocon::ScalarType::Number => {
+                if !sv.raw.contains('.') && !sv.raw.contains('e') && !sv.raw.contains('E') {
+                    if let Ok(n) = sv.raw.parse::<i64>() {
+                        return serde_json::json!(n as f64);
+                    }
+                }
+                if let Ok(f) = sv.raw.parse::<f64>() {
+                    return serde_json::json!(f);
+                }
+                serde_json::Value::String(sv.raw.clone())
+            }
+            hocon::ScalarType::String => serde_json::Value::String(sv.raw.clone()),
+            _ => serde_json::Value::String(sv.raw.clone()),
+        },
+        _ => unreachable!("unknown HoconValue variant"),
+    }
+}
+
+fn key_to_lookup_path(key: &str) -> String {
+    if key.is_empty()
+        || key.contains('.')
+        || key.contains('"')
+        || key.contains('\\')
+        || key.contains(' ')
+        || key.contains('\t')
+    {
+        let escaped = key.replace('\\', "\\\\").replace('"', "\\\"");
+        format!("\"{}\"", escaped)
+    } else {
+        key.to_string()
+    }
+}
+
+fn config_to_json(config: &hocon::Config) -> serde_json::Value {
+    let mut m = serde_json::Map::new();
+    for key in config.keys() {
+        let path = key_to_lookup_path(key);
+        if let Some(val) = config.get(&path) {
+            m.insert(key.to_string(), hocon_to_json(val));
+        }
+    }
+    normalize(&serde_json::Value::Object(m))
+}
+
+// ── Fixture helpers ───────────────────────────────────────────────────────────
+
+fn parse_fixture_with_env(name: &str) -> Result<hocon::Config, hocon::HoconError> {
+    let env = parse_env_sidecar(&env_path(name));
+    hocon::parse_file_with_env(&fixture_path(name), &env)
+}
+
+fn load_expected_json(name: &str) -> serde_json::Value {
+    let path = expected_path(name);
+    let s = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read expected {}: {}", path.display(), e));
+    let v: serde_json::Value = serde_json::from_str(&s)
+        .unwrap_or_else(|e| panic!("invalid JSON in {}: {}", path.display(), e));
+    normalize(&v)
+}
+
+fn assert_fixture_matches(name: &str) {
+    let cfg = parse_fixture_with_env(name)
+        .unwrap_or_else(|e| panic!("s13c {}: unexpected parse/resolve error: {:?}", name, e));
+    let got = config_to_json(&cfg);
+    let expected = load_expected_json(name);
+    assert_eq!(
+        got, expected,
+        "s13c {}: output mismatch\n  got:      {}\n  expected: {}",
+        name,
+        serde_json::to_string_pretty(&got).unwrap(),
+        serde_json::to_string_pretty(&expected).unwrap(),
+    );
+}
+
+// ── Unit 5 RED: ev01 basic expansion ─────────────────────────────────────────
+// (This will fail until Unit 5 GREEN adds resolve_env_list to the resolver.)
+
+/// ev01: `x = ${S13C_EV01_MY_LIST[]}` with _0=a, _1=b → `{"x": ["a","b"]}`.
+#[test]
+fn s13c_ev01_basic() {
+    assert_fixture_matches("ev01-basic");
+}
+
+// ── Unit 6: remaining success fixtures ───────────────────────────────────────
+// (These will also fail at RED; added here so their RED is captured in one commit.)
+
+/// ev02: stops at gap (_0 present, _1 absent, _2 present → only ["a"]).
+#[test]
+fn s13c_ev02_stops_at_gap() {
+    assert_fixture_matches("ev02-stops-at-gap");
+}
+
+/// ev04: optional with no _0 → key absent (`{}`).
+#[test]
+fn s13c_ev04_optional_no_elements() {
+    assert_fixture_matches("ev04-optional-no-elements");
+}
+
+/// ev05: config-defined wins (E6). `${X[]}` returns config value, not env list.
+#[test]
+fn s13c_ev05_config_defined_wins() {
+    assert_fixture_matches("ev05-config-defined-wins");
+}
+
+/// ev06: concat prepend — `["x","y"] ${?S13C_EV06_MY_LIST[]}` → `["x","y","a"]`.
+#[test]
+fn s13c_ev06_concat_prepend() {
+    assert_fixture_matches("ev06-concat-prepend");
+}
+
+/// ev07: concat append — `${?S13C_EV07_MY_LIST[]} ["x","y"]` → `["a","x","y"]`.
+#[test]
+fn s13c_ev07_concat_append() {
+    assert_fixture_matches("ev07-concat-append");
+}
+
+/// ev09: E7 — whitespace before `[]` in fixture: `${S13C_EV09_MY_LIST []}`.
+#[test]
+fn s13c_ev09_whitespace_before_suffix() {
+    assert_fixture_matches("ev09-whitespace-before-suffix");
+}
+
+/// ev10: empty-string element is preserved (stop on absent key, not empty value).
+#[test]
+fn s13c_ev10_empty_string_element() {
+    assert_fixture_matches("ev10-empty-string-element");
+}
+
+/// ev11: include context — relativized fallback strips include prefix.
+#[test]
+fn s13c_ev11_include_context() {
+    assert_fixture_matches("ev11-include-context");
+}
+
+// ── Unit 7: error fixture ─────────────────────────────────────────────────────
+
+/// ev03: required `${S13C_EV03_MY_LIST[]}` with no _0 → ResolveError.
+#[test]
+fn s13c_ev03_required_no_elements_errors() {
+    let result = parse_fixture_with_env("ev03-required-no-elements");
+    assert!(
+        matches!(result, Err(hocon::HoconError::Resolve(_))),
+        "ev03: required list with no _0 must raise ResolveError, got: {:?}",
+        result
+    );
+}
+
+// ── Unit 8: S13c.5 — scalar env fallback suppressed when list_suffix=true ────
+
+/// When `list_suffix=true` and config lookup misses AND no `_0` element exists,
+/// the resolver must NOT fall through to the scalar env fallback.
+/// Required form must raise ResolveError.
+#[test]
+fn s13c_s5_required_no_scalar_fallback() {
+    let mut env = HashMap::new();
+    env.insert("S13C_BARE".into(), "scalar".into());
+    // No S13C_BARE_0 → list lookup finds nothing → must error (not "scalar").
+    let result = hocon::parse_with_env("x = ${S13C_BARE[]}", &env);
+    assert!(
+        matches!(result, Err(hocon::HoconError::Resolve(_))),
+        "S13c.5: required list with no _0 must raise ResolveError even when bare key exists, got: {:?}",
+        result
+    );
+}
+
+/// Optional form with `list_suffix=true` and no `_0` → key absent, not scalar fallback.
+#[test]
+fn s13c_s5_optional_no_scalar_fallback() {
+    let mut env = HashMap::new();
+    env.insert("S13C_BARE_OPT".into(), "scalar".into());
+    // No S13C_BARE_OPT_0 → optional list lookup finds nothing → key removed.
+    let cfg = hocon::parse_with_env("x = ${?S13C_BARE_OPT[]}", &env)
+        .expect("s13c.5: optional list with no _0 must parse OK (key dropped)");
+    // x must be absent (not "scalar")
+    assert!(
+        cfg.get("x").is_none(),
+        "S13c.5: optional list with no _0 must drop key (got {:?})",
+        cfg.get("x")
+    );
+}
+
+// ── Unit 9: ev08 tripwire ─────────────────────────────────────────────────────
+
+/// ev08 depends on S13a.13 self-ref-lookback fix (cluster 3f, not yet landed).
+///
+/// Today `x = ${?x} ${?LIST[]}` fails to look back at the prior `x = ["x"]`,
+/// so the assertion below panics with a message containing "ev08". When S13a.13
+/// lands, the equality holds, no panic → `#[should_panic]` fires, forcing a
+/// code change. Identical pattern to `s8_6_us13_known_gap_tripwire`.
+#[test]
+#[should_panic(expected = "ev08")]
+fn s13c_ev08_self_ref_tripwire() {
+    let result = parse_fixture_with_env("ev08-self-append");
+    let got = result
+        .map(|c| config_to_json(&c))
+        .unwrap_or_else(|e| panic!("ev08: parse failed (expected resolve): {:?}", e));
+    let expected = load_expected_json("ev08-self-append");
+    assert_eq!(
+        got, expected,
+        "ev08: depends on S13a.13 self-ref-lookback fix (cluster 3f)"
+    );
+}

--- a/tests/env_var_list_test.rs
+++ b/tests/env_var_list_test.rs
@@ -177,8 +177,7 @@ fn assert_fixture_matches(name: &str) {
     );
 }
 
-// ── Unit 5 RED: ev01 basic expansion ─────────────────────────────────────────
-// (This will fail until Unit 5 GREEN adds resolve_env_list to the resolver.)
+// ── ev01: basic env-var list expansion ───────────────────────────────────────
 
 /// ev01: `x = ${S13C_EV01_MY_LIST[]}` with _0=a, _1=b → `{"x": ["a","b"]}`.
 #[test]
@@ -186,8 +185,7 @@ fn s13c_ev01_basic() {
     assert_fixture_matches("ev01-basic");
 }
 
-// ── Unit 6: remaining success fixtures ───────────────────────────────────────
-// (These will also fail at RED; added here so their RED is captured in one commit.)
+// ── Remaining success fixtures (ev02, ev04–ev11) ─────────────────────────────
 
 /// ev02: stops at gap (_0 present, _1 absent, _2 present → only ["a"]).
 #[test]
@@ -348,37 +346,54 @@ fn s13c_cache_disambiguation_list_then_scalar() {
     assert_eq!(cfg.get_string("b").unwrap(), "scalar-val");
 }
 
-/// I1: `${X.[]}` must be rejected as empty-segment-before-suffix.
+/// `${X.[]}` must be rejected as empty-segment-before-suffix at parse time.
 ///
-/// Before the fix, the `'[' =>` arm only checked `!cur_started && segments.is_empty()`,
-/// which missed the case where a trailing dot just reset cur_started but segments
-/// already had entries from prior segment parsing.
+/// The empty-segment guard at the `'[' =>` arm fires when `!cur_started` (no
+/// segment text is being accumulated), uniformly handling both `${[]}` (no
+/// segments at all) and `${X.[]}` (trailing dot just reset cur_started but
+/// segments already has entries from prior parsing).
+///
+/// Tests assert specifically `Err(HoconError::Parse(_))` rather than any error
+/// because an empty env map could otherwise let resolution fail with
+/// HoconError::Resolve and mask a lexer regression (Copilot review on rs#88).
 #[test]
 fn s13c_lex_trailing_dot_before_suffix_errors() {
     let env = HashMap::new();
     let err = hocon::parse_with_env("x = ${A.[]}", &env);
-    assert!(err.is_err(), "expected ParseError for ${{A.[]}}, got Ok");
+    assert!(
+        matches!(err, Err(hocon::HoconError::Parse(_))),
+        "expected HoconError::Parse for ${{A.[]}}, got {:?}",
+        err
+    );
 }
 
 #[test]
 fn s13c_lex_trailing_dot_space_before_suffix_errors() {
     let env = HashMap::new();
     let err = hocon::parse_with_env("x = ${A . []}", &env);
-    assert!(err.is_err(), "expected ParseError for ${{A . []}}, got Ok");
+    assert!(
+        matches!(err, Err(hocon::HoconError::Parse(_))),
+        "expected HoconError::Parse for ${{A . []}}, got {:?}",
+        err
+    );
 }
 
-/// I2: E7 narrow-allow-list — only ASCII SPACE / TAB allowed before `[]`.
+/// E7 narrow-allow-list — only ASCII SPACE / TAB allowed before `[]`.
 ///
-/// Before the fix, pending_ws accumulated wider HOCON whitespace (NBSP, CR,
-/// Zs, BOM) and the `[` arm discarded it all unconditionally. The new check
-/// rejects any non-{space,tab} char in pending_ws.
+/// The `[` arm validates pending_ws and rejects any non-{space,tab} char.
+/// General subst-body inter-segment whitespace is broader (S6 set: NBSP, CR,
+/// Zs, BOM, …) but at the `[` arm we are strict per extra-spec E7.
+///
+/// Tests assert specifically `Err(HoconError::Parse(_))` for the same reason as
+/// the trailing-dot tests above (Copilot review on rs#88).
 #[test]
 fn s13c_lex_nbsp_before_suffix_errors() {
     let env = HashMap::new();
     let err = hocon::parse_with_env("x = ${A\u{00A0}[]}", &env);
     assert!(
-        err.is_err(),
-        "expected ParseError for ${{A\\u00A0[]}} (NBSP), got Ok"
+        matches!(err, Err(hocon::HoconError::Parse(_))),
+        "expected HoconError::Parse for ${{A\\u00A0[]}} (NBSP), got {:?}",
+        err
     );
 }
 
@@ -387,8 +402,9 @@ fn s13c_lex_cr_before_suffix_errors() {
     let env = HashMap::new();
     let err = hocon::parse_with_env("x = ${A\r[]}", &env);
     assert!(
-        err.is_err(),
-        "expected ParseError for ${{A\\r[]}} (CR), got Ok"
+        matches!(err, Err(hocon::HoconError::Parse(_))),
+        "expected HoconError::Parse for ${{A\\r[]}} (CR), got {:?}",
+        err
     );
 }
 
@@ -397,8 +413,9 @@ fn s13c_lex_zs_em_space_before_suffix_errors() {
     let env = HashMap::new();
     let err = hocon::parse_with_env("x = ${A\u{2003}[]}", &env);
     assert!(
-        err.is_err(),
-        "expected ParseError for ${{A\\u2003[]}} (em-space), got Ok"
+        matches!(err, Err(hocon::HoconError::Parse(_))),
+        "expected HoconError::Parse for ${{A\\u2003[]}} (em-space), got {:?}",
+        err
     );
 }
 

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -189,3 +189,82 @@ fn lex_subst_no_list_suffix_for_plain() {
         .expect("SubstPayload");
     assert!(!p.list_suffix, "plain ${{X}} must NOT set list_suffix");
 }
+
+// ── Unit 4: E7 — whitespace before '[]' is allowed ───────────────────────────
+
+/// ASCII space between path and `[]` is allowed (E7).
+#[test]
+fn lex_subst_list_suffix_e7_space() {
+    // ${X []} — one space before `[`
+    let tokens = hocon::tokenize("${X []}").unwrap();
+    let p = tokens
+        .iter()
+        .find(|t| t.kind == hocon::TokenKind::Substitution)
+        .and_then(|t| t.subst.as_ref())
+        .expect("SubstPayload");
+    assert!(p.list_suffix, "space before [] must still set list_suffix");
+    assert_eq!(p.segments.len(), 1);
+    assert_eq!(p.segments[0].text, "X");
+}
+
+/// ASCII tab between path and `[]` is allowed (E7).
+#[test]
+fn lex_subst_list_suffix_e7_tab() {
+    // "${X\t[]}" — tab before `[`
+    let input = "${X\t[]}";
+    let tokens = hocon::tokenize(input).unwrap();
+    let p = tokens
+        .iter()
+        .find(|t| t.kind == hocon::TokenKind::Substitution)
+        .and_then(|t| t.subst.as_ref())
+        .expect("SubstPayload");
+    assert!(p.list_suffix, "tab before [] must still set list_suffix");
+    assert_eq!(p.segments[0].text, "X");
+}
+
+// ── Unit 3: error shapes for malformed '[]' suffix ────────────────────────────
+
+/// `${[]}` — empty path before `[]` suffix is a lex error.
+#[test]
+fn lex_subst_list_suffix_empty_path_errors() {
+    let err = hocon::tokenize("${[]}").unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("empty segment before") || msg.contains("empty substitution path"),
+        "expected empty-segment/path error, got: {}",
+        msg
+    );
+}
+
+/// `${X[}` — missing `]` is a lex error.
+#[test]
+fn lex_subst_list_suffix_missing_close_bracket_errors() {
+    let err = hocon::tokenize("${X[}").unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("expected ']'"),
+        "expected ']' missing error, got: {}",
+        msg
+    );
+}
+
+/// `${X[ ]}` — whitespace inside `[]` is a lex error (strict per spec Decision §1).
+#[test]
+fn lex_subst_list_suffix_whitespace_inside_brackets_errors() {
+    let err = hocon::tokenize("${X[ ]}").unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("expected ']'"),
+        "expected ']' missing error for whitespace inside [], got: {}",
+        msg
+    );
+}
+
+/// `${X[][]}` — double suffix is a lex error (second `[` is unexpected after `}`).
+#[test]
+fn lex_subst_list_suffix_double_suffix_errors() {
+    // After `${X[]}` the tokenizer emits Substitution and advances past `}`.
+    // The trailing `[]` is then an unexpected `[` in value position → ParseError.
+    let result = hocon::tokenize("x = ${X[][]}");
+    assert!(result.is_err(), "${{X[][]}} must be a lex/parse error");
+}

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -130,3 +130,62 @@ fn surrogate_codepoint_rejected_inside_subst() {
     let msg = err.to_string();
     assert!(msg.contains("invalid unicode escape"), "msg = {}", msg);
 }
+
+// ── S13c: `[]` suffix on substitutions ───────────────────────────────────────
+
+/// Unit 2 RED: `${X[]}` lexes into a Substitution token with list_suffix=true,
+/// segments=["X"].
+#[test]
+fn lex_subst_list_suffix_basic() {
+    let tokens = hocon::tokenize("${X[]}").unwrap();
+    let t = tokens
+        .iter()
+        .find(|t| t.kind == hocon::TokenKind::Substitution)
+        .expect("Substitution token");
+    let p = t.subst.as_ref().expect("SubstPayload");
+    assert!(p.list_suffix, "list_suffix must be true for ${{X[]}}");
+    assert_eq!(p.segments.len(), 1, "exactly one segment");
+    assert_eq!(p.segments[0].text, "X");
+    assert!(!p.optional);
+}
+
+/// Unit 2: `${?X[]}` — optional form with list_suffix.
+#[test]
+fn lex_subst_list_suffix_optional() {
+    let tokens = hocon::tokenize("${?X[]}").unwrap();
+    let t = tokens
+        .iter()
+        .find(|t| t.kind == hocon::TokenKind::Substitution)
+        .expect("Substitution token");
+    let p = t.subst.as_ref().expect("SubstPayload");
+    assert!(p.list_suffix, "list_suffix must be true for ${{?X[]}}");
+    assert!(p.optional);
+    assert_eq!(p.segments[0].text, "X");
+}
+
+/// Unit 2: multi-segment path `${FOO.BAR[]}`.
+#[test]
+fn lex_subst_list_suffix_multipath() {
+    let tokens = hocon::tokenize("${FOO.BAR[]}").unwrap();
+    let p = tokens
+        .iter()
+        .find(|t| t.kind == hocon::TokenKind::Substitution)
+        .and_then(|t| t.subst.as_ref())
+        .expect("SubstPayload");
+    assert!(p.list_suffix);
+    assert_eq!(p.segments.len(), 2);
+    assert_eq!(p.segments[0].text, "FOO");
+    assert_eq!(p.segments[1].text, "BAR");
+}
+
+/// Unit 2: plain `${X}` must NOT set list_suffix.
+#[test]
+fn lex_subst_no_list_suffix_for_plain() {
+    let tokens = hocon::tokenize("${X}").unwrap();
+    let p = tokens
+        .iter()
+        .find(|t| t.kind == hocon::TokenKind::Substitution)
+        .and_then(|t| t.subst.as_ref())
+        .expect("SubstPayload");
+    assert!(!p.list_suffix, "plain ${{X}} must NOT set list_suffix");
+}

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -133,8 +133,7 @@ fn surrogate_codepoint_rejected_inside_subst() {
 
 // ── S13c: `[]` suffix on substitutions ───────────────────────────────────────
 
-/// Unit 2 RED: `${X[]}` lexes into a Substitution token with list_suffix=true,
-/// segments=["X"].
+/// `${X[]}` lexes into a Substitution token with list_suffix=true, segments=["X"].
 #[test]
 fn lex_subst_list_suffix_basic() {
     let tokens = hocon::tokenize("${X[]}").unwrap();
@@ -260,11 +259,12 @@ fn lex_subst_list_suffix_whitespace_inside_brackets_errors() {
     );
 }
 
-/// `${X[][]}` — double suffix is a lex error (second `[` is unexpected after `}`).
+/// `${X[][]}` — double suffix is a lex error. After the literal `[]` suffix
+/// is consumed, the `[` arm in `parse_subst_body` expects the closing `}` and
+/// errors with "expected '}' after '[]' in substitution" because the next char
+/// is `[`, not `}`. (Lex error fires inside parse_subst_body, not afterwards.)
 #[test]
 fn lex_subst_list_suffix_double_suffix_errors() {
-    // After `${X[]}` the tokenizer emits Substitution and advances past `}`.
-    // The trailing `[]` is then an unexpected `[` in value position → ParseError.
     let result = hocon::tokenize("x = ${X[][]}");
     assert!(result.is_err(), "${{X[][]}} must be a lex/parse error");
 }


### PR DESCRIPTION
## Summary

Add HOCON `${X[]}` / `${?X[]}` env-var list expansion (HOCON.md L893–L917, S13c.1–5) plus extra-spec **E6** (config-defined wins) and **E7** (whitespace before `[]`).

- **Lexer** (`src/lexer.rs`): `SubstPayload.list_suffix: bool` + `#[non_exhaustive]`; new `'[' =>` arm in `parse_subst_body`; new `parse_literal_brackets` helper.
- **AST** (`src/parser.rs`): `AstNode::Substitution.list_suffix` + `#[non_exhaustive]`.
- **Resolver** (`src/resolver/types.rs`, `structure_builder.rs`, `substitution_resolver.rs`): `SubstPlaceholder.list_suffix`; `resolve_env_list` helper. Branches BEFORE scalar env fallback (S13c.5). Cache key includes `list_suffix` to prevent `${X}` / `${X[]}` collision.
- **Tests** (`tests/env_var_list_test.rs`): 11 ev fixtures + dedicated unit tests (S13c.5 unit pin, cache disambiguation, lexer E7/`${X.[]}` regressions).

## `#[non_exhaustive]` discipline

Applied to `SubstPayload` (pub struct) AND `AstNode::Substitution` (pub enum variant) in the same commit as the field addition. Rationale: this is the v1.2.0 → v1.3.0 window where SemVer discipline can be installed before more public-API field additions accumulate. Phase 6 #1 and #2 followed the same pattern.

## Cross-impl multi-impl convergence

Spec/plan originally classified ev08-self-append as a `#[should_panic]` tripwire pending cluster 3f (S13a.13). Multi-impl probe (ts + rs + go all pass naturally) confirmed the assumption was wrong: ev08's `x = ["x"]; x = ${?x} ${?LIST[]}` has a clear prior value for `x`. Ships as a regular passing test.

## Multi-agent-review fixes applied

Local /multi-agent-review (Claude + Codex file-pipe) flagged 1 Critical + 2 Important:

- **Critical C1** (discovered HERE first): cache-key collision between `${X}` and `${X[]}`. Same code shape exists in ts.hocon (also fixed there). go.hocon is incidentally immune (cache is self-ref-recovery only).
- **Important I1**: `${X.[]}` silently accepted. Fixed via `if !cur_started { error }`. Convergent with ts + go.
- **Important I2**: E7 whitespace too broad. Restricted to ASCII SPACE/TAB. Convergent with ts + go.

All 3 pinned with new regression tests in `tests/env_var_list_test.rs` (22 tests total: 16 fixture + 6 new).

## Test plan

- [ ] `cargo test --all-targets` — all green (397+ tests, including 6 new S13c regressions)
- [ ] `cargo test --features serde` — clean (serde Vec<T> deserialization works via existing impl)
- [ ] `cargo fmt --check` — clean
- [ ] `cargo doc --no-deps` — clean (all new pub fields have doc comments)
- [ ] `docs/spec-compliance.md` S13c.1–5 ✅; E6/E7 ✅
- [ ] CHANGELOG entry under Unreleased

Note: `cargo clippy --all-targets -- -D warnings` has pre-existing failures on develop unrelated to this PR (PI approximations in `integration_test.rs`, doc-list-indent in `s8_unquoted_starts.rs`); follow-up clippy cleanup is a separate concern.

## Merge order

Can merge after xx.hocon ev12/13 fixtures PR (no hard dependency since rs pins S13c.5 via unit tests, not xx fixtures). Independent of ts + go impl PRs.

Spec: `.claude/superpowers/specs/2026-05-18-s13c-env-var-list-design.md`
Plan: `.claude/superpowers/plans/2026-05-18-s13c-rs-hocon-impl.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)