### PR TITLE
fix(s12.5): reject unquoted include at start of key path (HOCON.md L570) — Phase 6 #3e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **S12.5 — `include` reserved at start of key path** (Phase 6 #3e):
+  Unquoted `include` at the start of a key path expression (including the dotted form
+  `include.foo = 1`) is now a parse error per HOCON.md L570. The bare forms
+  (`include = 1`, `include : 1`, `include += [1]`, `include { ... }`) were already
+  rejected via the include-statement branch; this fix adds the dotted case.
+  Quoted `"include"` and non-initial `foo.include` are unaffected.
+  Closes #71.
+
 - **S10.4/S10.13/S10.19 — concat type-check tightening** (Phase 6 #3b):
   `join_pair` in the substitution resolver now returns `ResolveError` for every
   spec-disallowed value-concatenation type pair instead of silently coercing.

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -296,8 +296,8 @@ same item descriptions verbatim.
   tests: tests/testdata/hocon/equiv02/path-keys-weird-whitespace.conf (fixture)
   status: ✅
 - **S12.5** `include` may NOT begin a path expression in a key — §Paths as keys (L570)
-  tests: tests/integration_test.rs:921 (s12_5_include_as_key_pin); tests/integration_test.rs:932 (s12_5_include_as_key_spec)
-  status: ❌ (see #71)
+  tests: tests/integration_test.rs (s12_5_include_as_key_spec); tests/include_reservation_test.rs (ir01–ir14, ir03/ir04 per-impl overrides); src/parser.rs (include_dot_key_is_parse_error, include_nested_object_body_is_parse_error, quoted_include_bypasses_reservation, et al.)
+  status: ✅ (fixed in fix/s12.5-include-reservation, closes #71)
 
 ## S13. Substitutions
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -217,10 +217,10 @@ impl<'a> Parser<'a> {
                 if let Some(first) = key.first() {
                     if first == "include" {
                         return Err(ParseError {
-                            message: format!(
-                                "'include' is reserved at the start of a key path expression; \
-                                 use \"include\" (quoted) or rename the key (HOCON.md L570)"
-                            ),
+                            message: "'include' is reserved at the start of a key path \
+                                      expression; use \"include\" (quoted) or rename the \
+                                      key (HOCON.md L570)"
+                                .to_string(),
                             line: key_pos.line,
                             col: key_pos.col,
                         });

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -199,9 +199,34 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
+            // S12.5 (HOCON.md L570): record whether the first key token is quoted
+            // so we can enforce the `include` reservation below.
+            let first_key_is_quoted = self.peek_kind() == TokenKind::QuotedString;
+
             // key
             let key_pos = self.current_pos();
             let key = self.parse_key()?;
+
+            // S12.5: `include` is reserved as the first *unquoted* path element in a key.
+            // The bare form (`include = 1`, `include += [1]`, `include { ... }`) is already
+            // rejected via parse_include() above (L191 branch). The dotted form
+            // (`include.foo = 1`) falls through here because the lexer emits
+            // `include.foo` as a single Unquoted token that does not equal the bare
+            // 7-char string "include".
+            if !first_key_is_quoted {
+                if let Some(first) = key.first() {
+                    if first == "include" {
+                        return Err(ParseError {
+                            message: format!(
+                                "'include' is reserved at the start of a key path expression; \
+                                 use \"include\" (quoted) or rename the key (HOCON.md L570)"
+                            ),
+                            line: key_pos.line,
+                            col: key_pos.col,
+                        });
+                    }
+                }
+            }
 
             // value separator (optional)
             self.skip(&[TokenKind::Newline]);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -832,4 +832,60 @@ mod tests {
             panic!("expected Include");
         }
     }
+
+    // ── S12.5: `include` reserved at start of key path (HOCON.md L570) ────────
+
+    #[test]
+    fn include_dot_key_is_parse_error() {
+        // ir03: unquoted dotted form must be rejected
+        assert!(matches!(
+            parse_tokens(&tokenize("include.foo = 1").unwrap()),
+            Err(ParseError { .. })
+        ));
+    }
+
+    #[test]
+    fn include_nested_object_body_is_parse_error() {
+        // ir04: reservation applies uniformly inside object literals
+        assert!(matches!(
+            parse_tokens(&tokenize("a = { include.bar = 1 }").unwrap()),
+            Err(ParseError { .. })
+        ));
+    }
+
+    #[test]
+    fn quoted_include_bypasses_reservation() {
+        // ir06: "include" = 1 must succeed
+        assert!(parse_tokens(&tokenize(r#""include" = 1"#).unwrap()).is_ok());
+    }
+
+    #[test]
+    fn quoted_include_dotted_bypasses_reservation() {
+        // ir11: "include".foo = 1 must succeed
+        assert!(parse_tokens(&tokenize(r#""include".foo = 1"#).unwrap()).is_ok());
+    }
+
+    #[test]
+    fn include_bare_equals_is_parse_error() {
+        // ir01 regression guard (already handled via parse_include path)
+        assert!(parse_tokens(&tokenize("include = 1").unwrap()).is_err());
+    }
+
+    #[test]
+    fn include_plus_equals_is_parse_error() {
+        // ir10: += separator form
+        assert!(parse_tokens(&tokenize("include += [1]").unwrap()).is_err());
+    }
+
+    #[test]
+    fn include_object_body_is_parse_error() {
+        // ir13: object-body field write form
+        assert!(parse_tokens(&tokenize("include { x = 1 }").unwrap()).is_err());
+    }
+
+    #[test]
+    fn foo_include_non_initial_is_ok() {
+        // ir07 regression guard: non-initial include is not reserved
+        assert!(parse_tokens(&tokenize("foo.include = 1").unwrap()).is_ok());
+    }
 }

--- a/tests/include_reservation_test.rs
+++ b/tests/include_reservation_test.rs
@@ -18,21 +18,17 @@ use std::path::PathBuf;
 /// Fixtures that are intentionally missing a sidecar because the Lightbend reference
 /// implementation silently accepts them (quirk, not a conformance gap).
 /// rs.hocon enforces strict HOCON.md compliance; see ir03_per_impl / ir04_per_impl below.
-const KNOWN_LIGHTBEND_QUIRKS: &[&str] = &[
-    "ir03-include-dot-foo-equals",
-    "ir04-include-nested-object",
-];
+const KNOWN_LIGHTBEND_QUIRKS: &[&str] =
+    &["ir03-include-dot-foo-equals", "ir04-include-nested-object"];
 
 // ── Paths ─────────────────────────────────────────────────────────────────────
 
 fn fixture_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/testdata/hocon/include-reservation")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/testdata/hocon/include-reservation")
 }
 
 fn expected_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/testdata/expected/include-reservation")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/testdata/expected/include-reservation")
 }
 
 fn fixture_path(stem: &str) -> PathBuf {

--- a/tests/include_reservation_test.rs
+++ b/tests/include_reservation_test.rs
@@ -1,0 +1,307 @@
+//! S12.5 — `include` reserved at start of key path — conformance tests.
+//! Fixtures: tests/testdata/hocon/include-reservation/ (ir01–ir14).
+//! Sidecars:  tests/testdata/expected/include-reservation/.
+//!
+//! Convention:
+//! - `.error` sidecar present → assert `parse_file_with_env(...).is_err()`
+//! - `-expected.json` present → assert `parse_file_with_env(...).is_ok()` + compare JSON
+//! - neither present → checked against KNOWN_LIGHTBEND_QUIRKS; error if not listed
+//!
+//! ir03/ir04 have no xx.hocon sidecar (Lightbend silently accepts them
+//! due to tokenizer quirk — see spec §Strict-spec posture). These are
+//! listed in KNOWN_LIGHTBEND_QUIRKS and tested via per-impl override
+//! functions that assert is_err() directly (strict HOCON.md compliance).
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Fixtures that are intentionally missing a sidecar because the Lightbend reference
+/// implementation silently accepts them (quirk, not a conformance gap).
+/// rs.hocon enforces strict HOCON.md compliance; see ir03_per_impl / ir04_per_impl below.
+const KNOWN_LIGHTBEND_QUIRKS: &[&str] = &[
+    "ir03-include-dot-foo-equals",
+    "ir04-include-nested-object",
+];
+
+// ── Paths ─────────────────────────────────────────────────────────────────────
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/testdata/hocon/include-reservation")
+}
+
+fn expected_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/testdata/expected/include-reservation")
+}
+
+fn fixture_path(stem: &str) -> PathBuf {
+    fixture_dir().join(format!("{}.conf", stem))
+}
+
+fn error_sidecar_path(stem: &str) -> PathBuf {
+    expected_dir().join(format!("{}.error", stem))
+}
+
+fn expected_json_path(stem: &str) -> PathBuf {
+    expected_dir().join(format!("{}-expected.json", stem))
+}
+
+// ── JSON helpers (mirrors concat_errors_test.rs) ──────────────────────────────
+
+fn normalize(v: &serde_json::Value) -> serde_json::Value {
+    match v {
+        serde_json::Value::Object(map) => {
+            let mut m = serde_json::Map::new();
+            for (k, val) in map {
+                m.insert(k.clone(), normalize(val));
+            }
+            serde_json::Value::Object(m)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(normalize).collect())
+        }
+        serde_json::Value::Number(n) => {
+            let f = n.as_f64().unwrap_or(0.0);
+            serde_json::json!(f)
+        }
+        other => other.clone(),
+    }
+}
+
+fn hocon_to_json(v: &hocon::HoconValue) -> serde_json::Value {
+    match v {
+        hocon::HoconValue::Object(map) => {
+            let mut m = serde_json::Map::new();
+            for (k, val) in map {
+                m.insert(k.clone(), hocon_to_json(val));
+            }
+            serde_json::Value::Object(m)
+        }
+        hocon::HoconValue::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(hocon_to_json).collect())
+        }
+        hocon::HoconValue::Scalar(sv) => match sv.value_type {
+            hocon::ScalarType::Null => serde_json::Value::Null,
+            hocon::ScalarType::Boolean => serde_json::Value::Bool(sv.raw == "true"),
+            hocon::ScalarType::Number => {
+                if !sv.raw.contains('.') && !sv.raw.contains('e') && !sv.raw.contains('E') {
+                    if let Ok(n) = sv.raw.parse::<i64>() {
+                        return serde_json::json!(n);
+                    }
+                }
+                if let Ok(f) = sv.raw.parse::<f64>() {
+                    return serde_json::json!(f);
+                }
+                serde_json::Value::String(sv.raw.clone())
+            }
+            hocon::ScalarType::String => serde_json::Value::String(sv.raw.clone()),
+            _ => serde_json::Value::String(sv.raw.clone()),
+        },
+        _ => panic!("hocon_to_json: unknown HoconValue variant: {:?}", v),
+    }
+}
+
+fn key_to_lookup_path(key: &str) -> String {
+    if key.is_empty()
+        || key.contains('.')
+        || key.contains('"')
+        || key.contains('\\')
+        || key.contains(' ')
+        || key.contains('\t')
+    {
+        let escaped = key.replace('\\', "\\\\").replace('"', "\\\"");
+        format!("\"{}\"", escaped)
+    } else {
+        key.to_string()
+    }
+}
+
+fn config_to_json(config: &hocon::Config) -> serde_json::Value {
+    let mut m = serde_json::Map::new();
+    for key in config.keys() {
+        let path = key_to_lookup_path(key);
+        if let Some(val) = config.get(&path) {
+            m.insert(key.to_string(), hocon_to_json(val));
+        }
+    }
+    normalize(&serde_json::Value::Object(m))
+}
+
+// ── Fixture runner ────────────────────────────────────────────────────────────
+
+fn run_fixture(stem: &str) {
+    let fp = fixture_path(stem);
+    let ep = error_sidecar_path(stem);
+    let jp = expected_json_path(stem);
+
+    let has_error = ep.exists();
+    let has_json = jp.exists();
+
+    if !has_error && !has_json {
+        if KNOWN_LIGHTBEND_QUIRKS.contains(&stem) {
+            eprintln!(
+                "note: include-reservation/{}.conf is a known Lightbend quirk — \
+                 skipping Lightbend-sidecar validation (per-impl override test applies instead)",
+                stem
+            );
+            return;
+        }
+        panic!(
+            "include-reservation/{stem}.conf has no expected sidecar (.error or -expected.json).\n\
+             Run `make testdata` first to fetch expected sidecars from xx.hocon.\n\
+             If this fixture is intentionally unsupported by Lightbend, add \"{stem}\" to \
+             KNOWN_LIGHTBEND_QUIRKS in tests/include_reservation_test.rs."
+        );
+    }
+
+    let env: HashMap<String, String> = HashMap::new();
+    let result = hocon::parse_file_with_env(&fp, &env);
+
+    if has_error {
+        assert!(
+            result.is_err(),
+            "include-reservation {}: expected parse/resolve error but got Ok (fixture: {})",
+            stem,
+            fp.display()
+        );
+    } else {
+        // has_json
+        let cfg = result.unwrap_or_else(|e| {
+            panic!(
+                "include-reservation {}: unexpected error {:?} (fixture: {})",
+                stem,
+                e,
+                fp.display()
+            )
+        });
+        let got = config_to_json(&cfg);
+
+        let json_src = std::fs::read_to_string(&jp)
+            .unwrap_or_else(|e| panic!("failed to read expected JSON {}: {}", jp.display(), e));
+        let expected: serde_json::Value = serde_json::from_str(&json_src)
+            .unwrap_or_else(|e| panic!("invalid JSON in {}: {}", jp.display(), e));
+        let expected = normalize(&expected);
+
+        assert_eq!(
+            got,
+            expected,
+            "include-reservation {}: output mismatch\n  got:      {}\n  expected: {}",
+            stem,
+            serde_json::to_string_pretty(&got).unwrap(),
+            serde_json::to_string_pretty(&expected).unwrap(),
+        );
+    }
+}
+
+// ── ir01–ir14 ─────────────────────────────────────────────────────────────────
+
+/// ir01: `include = 1` — parse error (S12.5)
+#[test]
+fn ir01_include_equals() {
+    run_fixture("ir01-include-equals");
+}
+
+/// ir02: `include : 1` — parse error (S12.5)
+#[test]
+fn ir02_include_colon() {
+    run_fixture("ir02-include-colon");
+}
+
+/// ir03: `include.foo = 1` — Lightbend quirk (silently accepts); rs.hocon enforces S12.5
+/// Lightbend-sidecar validation skipped via KNOWN_LIGHTBEND_QUIRKS.
+/// Per-impl override: ir03_include_dot_foo_per_impl below asserts is_err().
+#[test]
+fn ir03_include_dot_foo() {
+    run_fixture("ir03-include-dot-foo-equals");
+}
+
+/// ir04: `a = { include.bar = 1 }` — Lightbend quirk; rs.hocon enforces S12.5
+#[test]
+fn ir04_include_nested_object() {
+    run_fixture("ir04-include-nested-object");
+}
+
+/// ir05: `include "ir05-inner.conf"` — include statement still works (regression guard)
+#[test]
+fn ir05_include_statement() {
+    run_fixture("ir05-include-statement");
+}
+
+/// ir06: `"include" = 1` — quoted bypasses reservation, resolves to { include: 1 }
+#[test]
+fn ir06_quoted_include() {
+    run_fixture("ir06-quoted-include");
+}
+
+/// ir07: `foo.include = 1` — non-initial include is allowed
+#[test]
+fn ir07_include_non_initial() {
+    run_fixture("ir07-include-non-initial");
+}
+
+/// ir08: `a = include` — value-position include is an unquoted string, not a key
+#[test]
+fn ir08_include_as_value() {
+    run_fixture("ir08-include-as-value");
+}
+
+/// ir09: `include "ir09-inner.conf"` via file() form (regression guard)
+#[test]
+fn ir09_include_file_form() {
+    run_fixture("ir09-include-file-form");
+}
+
+/// ir10: `include += [1]` — += separator form, parse error (S12.5)
+#[test]
+fn ir10_include_plus_equals() {
+    run_fixture("ir10-include-plus-equals");
+}
+
+/// ir11: `"include".foo = 1` — quoted-dotted bypass; resolves to { include: { foo: 1 } }
+#[test]
+fn ir11_quoted_include_dotted() {
+    run_fixture("ir11-quoted-include-dotted");
+}
+
+/// ir12: `include\nfoo.conf` — existing include-statement parse error wins (not S12.5)
+#[test]
+fn ir12_include_newline_arg() {
+    run_fixture("ir12-include-newline-arg");
+}
+
+/// ir13: `include { x = 1 }` — object-body form, parse error (S12.5)
+#[test]
+fn ir13_include_object_body() {
+    run_fixture("ir13-include-object-body");
+}
+
+/// ir14: `a = ${include}` — substitution paths are NOT subject to the reservation
+#[test]
+fn ir14_substitution_include_path() {
+    run_fixture("ir14-substitution-include-path");
+}
+
+// ── Per-impl overrides for Lightbend quirks ───────────────────────────────────
+
+/// ir03 per-impl: rs.hocon strictly enforces S12.5 — `include.foo = 1` must fail.
+#[test]
+fn ir03_include_dot_foo_per_impl() {
+    let fp = fixture_path("ir03-include-dot-foo-equals");
+    let env: HashMap<String, String> = HashMap::new();
+    assert!(
+        hocon::parse_file_with_env(&fp, &env).is_err(),
+        "ir03: include.foo = 1 must be a parse error (S12.5, HOCON.md L570)"
+    );
+}
+
+/// ir04 per-impl: rs.hocon strictly enforces S12.5 — `a = {{ include.bar = 1 }}` must fail.
+#[test]
+fn ir04_include_nested_object_per_impl() {
+    let fp = fixture_path("ir04-include-nested-object");
+    let env: HashMap<String, String> = HashMap::new();
+    assert!(
+        hocon::parse_file_with_env(&fp, &env).is_err(),
+        "ir04: a = {{ include.bar = 1 }} must be a parse error (S12.5, HOCON.md L570)"
+    );
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -992,8 +992,14 @@ fn s12_5_include_as_key_spec() {
         );
     }
     // Quoted form and non-initial form must still succeed.
-    assert!(parse(r#""include" = 1"#).is_ok(), "quoted include must succeed");
-    assert!(parse("foo.include = 1").is_ok(), "non-initial include must succeed");
+    assert!(
+        parse(r#""include" = 1"#).is_ok(),
+        "quoted include must succeed"
+    );
+    assert!(
+        parse("foo.include = 1").is_ok(),
+        "non-initial include must succeed"
+    );
 }
 
 // --- S13b.2: `+=` on non-array prior value → error (HOCON L732) -------------

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -977,22 +977,23 @@ fn s11_9_subst_in_key_rejected() {
 
 // --- S12.5: `include` may NOT begin a key path (HOCON L570) -----------------
 #[test]
-fn s12_5_include_as_key_pin() {
-    // BUG: `include.foo = 42` is currently accepted; spec forbids `include` as the
-    // first element of a path expression in a key position.
-    assert!(
-        parse("include.foo = 42").is_ok(),
-        "[pin] include.foo currently accepted as a key — update when fixed"
-    );
-}
-
-#[test]
-#[ignore = "spec violation: unquoted `include` must not begin a key path per HOCON L570, see #71"]
 fn s12_5_include_as_key_spec() {
-    assert!(
-        parse("include.foo = 42").is_err(),
-        "unquoted `include` at start of a key path must be a parse error per HOCON L570"
-    );
+    // Trigger variants — all must be parse errors per HOCON.md L570.
+    for input in &[
+        "include.foo = 42",
+        "include : 1",
+        "include += [1]",
+        "include { x = 1 }",
+    ] {
+        assert!(
+            parse(input).is_err(),
+            "unquoted `include` at start of a key path must be a parse error per HOCON L570 (input: {})",
+            input
+        );
+    }
+    // Quoted form and non-initial form must still succeed.
+    assert!(parse(r#""include" = 1"#).is_ok(), "quoted include must succeed");
+    assert!(parse("foo.include = 1").is_ok(), "non-initial include must succeed");
 }
 
 // --- S13b.2: `+=` on non-array prior value → error (HOCON L732) -------------


### PR DESCRIPTION
## Summary

Implements **S12.5** (HOCON.md L570): unquoted `include` may not begin a key path. Strict-spec posture, intentionally stricter than Lightbend which silently accepts the dotted form. Closes #71.

`parse_object()` captures `first_key_is_quoted = peek_kind() == TokenKind::QuotedString` **before** `parse_key()` advances the cursor. After `parse_key()` returns, if `!first_key_is_quoted && key[0] == "include"` → `Err(ParseError)`.

**No struct changes** to `AstField`, `ParseError`, or `parse_key()` signature — local-flag approach in `parse_object` avoids `#[non_exhaustive]` SemVer impact entirely.

Preserved unchanged:
- `"include" = 1` and `"include".foo = 1` (quoted bypass)
- `foo.include = 1` (non-initial)
- `a = include` (value position)
- `${include}` and `${include.foo}` (substitution paths)
- `include "file.conf"` and all include-statement forms

## Test plan

- [x] 8 inline parser unit tests in `src/parser.rs` (`#[cfg(test)]` block)
- [x] `s12_5_include_as_key_pin` flipped + `#[ignore]` removed from `s12_5_include_as_key_spec` in `tests/integration_test.rs`
- [x] New `tests/include_reservation_test.rs` conformance suite (ir01-ir14, with `KNOWN_LIGHTBEND_QUIRKS = &["ir03-...", "ir04-..."]` for E9 cases + dedicated per-impl override tests)
- [x] `cargo test` — all suites pass (194 lib + 16 conformance + 108 integration + others)
- [x] `cargo clippy --all-targets -- -D warnings` — no new warnings (pre-existing PI approx_constant noise unrelated to this PR)
- [x] `cargo fmt --check` clean
- [x] Multi-agent-review (Claude + Codex) — Claude PASS, Codex P1 flagged fixture-tracking concern that matches the existing `concat_errors_test.rs` pattern (relies on `make testdata` running before `cargo test`, which CI does) — see `make testdata` early-exit condition + cache mechanics; ready to verify via CI on this PR

Spec authority: [.claude/superpowers/specs/2026-05-17-s12-include-key-reservation-design.md](../.claude/superpowers/specs/2026-05-17-s12-include-key-reservation-design.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)