### PR TITLE
fix(s18.4): string-with-no-unit uses family default + new get_period accessor — Phase 6 #3d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Period` struct** (Phase 6 #3d — S18 review fix):
+  New public `Period { years: i32, months: i32, days: i32 }` struct, marked `#[non_exhaustive]`
+  so future fields can be added without a breaking change. Re-exported from the crate root as
+  `hocon::Period`. Constructed via `Period::new(years, months, days)`.
+
 - **`get_period` / `get_period_option` accessors** (Phase 6 #3d):
-  New methods on `Config` for reading HOCON period values. Returns `(years: i32, months: i32, days: i32)`
-  tuple (no `chrono` dependency). Supported units: `d`/`day`/`days` (default),
-  `w`/`week`/`weeks` (× 7 days), `m`/`mo`/`month`/`months`, `y`/`year`/`years`.
-  Negative periods are permitted (the signed `i32` tuple supports them, matching Lightbend).
+  New methods on `Config` for reading HOCON period values. Returns `Period` (no `chrono`
+  dependency). Supported units: `d`/`day`/`days` (default), `w`/`week`/`weeks` (× 7 days),
+  `m`/`mo`/`month`/`months`, `y`/`year`/`years`.
+  Negative periods are permitted (signed `i32` fields, matching Lightbend).
 
 ### Fixed
 
@@ -28,7 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     vs `Double.parseDouble` per-family split.
   - `parse_bytes`: switched `.trim()` → HOCON_WS trim; changed `.round()` → `as i64`
     truncation to match Lightbend `BigDecimal.toBigInteger()` semantics.
-  - `get_bytes`: added negative-accessor rejection — byte sizes must be non-negative
+  - `get_bytes`: added negative-accessor rejection on both the string path and the bare-number
+    path — byte sizes must be non-negative regardless of source
     (Lightbend `getBytesBigInteger` positive-only invariant; ub04).
   - `parse_period` (new): integer-only (fractional rejected per Lightbend `Integer.parseInt`);
     default unit days; units as above.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`get_period` / `get_period_option` accessors** (Phase 6 #3d):
+  New methods on `Config` for reading HOCON period values. Returns `(years: i32, months: i32, days: i32)`
+  tuple (no `chrono` dependency). Supported units: `d`/`day`/`days` (default),
+  `w`/`week`/`weeks` (× 7 days), `m`/`mo`/`month`/`months`, `y`/`year`/`years`.
+  Negative periods are permitted (the signed `i32` tuple supports them, matching Lightbend).
+
 ### Fixed
+
+- **S18.4 — string value with no unit → family default unit** (Phase 6 #3d):
+  All three unit families now correctly interpret a bare number string as the family default:
+  duration → milliseconds, period → days, bytes → bytes (HOCON.md L1290 / L1301 / L1321 / L1341).
+  Previously `parse_duration` returned `None` for no-unit strings, causing `get_duration` to error.
+
+  Changes:
+  - `parse_duration`: added `""` arm (ms default); switched `.trim()` → HOCON_WS trim;
+    added integer pre-classification regex `[+-]?[0-9]+` to match Lightbend `Long.parseLong`
+    vs `Double.parseDouble` per-family split.
+  - `parse_bytes`: switched `.trim()` → HOCON_WS trim; changed `.round()` → `as i64`
+    truncation to match Lightbend `BigDecimal.toBigInteger()` semantics.
+  - `get_bytes`: added negative-accessor rejection — byte sizes must be non-negative
+    (Lightbend `getBytesBigInteger` positive-only invariant; ub04).
+  - `parse_period` (new): integer-only (fractional rejected per Lightbend `Integer.parseInt`);
+    default unit days; units as above.
+  - `is_hocon_whitespace` in `src/lexer.rs` promoted to `pub(crate)` for reuse.
+
+  **rs-specific limitation** — `get_duration` returns `Err` for negative duration strings
+  (e.g. `"-500"`). `std::time::Duration` is unsigned, whereas Lightbend's `java.time.Duration`
+  is signed. The `ud06` conformance test in `tests/units_default_test.rs` asserts `is_err()`
+  with a comment documenting this divergence.
 
 - **S12.5 — `include` reserved at start of key path** (Phase 6 #3e):
   Unquoted `include` at the start of a key path expression (including the dotted form

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -677,22 +677,21 @@ same item descriptions verbatim.
 
 ## S20. Period format
 
+rs.hocon exposes `get_period` / `get_period_option` returning a `Period { years, months, days }`
+struct. ts and go remain ➖ (no period accessor).
+
 - **S20.1** `d` / `day` / `days` — §Period Format (L1327)
-  out-of-scope: Period Format mirrors `java.time.Period`, a JVM-specific type; the spec text (L1316-1318) explicitly references this Java API. None of the three implementations exposes a period parser/API.
-  tests: —
-  status: ➖
+  tests: src/config.rs (parse_period_days_explicit, parse_period_bare_integer_uses_days_default); tests/units_default_test.rs (up01_period_bare, up02_period_leading_trailing_ws)
+  status: ✅ (rs.hocon) / ➖ (ts, go)
 - **S20.2** `w` / `week` / `weeks` — §Period Format (L1328)
-  out-of-scope: Period Format unsupported; see S20.1.
-  tests: —
-  status: ➖
+  tests: src/config.rs (parse_period_weeks_unit); tests/units_default_test.rs (up05_period_with_unit)
+  status: ✅ (rs.hocon) / ➖ (ts, go)
 - **S20.3** `m` / `mo` / `month` / `months` — §Period Format (L1329)
-  out-of-scope: Period Format unsupported; see S20.1.
-  tests: —
-  status: ➖
+  tests: src/config.rs (parse_period_months_unit)
+  status: ✅ (rs.hocon) / ➖ (ts, go)
 - **S20.4** `y` / `year` / `years` — §Period Format (L1333)
-  out-of-scope: Period Format unsupported; see S20.1.
-  tests: —
-  status: ➖
+  tests: src/config.rs (parse_period_years_unit)
+  status: ✅ (rs.hocon) / ➖ (ts, go)
 
 ## S21. Size in bytes format
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -643,9 +643,9 @@ same item descriptions verbatim.
   tests: tests/spec_phase5.rs (s18_3_unit_with_digit_rejected; s18_3_unit_with_hyphen_rejected; s18_3_valid_letter_only_unit_accepted)
   status: ✅
 - **S18.4** String with no unit → interpreted with default unit — §Units format (L1290)
-  tests: tests/spec_phase5.rs (s18_4_bytes_string_no_unit_uses_default; s18_4_pin_duration_string_no_unit_errors; s18_4_spec_duration_string_no_unit_uses_default [#ignore])
-  status: ⚠️
-  notes: bytes string with no unit correctly uses byte default (`"1024"` → 1024). Duration string with no unit errors instead of using millisecond default — `parse_duration` does not match empty unit string. Number scalars (non-string) work for both getters.
+  tests: tests/spec_phase5.rs (s18_4_bytes_string_no_unit_uses_default; s18_4_spec_duration_string_no_unit_uses_default); tests/units_default_test.rs (ud01–ud08, up01–up05, ub01–ub06, un01–un03)
+  status: ✅
+  notes: All three families (duration→ms, period→days, bytes→bytes) now treat a bare number string as the default unit. `parse_duration` and `parse_bytes` use HOCON_WS trim and integer pre-classification. `parse_bytes` truncates fractional values per Lightbend `BigDecimal.toBigInteger()`. `get_bytes` rejects negative byte sizes at the accessor (positive-only invariant). `get_period`/`get_period_option` accessors added (net-new, return `(years: i32, months: i32, days: i32)`). rs-specific: `get_duration` returns `Err` for negative inputs (`std::time::Duration` is unsigned; see CHANGELOG).
 
 ## S19. Duration format
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,32 @@ use crate::numeric_array::numeric_object_to_array;
 use crate::value::{HoconValue, ScalarType};
 use indexmap::IndexMap;
 
+/// A calendar period with year, month, and day components.
+///
+/// Returned by [`Config::get_period`] and [`Config::get_period_option`].
+/// All fields are `i32` to support negative periods (matching Lightbend behaviour).
+///
+/// The struct is `#[non_exhaustive]` so that new fields (e.g. weeks, hours) can
+/// be added in a future minor version without a breaking change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub struct Period {
+    pub years: i32,
+    pub months: i32,
+    pub days: i32,
+}
+
+impl Period {
+    /// Construct a `Period` from year, month, and day components.
+    pub fn new(years: i32, months: i32, days: i32) -> Self {
+        Self {
+            years,
+            months,
+            days,
+        }
+    }
+}
+
 /// A parsed HOCON configuration object.
 ///
 /// `Config` wraps an ordered map of top-level keys to [`HoconValue`]s and
@@ -254,24 +280,23 @@ impl Config {
         })?;
         match v {
             HoconValue::Scalar(sv) => {
-                // Bare integer number: return as-is (assumed bytes)
-                if sv.value_type == ScalarType::Number {
-                    if let Ok(n) = sv.raw.parse::<i64>() {
-                        return Ok(n);
-                    }
-                    // Bare float without unit (e.g. "1.5") is not valid for bytes
-                    return Err(ConfigError {
+                let n: i64 = if sv.value_type == ScalarType::Number {
+                    // Bare integer number: return as-is (assumed bytes).
+                    // Bare float without unit (e.g. "1.5") is not valid for bytes.
+                    sv.raw.parse::<i64>().map_err(|_| ConfigError {
                         message: format!("expected byte size at {}", path),
                         path: path.to_string(),
-                    });
-                }
-                // String type: try byte-size string (e.g. "512 MB", "1.5 KiB")
-                let n = parse_bytes(&sv.raw).ok_or_else(|| ConfigError {
-                    message: format!("invalid byte size at {}: {}", path, sv.raw),
-                    path: path.to_string(),
-                })?;
+                    })?
+                } else {
+                    // String type: try byte-size string (e.g. "512 MB", "1.5 KiB")
+                    parse_bytes(&sv.raw).ok_or_else(|| ConfigError {
+                        message: format!("invalid byte size at {}: {}", path, sv.raw),
+                        path: path.to_string(),
+                    })?
+                };
                 // ub04: Lightbend `getBytesBigInteger` rejects negative byte sizes.
                 // Bytes represent a resource size and must be non-negative.
+                // This guard applies to BOTH the bare-numeric and string paths.
                 if n < 0 {
                     return Err(ConfigError {
                         message: format!("negative byte size at {}: {}", path, sv.raw),
@@ -292,7 +317,7 @@ impl Config {
         self.get_bytes(path).ok()
     }
 
-    /// Return the value at `path` as a calendar period `(years, months, days)`.
+    /// Return the value at `path` as a calendar [`Period`].
     ///
     /// Accepts HOCON period strings (e.g. `"7d"`, `"2w"`, `"3m"`, `"1y"`) or a bare
     /// integer string, which is taken as days per HOCON.md L1321.
@@ -301,21 +326,17 @@ impl Config {
     /// `m`/`mo`/`month`/`months`, `y`/`year`/`years`.
     ///
     /// Negative values are permitted (matches Lightbend behaviour).
-    ///
-    /// Return type is `(years, months, days)` using `i32` to support negative periods.
-    /// A `chrono` dependency is intentionally avoided; callers that need a typed `Period`
-    /// can decompose the tuple as needed.
-    pub fn get_period(&self, path: &str) -> Result<(i32, i32, i32), ConfigError> {
+    pub fn get_period(&self, path: &str) -> Result<Period, ConfigError> {
         match self.lookup_node(path) {
             None => Err(missing(path)),
             Some(HoconValue::Scalar(sv)) => {
-                if let Some(p) = parse_period(&sv.raw) {
-                    return Ok(p);
+                if let Some((y, mo, d)) = parse_period(&sv.raw) {
+                    return Ok(Period::new(y, mo, d));
                 }
                 // Bare integer scalar (non-string): treat as days default (S18.1 parallel).
                 if sv.value_type == ScalarType::Number {
                     if let Ok(n) = sv.raw.parse::<i32>() {
-                        return Ok((0, 0, n));
+                        return Ok(Period::new(0, 0, n));
                     }
                 }
                 Err(ConfigError {
@@ -331,7 +352,7 @@ impl Config {
     }
 
     /// Like [`get_period`](Self::get_period) but returns `None` instead of an error.
-    pub fn get_period_option(&self, path: &str) -> Option<(i32, i32, i32)> {
+    pub fn get_period_option(&self, path: &str) -> Option<Period> {
         self.get_period(path).ok()
     }
 
@@ -1148,7 +1169,26 @@ mod tests {
         let cfg = crate::parse_with_env(r#"b = "-1""#, &HashMap::new()).unwrap();
         assert!(
             cfg.get_bytes("b").is_err(),
-            "ub04: negative byte size must error at accessor"
+            "ub04: negative byte size must error at accessor (string path)"
+        );
+    }
+    #[test]
+    fn get_bytes_negative_bare_number_rejects() {
+        use std::collections::HashMap;
+        // b = -1 (unquoted number scalar) — previously bypassed the guard and returned Ok(-1).
+        let cfg = crate::parse_with_env(r#"b = -1"#, &HashMap::new()).unwrap();
+        assert!(
+            cfg.get_bytes("b").is_err(),
+            "ub04-bare: bare numeric -1 must error at accessor (both paths must hit guard)"
+        );
+    }
+    #[test]
+    fn get_bytes_option_negative_bare_number_is_none() {
+        use std::collections::HashMap;
+        let cfg = crate::parse_with_env(r#"b = -1"#, &HashMap::new()).unwrap();
+        assert!(
+            cfg.get_bytes_option("b").is_none(),
+            "ub04-bare-option: get_bytes_option must return None for bare numeric -1"
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -478,7 +478,7 @@ impl Config {
 /// Unlike `str::trim()` (which is ASCII-only for whitespace), this respects the full
 /// HOCON_WS set (U+00A0 NBSP, U+FEFF BOM, various Unicode space separators, etc.).
 fn trim_hocon_ws(s: &str) -> &str {
-    s.trim_matches(|c| is_hocon_whitespace(c))
+    s.trim_matches(is_hocon_whitespace)
 }
 
 /// Returns `true` if `s` matches `[+-]?[0-9]+` (integer pre-classification).

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use crate::error::ConfigError;
+use crate::lexer::is_hocon_whitespace;
 use crate::numeric_array::numeric_object_to_array;
 use crate::value::{HoconValue, ScalarType};
 use indexmap::IndexMap;
@@ -265,10 +266,19 @@ impl Config {
                     });
                 }
                 // String type: try byte-size string (e.g. "512 MB", "1.5 KiB")
-                parse_bytes(&sv.raw).ok_or_else(|| ConfigError {
+                let n = parse_bytes(&sv.raw).ok_or_else(|| ConfigError {
                     message: format!("invalid byte size at {}: {}", path, sv.raw),
                     path: path.to_string(),
-                })
+                })?;
+                // ub04: Lightbend `getBytesBigInteger` rejects negative byte sizes.
+                // Bytes represent a resource size and must be non-negative.
+                if n < 0 {
+                    return Err(ConfigError {
+                        message: format!("negative byte size at {}: {}", path, sv.raw),
+                        path: path.to_string(),
+                    });
+                }
+                Ok(n)
             }
             _ => Err(ConfigError {
                 message: format!("expected byte size at {}", path),
@@ -280,6 +290,49 @@ impl Config {
     /// Like [`get_bytes`](Self::get_bytes) but returns `None` instead of an error.
     pub fn get_bytes_option(&self, path: &str) -> Option<i64> {
         self.get_bytes(path).ok()
+    }
+
+    /// Return the value at `path` as a calendar period `(years, months, days)`.
+    ///
+    /// Accepts HOCON period strings (e.g. `"7d"`, `"2w"`, `"3m"`, `"1y"`) or a bare
+    /// integer string, which is taken as days per HOCON.md L1321.
+    ///
+    /// Supported units: `d`/`day`/`days` (default), `w`/`week`/`weeks` (× 7 days),
+    /// `m`/`mo`/`month`/`months`, `y`/`year`/`years`.
+    ///
+    /// Negative values are permitted (matches Lightbend behaviour).
+    ///
+    /// Return type is `(years, months, days)` using `i32` to support negative periods.
+    /// A `chrono` dependency is intentionally avoided; callers that need a typed `Period`
+    /// can decompose the tuple as needed.
+    pub fn get_period(&self, path: &str) -> Result<(i32, i32, i32), ConfigError> {
+        match self.lookup_node(path) {
+            None => Err(missing(path)),
+            Some(HoconValue::Scalar(sv)) => {
+                if let Some(p) = parse_period(&sv.raw) {
+                    return Ok(p);
+                }
+                // Bare integer scalar (non-string): treat as days default (S18.1 parallel).
+                if sv.value_type == ScalarType::Number {
+                    if let Ok(n) = sv.raw.parse::<i32>() {
+                        return Ok((0, 0, n));
+                    }
+                }
+                Err(ConfigError {
+                    message: format!("invalid period at {}: {}", path, sv.raw),
+                    path: path.to_string(),
+                })
+            }
+            _ => Err(ConfigError {
+                message: format!("expected period at {}", path),
+                path: path.to_string(),
+            }),
+        }
+    }
+
+    /// Like [`get_period`](Self::get_period) but returns `None` instead of an error.
+    pub fn get_period_option(&self, path: &str) -> Option<(i32, i32, i32)> {
+        self.get_period(path).ok()
     }
 
     /// Return `true` if a value exists at the given dot-separated path.
@@ -420,23 +473,62 @@ impl Config {
     }
 }
 
+/// Trim HOCON whitespace (per `is_hocon_whitespace`) from both ends of `s`.
+///
+/// Unlike `str::trim()` (which is ASCII-only for whitespace), this respects the full
+/// HOCON_WS set (U+00A0 NBSP, U+FEFF BOM, various Unicode space separators, etc.).
+fn trim_hocon_ws(s: &str) -> &str {
+    s.trim_matches(|c| is_hocon_whitespace(c))
+}
+
+/// Returns `true` if `s` matches `[+-]?[0-9]+` (integer pre-classification).
+///
+/// Mirrors Lightbend `SimpleConfig.isWholeNumber`. Used to choose the integer fast-path
+/// vs fractional fallback in `parse_duration` and `parse_bytes`.
+fn is_integer_str(s: &str) -> bool {
+    let s = s.strip_prefix(['+', '-']).unwrap_or(s);
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Parse a HOCON duration string into a [`std::time::Duration`].
+///
+/// Accepts `[ws] number [ws] [unit] [ws]` where `unit` is one of the HOCON duration
+/// units (HOCON.md L1304-1313). When no unit is present the default is **milliseconds**
+/// (HOCON.md L1301: "bare numbers are taken to be in milliseconds already").
+///
+/// # Fractional values (Lightbend-faithful per-family)
+///
+/// - Integer form `[+-]?[0-9]+`: parsed as `i64` milliseconds → scaled to nanos.
+/// - Fractional form: parsed as `f64`, multiplied by `nanos_per_unit`.
+///
+/// # Negative values (rs-specific limitation)
+///
+/// `std::time::Duration` is unsigned; this function returns `None` for negative inputs.
+/// Callers that need signed duration semantics should inspect the raw string first.
+/// `get_duration` documents this constraint; ud06 conformance test asserts `is_err()`.
 fn parse_duration(s: &str) -> Option<std::time::Duration> {
-    let s = s.trim();
+    let s = trim_hocon_ws(s);
+    if s.is_empty() {
+        return None;
+    }
+
+    // Scan to end of the numeric prefix (digits, optional leading sign, optional decimal).
     let num_end = s
-        .find(|c: char| !c.is_ascii_digit() && c != '.' && c != '-')
+        .find(|c: char| !c.is_ascii_digit() && c != '.' && c != '-' && c != '+')
         .unwrap_or(s.len());
     let num_str = s[..num_end].trim();
-    let unit_str = s[num_end..].trim().to_lowercase();
+    // Trim HOCON whitespace between number and unit, then lowercase the unit.
+    let unit_str = trim_hocon_ws(&s[num_end..]).to_lowercase();
 
-    let num: f64 = num_str.parse().ok()?;
-    if num < 0.0 || !num.is_finite() {
+    if num_str.is_empty() {
         return None;
     }
 
     let nanos_per_unit: f64 = match unit_str.as_str() {
+        // Default: milliseconds (HOCON.md L1301).
+        "" | "ms" | "milli" | "millis" | "millisecond" | "milliseconds" => 1_000_000.0,
         "ns" | "nano" | "nanos" | "nanosecond" | "nanoseconds" => 1.0,
         "us" | "micro" | "micros" | "microsecond" | "microseconds" => 1_000.0,
-        "ms" | "milli" | "millis" | "millisecond" | "milliseconds" => 1_000_000.0,
         "s" | "second" | "seconds" => 1_000_000_000.0,
         "m" | "minute" | "minutes" => 60_000_000_000.0,
         "h" | "hour" | "hours" => 3_600_000_000_000.0,
@@ -445,21 +537,100 @@ fn parse_duration(s: &str) -> Option<std::time::Duration> {
         _ => return None,
     };
 
-    Some(std::time::Duration::from_nanos(
-        (num * nanos_per_unit) as u64,
-    ))
+    // Integer fast-path (matches Lightbend `Long.parseLong`).
+    if is_integer_str(num_str) {
+        let n: i64 = num_str.parse().ok()?;
+        // rs-specific: std::time::Duration is unsigned; negative values are rejected.
+        // Lightbend's java.time.Duration is signed. See CHANGELOG for rs-specific note.
+        if n < 0 {
+            return None;
+        }
+        let nanos = (n as f64 * nanos_per_unit) as u64;
+        return Some(std::time::Duration::from_nanos(nanos));
+    }
+
+    // Fractional fallback (matches Lightbend `Double.parseDouble`).
+    let f: f64 = num_str.parse().ok()?;
+    if f < 0.0 || !f.is_finite() {
+        return None;
+    }
+    let nanos = (f * nanos_per_unit) as u64;
+    Some(std::time::Duration::from_nanos(nanos))
 }
 
-fn parse_bytes(s: &str) -> Option<i64> {
-    let s = s.trim();
+/// Parse a HOCON period string into a `(years, months, days)` tuple.
+///
+/// Accepts `[ws] integer [ws] [unit] [ws]` where `unit` is one of the HOCON period
+/// units (HOCON.md L1324-1333). When no unit is present the default is **days**
+/// (HOCON.md L1321: "bare numbers are taken to be in days").
+///
+/// Period is integer-only (matches Lightbend `Integer.parseInt`). Fractional strings
+/// like `"7.5"` return `None`.
+///
+/// Returns `(years, months, days)` as `i32` to support negative periods (Lightbend allows
+/// negative). A `chrono` dependency is intentionally avoided; callers that need a typed
+/// `Period` can decompose the tuple.
+pub(crate) fn parse_period(s: &str) -> Option<(i32, i32, i32)> {
+    let s = trim_hocon_ws(s);
+    if s.is_empty() {
+        return None;
+    }
+
+    // Scan numeric prefix.
     let num_end = s
-        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .find(|c: char| !c.is_ascii_digit() && c != '-' && c != '+')
         .unwrap_or(s.len());
     let num_str = s[..num_end].trim();
-    let unit_str = s[num_end..].trim();
+    let unit_str = trim_hocon_ws(&s[num_end..]);
+
+    if num_str.is_empty() {
+        return None;
+    }
+
+    // Period is integer-only (Lightbend `Integer.parseInt`). Reject fractional.
+    if !is_integer_str(num_str) {
+        return None;
+    }
+
+    let n: i32 = num_str.parse().ok()?;
+
+    // Unit match — case-sensitive per HOCON.md L1304 (period shares the same
+    // "unit names are case-sensitive" rule as duration; only lowercase accepted).
+    match unit_str {
+        // Default: days (HOCON.md L1321).
+        "" | "d" | "day" | "days" => Some((0, 0, n)),
+        "w" | "week" | "weeks" => Some((0, 0, n.checked_mul(7)?)),
+        "m" | "mo" | "month" | "months" => Some((0, n, 0)),
+        "y" | "year" | "years" => Some((n, 0, 0)),
+        _ => None,
+    }
+}
+
+/// Parse a HOCON byte-size string into a byte count.
+///
+/// Accepts `[ws] number [ws] [unit] [ws]`. When no unit is present the default is
+/// **bytes** (HOCON.md L1341: "bare numbers are taken to be in bytes").
+///
+/// Fractional values are accepted and **truncated** (not rounded) per Lightbend's
+/// `BigDecimal.toBigInteger()` semantics (e.g. `"1024.5"` → 1024 bytes).
+///
+/// Note: `get_bytes` rejects negative results at the accessor level (ub04 / Lightbend
+/// `getBytesBigInteger` positive-only invariant). `parse_bytes` itself allows negative
+/// integer inputs.
+fn parse_bytes(s: &str) -> Option<i64> {
+    let s = trim_hocon_ws(s);
+    let num_end = s
+        .find(|c: char| !c.is_ascii_digit() && c != '.' && c != '-' && c != '+')
+        .unwrap_or(s.len());
+    let num_str = s[..num_end].trim();
+    let unit_str = trim_hocon_ws(&s[num_end..]);
+
+    if num_str.is_empty() {
+        return None;
+    }
 
     // Case-sensitive matching: KB vs KiB matters. Short forms (K, M, G, T) are
-    // treated as SI decimal units (KB, MB, GB, TB).
+    // treated as SI decimal units (KB, MB, GB, TB) per HOCON.md L1344.
     let multiplier: i64 = match unit_str {
         "" | "B" | "byte" | "bytes" => 1,
         "K" | "KB" | "kilobyte" | "kilobytes" => 1_000,
@@ -473,17 +644,19 @@ fn parse_bytes(s: &str) -> Option<i64> {
         _ => return None,
     };
 
-    // Try lossless integer path first, fall back to f64 for fractional values
-    if let Ok(n) = num_str.parse::<i64>() {
-        n.checked_mul(multiplier)
-    } else {
-        let num: f64 = num_str.parse().ok()?;
-        let result = (num * multiplier as f64).round();
-        if !result.is_finite() || result > i64::MAX as f64 || result < i64::MIN as f64 {
-            return None;
-        }
-        Some(result as i64)
+    // Integer fast-path: lossless, avoids any floating-point rounding.
+    if is_integer_str(num_str) {
+        let n: i64 = num_str.parse().ok()?;
+        return n.checked_mul(multiplier);
     }
+
+    // Fractional fallback: truncate toward zero per Lightbend `BigDecimal.toBigInteger()`.
+    let f: f64 = num_str.parse().ok()?;
+    let result = (f * multiplier as f64) as i64; // `as i64` truncates (Rust saturates on overflow)
+    if !f.is_finite() || f.abs() * multiplier as f64 > i64::MAX as f64 {
+        return None;
+    }
+    Some(result)
 }
 
 fn missing(path: &str) -> ConfigError {
@@ -905,6 +1078,119 @@ mod tests {
         // 1.5 KiB = 1536 bytes exactly; rounding should not change it
         let c = make_config(vec![("s", sv("1.5 KiB"))]);
         assert_eq!(c.get_bytes("s").unwrap(), 1536);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Unit B — parse_duration bare/fractional/ws tests (RED phase)
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_duration_bare_integer_uses_ms_default() {
+        assert_eq!(
+            parse_duration("500"),
+            Some(std::time::Duration::from_millis(500))
+        );
+    }
+    #[test]
+    fn parse_duration_leading_ws_bare() {
+        assert_eq!(
+            parse_duration(" 500"),
+            Some(std::time::Duration::from_millis(500))
+        );
+    }
+    #[test]
+    fn parse_duration_trailing_ws_bare() {
+        assert_eq!(
+            parse_duration("500 "),
+            Some(std::time::Duration::from_millis(500))
+        );
+    }
+    #[test]
+    fn parse_duration_both_ws_bare() {
+        assert_eq!(
+            parse_duration(" 500 "),
+            Some(std::time::Duration::from_millis(500))
+        );
+    }
+    #[test]
+    fn parse_duration_fractional_bare_uses_nanos() {
+        let d = parse_duration("500.5").unwrap();
+        assert_eq!(d.as_nanos(), 500_500_000);
+    }
+    #[test]
+    fn parse_duration_empty_is_none() {
+        assert!(parse_duration("").is_none());
+    }
+    #[test]
+    fn parse_duration_ws_only_is_none() {
+        assert!(parse_duration("   ").is_none());
+    }
+    #[test]
+    fn parse_duration_unit_only_is_none() {
+        assert!(parse_duration("ms").is_none());
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Unit C — parse_bytes ws / truncate / negative-accessor (RED)
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_bytes_leading_trailing_ws_bare() {
+        assert_eq!(parse_bytes(" 1024 "), Some(1024));
+    }
+    #[test]
+    fn parse_bytes_fractional_truncated() {
+        assert_eq!(parse_bytes("1024.5"), Some(1024));
+    }
+    #[test]
+    fn get_bytes_negative_accessor_rejects() {
+        use std::collections::HashMap;
+        let cfg = crate::parse_with_env(r#"b = "-1""#, &HashMap::new()).unwrap();
+        assert!(
+            cfg.get_bytes("b").is_err(),
+            "ub04: negative byte size must error at accessor"
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Unit D — parse_period (RED phase)
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_period_bare_integer_uses_days_default() {
+        assert_eq!(parse_period("7"), Some((0, 0, 7)));
+    }
+    #[test]
+    fn parse_period_leading_trailing_ws() {
+        assert_eq!(parse_period(" 7 "), Some((0, 0, 7)));
+    }
+    #[test]
+    fn parse_period_fractional_rejected() {
+        assert!(parse_period("7.5").is_none());
+    }
+    #[test]
+    fn parse_period_negative_allowed() {
+        assert_eq!(parse_period("-7"), Some((0, 0, -7)));
+    }
+    #[test]
+    fn parse_period_weeks_unit() {
+        assert_eq!(parse_period("7w"), Some((0, 0, 49)));
+    }
+    #[test]
+    fn parse_period_months_unit() {
+        assert_eq!(parse_period("3m"), Some((0, 3, 0)));
+    }
+    #[test]
+    fn parse_period_years_unit() {
+        assert_eq!(parse_period("2y"), Some((2, 0, 0)));
+    }
+    #[test]
+    fn parse_period_days_explicit() {
+        assert_eq!(parse_period("5d"), Some((0, 0, 5)));
+    }
+    #[test]
+    fn parse_period_empty_is_none() {
+        assert!(parse_period("").is_none());
     }
 
     #[test]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -70,7 +70,7 @@ pub struct Token {
 /// NOTE: U+000A (LF) is included here because it is in the Java
 /// Character.isWhitespace set.  Callers that need to distinguish newline from
 /// inter-token whitespace must call is_hocon_newline first.
-fn is_hocon_whitespace(ch: char) -> bool {
+pub(crate) fn is_hocon_whitespace(ch: char) -> bool {
     matches!(ch,
         '\t' | '\n' | '\u{000B}' | '\u{000C}' | '\r'
       | '\u{001C}'..='\u{001F}'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ pub mod value;
 #[cfg(feature = "serde")]
 pub mod serde;
 
-pub use config::Config;
+pub use config::{Config, Period};
 pub use error::{ConfigError, HoconError, ParseError, ResolveError};
 pub use value::{HoconValue, ScalarType, ScalarValue};
 

--- a/tests/spec_phase5.rs
+++ b/tests/spec_phase5.rs
@@ -356,24 +356,7 @@ fn s18_4_bytes_string_no_unit_uses_default() {
     );
 }
 
-/// Duration pin: string "500" with no unit currently errors (does not use default ms).
 #[test]
-fn s18_4_pin_duration_string_no_unit_errors() {
-    let cfg = hocon::parse_with_env(r#"t = "500""#, &HashMap::new()).unwrap();
-    assert!(
-        cfg.get_duration("t").is_err(),
-        "[pin] S18.4: impl currently errors on duration string without unit (should use default ms per spec L1290)"
-    );
-    let err = cfg.get_duration("t").unwrap_err().to_string();
-    assert!(
-        err.contains("invalid duration"),
-        "[pin] S18.4: error message should contain 'invalid duration'; got: {}",
-        err
-    );
-}
-
-#[test]
-#[ignore = "spec violation per S18.4 (L1290): duration string '500' with no unit must be interpreted as milliseconds (default unit); impl errors instead"]
 fn s18_4_spec_duration_string_no_unit_uses_default() {
     let cfg = hocon::parse_with_env(r#"t = "500""#, &HashMap::new()).unwrap();
     assert_eq!(

--- a/tests/units_default_test.rs
+++ b/tests/units_default_test.rs
@@ -1,0 +1,282 @@
+//! S18.4 — string value with no unit → default unit — conformance tests.
+//!
+//! Fixtures: xx.hocon testdata/hocon/units-default/ (22 fixtures).
+//! No expected sidecars — per-impl assertions carry the assertion burden (the xx.hocon
+//! generator does not yet support accessor-time output capture; see spec §Test strategy).
+//!
+//! Coverage:
+//!   ud01-ud08  Duration family (bare int, WS variants, fractional, negative, regression)
+//!   up01-up05  Period family  (bare int, WS, fractional-rejected, negative, regression)
+//!   ub01-ub06  Bytes family   (bare int, WS, fractional-truncated, negative-accessor, unit, empty)
+//!   un01-un03  Cross-family negative edge cases (empty, WS-only, unit-only)
+
+use std::path::PathBuf;
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/testdata/hocon/units-default")
+}
+
+fn load(name: &str) -> hocon::Config {
+    let path = fixture_dir().join(name);
+    hocon::parse_file(&path).unwrap_or_else(|e| panic!("failed to load {}: {}", name, e))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Duration family (ud01–ud08)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// ud01: bare integer string → 500 ms (default unit).
+#[test]
+fn ud01_duration_bare() {
+    let cfg = load("ud01-duration-bare.conf");
+    assert_eq!(
+        cfg.get_duration("t").unwrap(),
+        std::time::Duration::from_millis(500),
+        "ud01: bare '500' must default to 500 ms"
+    );
+}
+
+/// ud02: leading whitespace before number → still 500 ms.
+#[test]
+fn ud02_duration_leading_ws() {
+    let cfg = load("ud02-duration-leading-ws.conf");
+    assert_eq!(
+        cfg.get_duration("t").unwrap(),
+        std::time::Duration::from_millis(500),
+        "ud02: leading-WS '\" 500\"' must default to 500 ms"
+    );
+}
+
+/// ud03: trailing whitespace after number → still 500 ms.
+#[test]
+fn ud03_duration_trailing_ws() {
+    let cfg = load("ud03-duration-trailing-ws.conf");
+    assert_eq!(
+        cfg.get_duration("t").unwrap(),
+        std::time::Duration::from_millis(500),
+        "ud03: trailing-WS '\"500 \"' must default to 500 ms"
+    );
+}
+
+/// ud04: leading + trailing whitespace → still 500 ms.
+#[test]
+fn ud04_duration_both_ws() {
+    let cfg = load("ud04-duration-both-ws.conf");
+    assert_eq!(
+        cfg.get_duration("t").unwrap(),
+        std::time::Duration::from_millis(500),
+        "ud04: both-WS '\" 500 \"' must default to 500 ms"
+    );
+}
+
+/// ud05: fractional bare string → 500_500_000 nanos (Lightbend Double×nanos_per_unit).
+///
+/// Lightbend-faithful: duration accepts fractional; `"500.5"` with ms default =
+/// 500.5 × 1_000_000 ns = 500_500_000 ns.
+#[test]
+fn ud05_duration_fractional() {
+    let cfg = load("ud05-duration-fractional.conf");
+    assert_eq!(
+        cfg.get_duration("t").unwrap().as_nanos(),
+        500_500_000,
+        "ud05: fractional '500.5' must yield 500_500_000 nanos (Lightbend Double path)"
+    );
+}
+
+/// ud06: negative bare string → Err (rs-specific limitation).
+///
+/// rs-specific: `std::time::Duration` is unsigned. Lightbend's `java.time.Duration` is
+/// signed. For `"-500"` rs.hocon returns `Err` rather than −500 ms. This is a documented
+/// rs-specific divergence; see CHANGELOG.
+#[test]
+fn ud06_duration_negative() {
+    let cfg = load("ud06-duration-negative.conf");
+    assert!(
+        cfg.get_duration("t").is_err(),
+        // rs-specific: std::time::Duration cannot represent negative durations.
+        // Lightbend java.time.Duration CAN represent negatives. See CHANGELOG.
+        "ud06 (rs-specific): get_duration(\"-500\") must Err (std::time::Duration is unsigned)"
+    );
+}
+
+/// ud07: string with explicit unit `"500ms"` → 500 ms (regression guard for existing path).
+#[test]
+fn ud07_duration_with_unit() {
+    let cfg = load("ud07-duration-with-unit.conf");
+    assert_eq!(
+        cfg.get_duration("t").unwrap(),
+        std::time::Duration::from_millis(500),
+        "ud07 (regression): explicit unit '500ms' must still parse correctly"
+    );
+}
+
+/// ud08: WS between number and unit `"500 ms"` → 500 ms (regression guard).
+#[test]
+fn ud08_duration_ws_between() {
+    let cfg = load("ud08-duration-ws-between.conf");
+    assert_eq!(
+        cfg.get_duration("t").unwrap(),
+        std::time::Duration::from_millis(500),
+        "ud08 (regression): WS between number and unit must parse correctly"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Period family (up01–up05)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// up01: bare integer string → 7 days (default unit = days, HOCON.md L1321).
+#[test]
+fn up01_period_bare() {
+    let cfg = load("up01-period-bare.conf");
+    assert_eq!(
+        cfg.get_period("p").unwrap(),
+        (0, 0, 7),
+        "up01: bare '7' must default to 7 days"
+    );
+}
+
+/// up02: leading + trailing whitespace → still 7 days.
+#[test]
+fn up02_period_leading_trailing_ws() {
+    let cfg = load("up02-period-leading-trailing-ws.conf");
+    assert_eq!(
+        cfg.get_period("p").unwrap(),
+        (0, 0, 7),
+        "up02: whitespace-padded '\" 7 \"' must default to 7 days"
+    );
+}
+
+/// up03: fractional string `"7.5"` → Err (period is integer-only, Lightbend Integer.parseInt).
+#[test]
+fn up03_period_fractional_rejected() {
+    let cfg = load("up03-period-fractional-rejected.conf");
+    assert!(
+        cfg.get_period("p").is_err(),
+        "up03: fractional '7.5' must Err (period is integer-only per Lightbend Integer.parseInt)"
+    );
+}
+
+/// up04: negative `"-7"` → (0, 0, -7) — period allows negative at accessor (Lightbend).
+#[test]
+fn up04_period_negative() {
+    let cfg = load("up04-period-negative.conf");
+    assert_eq!(
+        cfg.get_period("p").unwrap(),
+        (0, 0, -7),
+        "up04: negative '-7' must yield (0, 0, -7) days (signed i32 tuple)"
+    );
+}
+
+/// up05: `"7w"` → 49 days (regression guard: explicit weeks unit).
+#[test]
+fn up05_period_with_unit() {
+    let cfg = load("up05-period-with-unit.conf");
+    assert_eq!(
+        cfg.get_period("p").unwrap(),
+        (0, 0, 49),
+        "up05 (regression): '7w' must yield (0, 0, 49) days"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bytes family (ub01–ub06)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// ub01: bare integer string `"1024"` → 1024 bytes (default unit = bytes).
+#[test]
+fn ub01_bytes_bare() {
+    let cfg = load("ub01-bytes-bare.conf");
+    assert_eq!(
+        cfg.get_bytes("b").unwrap(),
+        1024,
+        "ub01: bare '1024' must default to 1024 bytes"
+    );
+}
+
+/// ub02: whitespace-padded `" 1024 "` → 1024 bytes.
+#[test]
+fn ub02_bytes_leading_trailing_ws() {
+    let cfg = load("ub02-bytes-leading-trailing-ws.conf");
+    assert_eq!(
+        cfg.get_bytes("b").unwrap(),
+        1024,
+        "ub02: whitespace-padded '\" 1024 \"' must yield 1024 bytes"
+    );
+}
+
+/// ub03: fractional `"1024.5"` → 1024 bytes (truncated, Lightbend BigDecimal.toBigInteger).
+#[test]
+fn ub03_bytes_fractional_truncated() {
+    let cfg = load("ub03-bytes-fractional-truncated.conf");
+    assert_eq!(
+        cfg.get_bytes("b").unwrap(),
+        1024,
+        "ub03: fractional '1024.5' must truncate to 1024 bytes (not round to 1025)"
+    );
+}
+
+/// ub04: negative `"-1"` → Err at accessor (Lightbend positive-only invariant on byte sizes).
+#[test]
+fn ub04_bytes_negative_accessor_rejects() {
+    let cfg = load("ub04-bytes-negative-accessor-rejects.conf");
+    assert!(
+        cfg.get_bytes("b").is_err(),
+        "ub04: negative byte size '-1' must Err at accessor (positive-only invariant)"
+    );
+}
+
+/// ub05: `"1024K"` → 1_024_000 bytes (regression guard: SI unit K = 1000).
+#[test]
+fn ub05_bytes_with_unit() {
+    let cfg = load("ub05-bytes-with-unit.conf");
+    assert_eq!(
+        cfg.get_bytes("b").unwrap(),
+        1_024_000,
+        "ub05 (regression): '1024K' must yield 1_024_000 bytes (K = 1000 SI)"
+    );
+}
+
+/// ub06: empty string `""` → Err (no number to parse, HOCON.md L1284).
+#[test]
+fn ub06_bytes_empty_rejected() {
+    let cfg = load("ub06-bytes-empty-rejected.conf");
+    assert!(
+        cfg.get_bytes("b").is_err(),
+        "ub06: empty string must Err (no number present)"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cross-family negative edge cases (un01–un03)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// un01: empty string `""` → getDuration Err (no number, HOCON.md L1284).
+#[test]
+fn un01_empty_duration() {
+    let cfg = load("un01-empty-duration.conf");
+    assert!(
+        cfg.get_duration("t").is_err(),
+        "un01: empty string must Err for getDuration"
+    );
+}
+
+/// un02: whitespace-only string `"   "` → getDuration Err.
+#[test]
+fn un02_ws_only_duration() {
+    let cfg = load("un02-ws-only-duration.conf");
+    assert!(
+        cfg.get_duration("t").is_err(),
+        "un02: whitespace-only string must Err for getDuration"
+    );
+}
+
+/// un03: unit-only string `"ms"` → getDuration Err (number is required per L1284).
+#[test]
+fn un03_unit_only_duration() {
+    let cfg = load("un03-unit-only-duration.conf");
+    assert!(
+        cfg.get_duration("t").is_err(),
+        "un03: unit-only 'ms' must Err for getDuration (number required)"
+    );
+}

--- a/tests/units_default_test.rs
+++ b/tests/units_default_test.rs
@@ -131,7 +131,7 @@ fn up01_period_bare() {
     let cfg = load("up01-period-bare.conf");
     assert_eq!(
         cfg.get_period("p").unwrap(),
-        (0, 0, 7),
+        hocon::Period::new(0, 0, 7),
         "up01: bare '7' must default to 7 days"
     );
 }
@@ -142,7 +142,7 @@ fn up02_period_leading_trailing_ws() {
     let cfg = load("up02-period-leading-trailing-ws.conf");
     assert_eq!(
         cfg.get_period("p").unwrap(),
-        (0, 0, 7),
+        hocon::Period::new(0, 0, 7),
         "up02: whitespace-padded '\" 7 \"' must default to 7 days"
     );
 }
@@ -157,25 +157,25 @@ fn up03_period_fractional_rejected() {
     );
 }
 
-/// up04: negative `"-7"` → (0, 0, -7) — period allows negative at accessor (Lightbend).
+/// up04: negative `"-7"` → Period { years:0, months:0, days:-7 } — period allows negative at accessor (Lightbend).
 #[test]
 fn up04_period_negative() {
     let cfg = load("up04-period-negative.conf");
     assert_eq!(
         cfg.get_period("p").unwrap(),
-        (0, 0, -7),
-        "up04: negative '-7' must yield (0, 0, -7) days (signed i32 tuple)"
+        hocon::Period::new(0, 0, -7),
+        "up04: negative '-7' must yield Period {{ years:0, months:0, days:-7 }}"
     );
 }
 
-/// up05: `"7w"` → 49 days (regression guard: explicit weeks unit).
+/// up05: `"7w"` → Period { years:0, months:0, days:49 } (regression guard: explicit weeks unit).
 #[test]
 fn up05_period_with_unit() {
     let cfg = load("up05-period-with-unit.conf");
     assert_eq!(
         cfg.get_period("p").unwrap(),
-        (0, 0, 49),
-        "up05 (regression): '7w' must yield (0, 0, 49) days"
+        hocon::Period::new(0, 0, 49),
+        "up05 (regression): '7w' must yield Period {{ years:0, months:0, days:49 }}"
     );
 }
 


### PR DESCRIPTION
## Summary

**Closes rs.hocon S18.4 ⚠️ → ✅** (Phase 6 #3d, ★1 approved with Q1=Lightbend-faithful per-family fractional).

S18.4 fix in `parse_duration` and `parse_bytes` + **net-new `get_period` / `get_period_option` accessors** returning a `Period { years, months, days }` struct (no `chrono` dependency added).

## Changes

- `src/lexer.rs`: `is_hocon_whitespace` made `pub(crate)`.
- `src/config.rs`: 
  - `parse_duration` rewrite: `HOCON_WS` trim, integer pre-classification regex, empty-unit fallthrough → ms default
  - `parse_bytes` fix: `.round()` → truncate `as i64` (Lightbend `BigDecimal.toBigInteger()`), HOCON_WS, negative-accessor guard (handles BOTH bare-numeric and string paths)
  - New `Period { years: i32, months: i32, days: i32 }` `#[non_exhaustive]` struct
  - New `parse_period` helper + `get_period` / `get_period_option` accessors (days default; supports d/day/days, w/week/weeks, m/mo/month/months, y/year/years)
- `tests/spec_phase5.rs`: pin test deleted, `#[ignore]` removed.
- `tests/units_default_test.rs` (NEW): 22 conformance tests (ud01-ud08, up01-up05, ub01-ub06, un01-un03).
- 48 inline unit tests in `src/config.rs`.
- `docs/spec-compliance.md`: S18.4 ⚠️→✅, S20.1-S20.4 updated (rs ✅, ts/go remain ➖).
- `CHANGELOG.md`: Added `Period` struct + `get_period`; Fixed S18.4.

## rs-specific limitation

`std::time::Duration` is unsigned — Lightbend's `java.time.Duration` is signed. For `parse_duration("-500")` (ud06), `get_duration` returns `Err`. Documented in CHANGELOG.

## Multi-agent-review

Codex (P1 fixture path, P2 unquoted negative bytes) + Claude (Critical spec-compliance.md S20 stale, Critical `get_bytes` bare-numeric bypass, Important Period tuple → struct).

Critical/Important fixes applied in commits `abf2737` / `687e180` / `638ba3b`:
- `get_bytes` bare-numeric negative guard (CONVERGENT Codex P2 + Claude C2)
- spec-compliance.md S20.1-S20.4 updated to reflect rs ✅ on Period
- `Period` struct (`#[non_exhaustive]`) replaces tuple per user-confirmed API design

Codex P1 fixture-tracking concern dismissed: matches existing `concat_errors_test.rs` pattern; CI's `make testdata` early-exit correctly detects remote-vs-local SHA divergence and fetches fresh fixtures. CI will confirm.

## Test plan

- [x] 22 fixture conformance tests pass
- [x] 48 inline unit tests pass
- [x] `cargo test`: 509 tests pass / 0 fail / 9 pre-existing ignored
- [x] `cargo clippy --all-targets -- -D warnings`: no new warnings (pre-existing PI approx_constant noise unrelated)
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)