### PR TITLE
fix(s13a.13): self-ref look-back no-prior short-circuit — Phase 6 #3f

### DIFF
--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -400,8 +400,8 @@ same item descriptions verbatim.
   tests: tests/lightbend_test.rs:275 (lightbend_test06_delayed_merge)
   status: ✅
 - **S13a.13** `a = ${?a}foo` resolves to `"foo"` (look-back undefined) — §Self-Referential (L841)
-  tests: tests/integration_test.rs:1103 (s13a_13_optional_self_ref_concat_with_no_prior_pin); tests/integration_test.rs:1115 (s13a_13_optional_self_ref_concat_with_no_prior_spec)
-  status: ❌ (see #76)
+  tests: tests/integration_test.rs (s13a_13_optional_self_ref_concat_with_no_prior_spec); tests/self_ref_lookback_test.rs (sr01–sr11)
+  status: ✅ (fixed in #76; cleared in cluster phase6-3f)
 - **S13a.14** Mutually-referring object fields (`bar.a = ${foo.d}; foo.c = ${bar.b}`) resolve lazily without false cycle — §Self-Referential (L825-834)
   tests: tests/spec_phase5.rs (s13a_14_mutual_refs_no_false_cycle)
   status: ✅

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -12,6 +12,15 @@ pub(crate) struct SubstitutionResolver<'a> {
     env: &'a HashMap<String, String>,
     resolving: HashSet<String>,
     cache: HashMap<String, HoconValue>,
+    /// Path stack tracking the full dotted path of the field currently being
+    /// assigned in `resolve_res_obj`.  Leaf keys are pushed on entry to each
+    /// `for (key, val)` iteration and popped on exit, so nested objects build
+    /// up the full path (e.g. `["foo", "a"]` while resolving `foo.a`).
+    ///
+    /// Used to tighten the self-ref detection: a substitution `${x}` whose
+    /// found value contains a self-reference is only a true self-reference when
+    /// the field we are assigning IS `x` (i.e., the joined path == subst key).
+    resolving_field_path: Vec<String>,
 }
 
 impl<'a> SubstitutionResolver<'a> {
@@ -21,6 +30,7 @@ impl<'a> SubstitutionResolver<'a> {
             env,
             resolving: HashSet::new(),
             cache: HashMap::new(),
+            resolving_field_path: Vec::new(),
         }
     }
 
@@ -32,14 +42,18 @@ impl<'a> SubstitutionResolver<'a> {
     fn resolve_res_obj(&mut self, obj: &ResObj) -> Result<HoconValue, ResolveError> {
         let mut result = IndexMap::new();
         for (key, val) in &obj.fields {
-            match self.resolve_val(val, obj)? {
+            self.resolving_field_path.push(key.clone());
+            let resolved_result = self.resolve_val(val, obj);
+            self.resolving_field_path.pop();
+            match resolved_result? {
                 Some(resolved) => {
                     // Delayed merge: if both current and prior resolve to objects, deep merge
                     if let HoconValue::Object(ref current_fields) = resolved {
                         if let Some(prior) = obj.prior_values.get(key) {
-                            if let Some(HoconValue::Object(prior_fields)) =
-                                self.resolve_val(prior, obj)?
-                            {
+                            self.resolving_field_path.push(key.clone());
+                            let prior_result = self.resolve_val(prior, obj);
+                            self.resolving_field_path.pop();
+                            if let Some(HoconValue::Object(prior_fields)) = prior_result? {
                                 let merged =
                                     deep_merge_hocon_objects(prior_fields, current_fields.clone());
                                 result.insert(key.clone(), merged);
@@ -52,7 +66,10 @@ impl<'a> SubstitutionResolver<'a> {
                 None => {
                     // Unresolved optional: fall back to prior value
                     if let Some(prior) = obj.prior_values.get(key) {
-                        if let Some(prior_resolved) = self.resolve_val(prior, obj)? {
+                        self.resolving_field_path.push(key.clone());
+                        let prior_result = self.resolve_val(prior, obj);
+                        self.resolving_field_path.pop();
+                        if let Some(prior_resolved) = prior_result? {
                             result.insert(key.clone(), prior_resolved);
                         }
                     }
@@ -155,13 +172,32 @@ impl<'a> SubstitutionResolver<'a> {
             // Self-referential substitution: only use prior value when the substitution
             // path matches the key we found (e.g., b=${b} where fields[b]=Subst(b)).
             if matches!(found, ResolverValue::Subst(_) | ResolverValue::Concat(_)) {
-                let is_self_ref = match &found {
-                    ResolverValue::Subst(sub) => segments_text_equal(&sub.segments, &s.segments),
-                    ResolverValue::Concat(c) => c.nodes.iter().any(|n| {
-                        matches!(n, ResolverValue::Subst(sub) if segments_text_equal(&sub.segments, &s.segments))
-                    }),
-                    _ => false,
-                };
+                // Guard: the self-ref short-circuit only fires when the field currently
+                // being assigned IS the field that the substitution points at.
+                // Without this guard, resolving `b = ${a}` would see that `a`'s value
+                // is `${?a}foo` (a self-referential concat) and mis-fire the short-circuit,
+                // returning an error instead of resolving `a` normally and giving `b = "foo"`.
+                //
+                // `resolving_field_path` holds the leaf keys pushed by `resolve_res_obj`
+                // as it recurses into nested objects, giving the full path of the field
+                // being assigned (e.g. `["foo", "a"]` while resolving `foo.a = …`).
+                // We compare by text so quoting differences don't cause false negatives.
+                let is_owner = self.resolving_field_path.len() == s.segments.len()
+                    && self
+                        .resolving_field_path
+                        .iter()
+                        .zip(s.segments.iter())
+                        .all(|(p, seg)| p == &seg.text);
+                let is_self_ref = is_owner
+                    && match &found {
+                        ResolverValue::Subst(sub) => {
+                            segments_text_equal(&sub.segments, &s.segments)
+                        }
+                        ResolverValue::Concat(c) => c.nodes.iter().any(|n| {
+                            matches!(n, ResolverValue::Subst(sub) if segments_text_equal(&sub.segments, &s.segments))
+                        }),
+                        _ => false,
+                    };
                 if is_self_ref {
                     let root_seg = s.segments.first().map(|s| s.text.as_str()).unwrap_or("");
                     let prior_root = scope
@@ -579,7 +615,7 @@ fn stringify_value(v: &HoconValue) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::value::{ScalarType, ScalarValue};
+    use crate::value::ScalarValue;
 
     /// Fix #2: type_name must return scalar subtype names (not "scalar").
     #[test]

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -20,6 +20,13 @@ pub(crate) struct SubstitutionResolver<'a> {
     /// Used to tighten the self-ref detection: a substitution `${x}` whose
     /// found value contains a self-reference is only a true self-reference when
     /// the field we are assigning IS `x` (i.e., the joined path == subst key).
+    ///
+    /// Spec deviation: the S13a.13 spec ★1 decision #1 specified path-equality
+    /// preservation for self-ref detection. Round-2 multi-agent-review surfaced
+    /// a false-positive on external lookups (`a = ${?a}foo; b = ${a}`), so the
+    /// criterion was tightened with this `is_owner` guard — strictly narrower
+    /// than the original path-equality check. Spec amendment deferred to a
+    /// follow-up xx.hocon PR (see Phase 6 #3f close-out notes).
     resolving_field_path: Vec<String>,
 }
 

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -234,11 +234,35 @@ impl<'a> SubstitutionResolver<'a> {
                         // Prior root exists but nested path not found — fall through to
                         // no-prior short-circuit below.
                     }
+                    // Object-literal form fallback: when `foo { a = "x"; a = ${?foo.a}bar }`
+                    // is used, the prior for the leaf key `a` is stored directly in the
+                    // current scope (inner_obj.prior_values["a"]), not in the root scope
+                    // under the parent key "foo".  The root-segment lookup above only
+                    // finds the parent object's prior (used for dotted-path reassignments
+                    // at root level), so it finds nothing here.
+                    //
+                    // Guard: only fire this fallback when the substitution is multi-segment
+                    // (len > 1) — single-segment priors are already handled above — and the
+                    // leaf segment's prior lives directly in `scope`.
+                    if s.segments.len() > 1 {
+                        let leaf_seg = s.segments.last().map(|seg| seg.text.as_str()).unwrap_or("");
+                        if let Some(leaf_prior) = scope.prior_values.get(leaf_seg).cloned() {
+                            let result = self.resolve_val(&leaf_prior, scope)?;
+                            if let Some(ref r) = result {
+                                self.cache.insert(key.to_string(), r.clone());
+                            }
+                            return Ok(result);
+                        }
+                    }
                     // Spec L841: no prior + self-ref → optional yields undefined; required errors.
                     if s.optional {
-                        // Cache the undefined result for idempotency (spec Q2).
                         // Return None (undefined) — the concat-layer optional-omission rule
                         // (Phase 6 #3b) will omit this from the fold input.
+                        // Note: no explicit cache entry is inserted here; undefined is
+                        // encoded by absence from the cache (cache stores HoconValue, not
+                        // Option<HoconValue>). Re-resolving the same self-ref deterministically
+                        // returns None without a cached entry — spec Q2 idempotency is
+                        // satisfied structurally.
                         return Ok(None);
                     }
                     return Err(ResolveError {

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -164,18 +164,48 @@ impl<'a> SubstitutionResolver<'a> {
                 };
                 if is_self_ref {
                     let root_seg = s.segments.first().map(|s| s.text.as_str()).unwrap_or("");
-                    let prior = scope
+                    let prior_root = scope
                         .prior_values
                         .get(root_seg)
                         .or_else(|| self.root.prior_values.get(root_seg))
                         .cloned();
-                    if let Some(prior) = prior {
-                        let result = self.resolve_val(&prior, scope)?;
-                        if let Some(ref r) = result {
-                            self.cache.insert(key.to_string(), r.clone());
+                    if let Some(prior_root) = prior_root {
+                        // For multi-segment paths (e.g. foo.a), navigate into the prior
+                        // root object to find the value at the full path.
+                        let prior = if s.segments.len() > 1 {
+                            if let ResolverValue::Obj(ref prior_obj) = prior_root {
+                                lookup_path(prior_obj, &s.segments[1..]).cloned()
+                            } else {
+                                None
+                            }
+                        } else {
+                            Some(prior_root)
+                        };
+                        if let Some(prior) = prior {
+                            let result = self.resolve_val(&prior, scope)?;
+                            if let Some(ref r) = result {
+                                self.cache.insert(key.to_string(), r.clone());
+                            }
+                            return Ok(result);
                         }
-                        return Ok(result);
+                        // Prior root exists but nested path not found — fall through to
+                        // no-prior short-circuit below.
                     }
+                    // Spec L841: no prior + self-ref → optional yields undefined; required errors.
+                    if s.optional {
+                        // Cache the undefined result for idempotency (spec Q2).
+                        // Return None (undefined) — the concat-layer optional-omission rule
+                        // (Phase 6 #3b) will omit this from the fold input.
+                        return Ok(None);
+                    }
+                    return Err(ResolveError {
+                        message: format!(
+                            "could not resolve substitution: ${{{key}}} (self-referential with no prior value)"
+                        ),
+                        path: key.to_string(),
+                        line: s.line,
+                        col: s.col,
+                    });
                 }
             }
             let mut result = self.resolve_val(&found, scope)?;

--- a/tests/env_var_list_test.rs
+++ b/tests/env_var_list_test.rs
@@ -286,11 +286,8 @@ fn s13c_s5_optional_no_scalar_fallback() {
 
 /// ev08: `x = ["x"]; x = ${?x} ${?LIST[]}` → `["x","a"]`.
 ///
-/// The plan proposed a `#[should_panic]` tripwire (S13a.13 gap), but rs.hocon's
-/// existing prior_values / self-ref-lookback logic already handles this case
-/// correctly via the concat resolver and `join_pair`. Verified 2026-05-18:
-/// ev08 resolves to `["x","a"]` without the S13a.13 fix. This fixture therefore
-/// ships as a regular ✅ success test, not a tripwire.
+/// The prior value `x = ["x"]` is found by the self-ref look-back, so the array
+/// concat resolves correctly. Ships as a regular ✅ success test.
 #[test]
 fn s13c_ev08_self_ref_concat() {
     assert_fixture_matches("ev08-self-append");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1203,25 +1203,10 @@ fn s13_16_substitution_in_key_is_rejected() {
 // No test added; see docs/spec-compliance.md S13a.10.
 
 // --- S13a.13: `a = ${?a}foo` resolves to "foo" (spec L841) ----------------------
-// BUG: rs.hocon currently evaluates ${?a} as the (already-set) value of `a`
-// ("foo") and produces "foofoo".
 #[test]
-fn s13a_13_optional_self_ref_concat_with_no_prior_pin() {
-    // [pin] Current (broken) behaviour: ${?a} sees "foo" instead of undefined.
+fn s13a_13_optional_self_ref_concat_with_no_prior_spec() {
     // Use empty env so an ambient `a` env var cannot leak in (single-letter env
     // names like `a` are common on POSIX shells — a real-world flake risk).
-    let cfg = hocon::parse_with_env("a = ${?a}foo", &std::collections::HashMap::new())
-        .expect("parse failed");
-    assert_eq!(
-        cfg.get_string("a").unwrap(),
-        "foofoo",
-        "[pin] a currently resolves to \"foofoo\" — update when fixed"
-    );
-}
-
-#[test]
-#[ignore = "spec violation: a = ${?a}foo must resolve to \"foo\" when a has no prior value, see #76"]
-fn s13a_13_optional_self_ref_concat_with_no_prior_spec() {
     let cfg = hocon::parse_with_env("a = ${?a}foo", &std::collections::HashMap::new())
         .expect("parse failed");
     assert_eq!(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1490,3 +1490,16 @@ fn s17_8_array_to_other_type_errors() {
         "get_list on an array must succeed"
     );
 }
+
+// --- S13a.13 Codex P2: external reference to a self-referential concat field ----
+/// When field `a = ${?a}foo` (self-ref optional concat) is referenced by another
+/// field `b = ${a}`, the self-ref look-back short-circuit must NOT fire for `b`.
+/// Previously the `is_self_ref` guard keyed only on structural match, so it
+/// mis-classified `b`'s resolution of `${a}` as a self-reference.
+#[test]
+fn s13a_13_external_reference_to_self_ref_field() {
+    let cfg = hocon::parse_with_env("a = ${?a}foo\nb = ${a}", &std::collections::HashMap::new())
+        .expect("parse failed");
+    assert_eq!(cfg.get_string("a").unwrap(), "foo");
+    assert_eq!(cfg.get_string("b").unwrap(), "foo");
+}

--- a/tests/self_ref_lookback_test.rs
+++ b/tests/self_ref_lookback_test.rs
@@ -1,0 +1,241 @@
+//! S13a.13 — optional self-ref look-back conformance tests.
+//!
+//! Fixtures loaded from `tests/testdata/hocon/self-ref-lookback/` (synced from
+//! xx.hocon via `make testdata`). Expected sidecars from
+//! `tests/testdata/expected/self-ref-lookback/`.
+//!
+//! Convention:
+//! - `.error` sidecar present → assert `parse_file(...).is_err()`
+//! - `-expected.json` present → assert `parse_file(...).is_ok()` + compare JSON
+//!
+//! Closes: rs.hocon#76 (S13a.13 self-ref look-back fix)
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+// ── Paths ─────────────────────────────────────────────────────────────────────
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/testdata/hocon/self-ref-lookback")
+}
+
+fn expected_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/testdata/expected/self-ref-lookback")
+}
+
+fn fixture_path(stem: &str) -> PathBuf {
+    fixture_dir().join(format!("{}.conf", stem))
+}
+
+fn error_sidecar_path(stem: &str) -> PathBuf {
+    expected_dir().join(format!("{}.error", stem))
+}
+
+fn expected_json_path(stem: &str) -> PathBuf {
+    expected_dir().join(format!("{}-expected.json", stem))
+}
+
+// ── JSON helpers ──────────────────────────────────────────────────────────────
+
+fn normalize(v: &serde_json::Value) -> serde_json::Value {
+    match v {
+        serde_json::Value::Object(map) => {
+            let mut m = serde_json::Map::new();
+            for (k, val) in map {
+                m.insert(k.clone(), normalize(val));
+            }
+            serde_json::Value::Object(m)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(normalize).collect())
+        }
+        serde_json::Value::Number(n) => {
+            let f = n.as_f64().unwrap_or(0.0);
+            serde_json::json!(f)
+        }
+        other => other.clone(),
+    }
+}
+
+fn hocon_to_json(v: &hocon::HoconValue) -> serde_json::Value {
+    match v {
+        hocon::HoconValue::Object(map) => {
+            let mut m = serde_json::Map::new();
+            for (k, val) in map {
+                m.insert(k.clone(), hocon_to_json(val));
+            }
+            serde_json::Value::Object(m)
+        }
+        hocon::HoconValue::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(hocon_to_json).collect())
+        }
+        hocon::HoconValue::Scalar(sv) => match sv.value_type {
+            hocon::ScalarType::Null => serde_json::Value::Null,
+            hocon::ScalarType::Boolean => serde_json::Value::Bool(sv.raw == "true"),
+            hocon::ScalarType::Number => {
+                if !sv.raw.contains('.') && !sv.raw.contains('e') && !sv.raw.contains('E') {
+                    if let Ok(n) = sv.raw.parse::<i64>() {
+                        return serde_json::json!(n);
+                    }
+                }
+                if let Ok(f) = sv.raw.parse::<f64>() {
+                    return serde_json::json!(f);
+                }
+                serde_json::Value::String(sv.raw.clone())
+            }
+            hocon::ScalarType::String => serde_json::Value::String(sv.raw.clone()),
+            _ => serde_json::Value::String(sv.raw.clone()),
+        },
+        _ => panic!("hocon_to_json: unknown HoconValue variant: {:?}", v),
+    }
+}
+
+fn key_to_lookup_path(key: &str) -> String {
+    if key.is_empty()
+        || key.contains('.')
+        || key.contains('"')
+        || key.contains('\\')
+        || key.contains(' ')
+        || key.contains('\t')
+    {
+        let escaped = key.replace('\\', "\\\\").replace('"', "\\\"");
+        format!("\"{}\"", escaped)
+    } else {
+        key.to_string()
+    }
+}
+
+fn config_to_json(config: &hocon::Config) -> serde_json::Value {
+    let mut m = serde_json::Map::new();
+    for key in config.keys() {
+        let path = key_to_lookup_path(key);
+        if let Some(val) = config.get(&path) {
+            m.insert(key.to_string(), hocon_to_json(val));
+        }
+    }
+    normalize(&serde_json::Value::Object(m))
+}
+
+// ── Fixture runner ────────────────────────────────────────────────────────────
+
+fn run_fixture(stem: &str) {
+    let fp = fixture_path(stem);
+    let ep = error_sidecar_path(stem);
+    let jp = expected_json_path(stem);
+
+    let has_error = ep.exists();
+    let has_json = jp.exists();
+
+    assert!(
+        has_error || has_json,
+        "self-ref-lookback/{stem}.conf has no expected sidecar (.error or -expected.json).\n\
+         Run `make testdata` first to fetch expected sidecars from xx.hocon."
+    );
+
+    let env: HashMap<String, String> = HashMap::new();
+    let result = hocon::parse_file_with_env(&fp, &env);
+
+    if has_error {
+        assert!(
+            result.is_err(),
+            "self-ref-lookback {}: expected parse/resolve error but got Ok (fixture: {})",
+            stem,
+            fp.display()
+        );
+    } else {
+        let cfg = result.unwrap_or_else(|e| {
+            panic!(
+                "self-ref-lookback {}: unexpected error {:?} (fixture: {})",
+                stem,
+                e,
+                fp.display()
+            )
+        });
+        let got = config_to_json(&cfg);
+
+        let json_src = std::fs::read_to_string(&jp)
+            .unwrap_or_else(|e| panic!("failed to read expected JSON {}: {}", jp.display(), e));
+        let expected: serde_json::Value = serde_json::from_str(&json_src)
+            .unwrap_or_else(|e| panic!("invalid JSON in {}: {}", jp.display(), e));
+        let expected = normalize(&expected);
+
+        assert_eq!(
+            got,
+            expected,
+            "self-ref-lookback {}: output mismatch\n  got:      {}\n  expected: {}",
+            stem,
+            serde_json::to_string_pretty(&got).unwrap(),
+            serde_json::to_string_pretty(&expected).unwrap(),
+        );
+    }
+}
+
+// ── sr01–sr11 ─────────────────────────────────────────────────────────────────
+
+/// sr01: `a = ${?a}foo` no prior → `"foo"` (core fix)
+#[test]
+fn sr01_optional_no_prior() {
+    run_fixture("sr01-optional-no-prior");
+}
+
+/// sr02: `a = bar${?a}` no prior → `"bar"` (leading literal)
+#[test]
+fn sr02_optional_no_prior_leading() {
+    run_fixture("sr02-optional-no-prior-leading");
+}
+
+/// sr03: `a = bar${?a}foo` no prior → `"barfoo"` (literal on both sides)
+#[test]
+fn sr03_optional_no_prior_both_sides() {
+    run_fixture("sr03-optional-no-prior-both-sides");
+}
+
+/// sr04: `a = "x"; a = ${?a}foo` → `"xfoo"` (regression: prior value used)
+#[test]
+fn sr04_optional_with_prior() {
+    run_fixture("sr04-optional-with-prior");
+}
+
+/// sr05: `a = ${a}foo` no prior → resolve error (required ref boundary)
+#[test]
+fn sr05_required_no_prior() {
+    run_fixture("sr05-required-no-prior");
+}
+
+/// sr06: `a = "x"; a = ${a}foo` → `"xfoo"` (regression: required + prior)
+#[test]
+fn sr06_required_with_prior() {
+    run_fixture("sr06-required-with-prior");
+}
+
+/// sr07: `a = ${?a} [2]` no prior → `[2]` (array variant)
+#[test]
+fn sr07_array_optional_no_prior() {
+    run_fixture("sr07-array-optional-no-prior");
+}
+
+/// sr08: `a = [1]; a = ${?a} [2]` → `[1, 2]` (regression: array with prior)
+#[test]
+fn sr08_array_optional_with_prior() {
+    run_fixture("sr08-array-optional-with-prior");
+}
+
+/// sr09: `foo.a = ${?foo.a}bar` no prior → `foo.a = "bar"` (nested path)
+#[test]
+fn sr09_nested_no_prior() {
+    run_fixture("sr09-nested-no-prior");
+}
+
+/// sr10: `foo.a = "x"; foo.a = ${?foo.a}bar` → `foo.a = "xbar"` (nested regression)
+#[test]
+fn sr10_nested_with_prior() {
+    run_fixture("sr10-nested-with-prior");
+}
+
+/// sr11: mutual forward-ref — not a self-ref; standard forward-ref resolution (regression guard)
+#[test]
+fn sr11_mutual_ref_forward() {
+    run_fixture("sr11-mutual-ref-forward");
+}

--- a/tests/self_ref_lookback_test.rs
+++ b/tests/self_ref_lookback_test.rs
@@ -16,13 +16,11 @@ use std::path::PathBuf;
 // ── Paths ─────────────────────────────────────────────────────────────────────
 
 fn fixture_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/testdata/hocon/self-ref-lookback")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/testdata/hocon/self-ref-lookback")
 }
 
 fn expected_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/testdata/expected/self-ref-lookback")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/testdata/expected/self-ref-lookback")
 }
 
 fn fixture_path(stem: &str) -> PathBuf {

--- a/tests/self_ref_lookback_test.rs
+++ b/tests/self_ref_lookback_test.rs
@@ -123,6 +123,12 @@ fn run_fixture(stem: &str) {
     let ep = error_sidecar_path(stem);
     let jp = expected_json_path(stem);
 
+    assert!(
+        fp.exists(),
+        "fixture missing: {} — run `make testdata` to sync fixtures from xx.hocon",
+        fp.display()
+    );
+
     let has_error = ep.exists();
     let has_json = jp.exists();
 
@@ -236,4 +242,20 @@ fn sr10_nested_with_prior() {
 #[test]
 fn sr11_mutual_ref_forward() {
     run_fixture("sr11-mutual-ref-forward");
+}
+
+/// sr12: object-literal form `foo { a = "x"\n a = ${?foo.a}bar }` → `foo.a = "xbar"`
+/// Regression guard: AST normalization must unify object-literal and dotted-path forms
+/// for self-ref look-back (Copilot rs-T1 verification).
+/// Note: HOCON field separator is LF (0x0A); semicolons are not newline equivalents
+/// in this parser, so the multi-field form requires a literal newline inside the
+/// object-literal block.
+#[test]
+fn s13a_13_nested_self_ref_object_literal_form() {
+    let cfg = hocon::parse_with_env(
+        "foo {\n  a = \"x\"\n  a = ${?foo.a}bar\n}",
+        &std::collections::HashMap::new(),
+    )
+    .expect("parse failed");
+    assert_eq!(cfg.get_string("foo.a").unwrap(), "xbar");
 }


### PR DESCRIPTION
## Summary

Fix S13a.13: `a = ${?a}foo` with no prior `a` now resolves to `"foo"` (per HOCON.md L841), was `"foofoo"`.

Closes #76.

## Mechanism

When the resolver encounters a self-referential substitution `${?a}` (or `${a}`) inside the value being assigned to path `a`:
1. If a prior assignment to `a` exists → look-back returns the prior value (unchanged behavior).
2. **NEW**: If no prior exists → short-circuit. Optional `${?a}` → `Ok(None)` (concat-fold omits it); required `${a}` → `ResolveError`.

Identification: a substitution is "self-referential" when **the currently-being-assigned field path equals the substitution path**. Tracked via a `resolving_field_path: Vec<String>` stack on the resolver (push leaf key on entry to each `for (key, val)` iteration in `resolve_res_obj`, pop on exit).

Additional fix (sr09/sr10 nested support): when prior is found and the substitution path is multi-segment (e.g. `foo.a`), navigate into the prior root object via `lookup_path(prior_obj, &s.segments[1..])` to find the nested leaf value.

## Why not the spec's path-equality alone?

The original spec ★1 decision #1 specified path-equality preservation for self-ref detection. Round-2 multi-agent-review surfaced a false-positive: external lookups like `a = ${?a}foo; b = ${a}` would error because `b`'s `${a}` lookup found `a`'s concat-with-self-ref and triggered the short-circuit (wrongly).

All 3 impls (ts/rs/go) independently tightened the mechanism. ts uses node-membership-in-iterating-set; rs uses this path stack + `is_owner` guard; go uses AST-node pointer-identity. **All three are strictly narrower than path-equality** (correctly exclude external lookups).

Spec amendment deferred to a follow-up xx.hocon PR. See [xx.hocon#27](https://github.com/o3co/xx.hocon/issues/27) for the cross-impl tracking issue.

## Test plan

- [x] Conformance fixtures sr01–sr11 (xx.hocon `testdata/hocon/self-ref-lookback/`) all pass
- [x] Integration tests for 11+ edge cases (no-prior, with-prior, required, array, nested, mutual-ref, external-ref regression guard)
- [x] Round-2 regression test: `a = ${?a}foo; b = ${a}` → both `"foo"`
- [x] Existing `s13a_13_optional_self_ref_concat_with_no_prior_pin` test removed; `s13a_13_..._spec` un-ignored
- [x] env_var_list_test.rs ev08 tripwire comments removed
- [x] `cargo test` green (~524 tests)
- [x] `cargo clippy --lib -- -D warnings` clean (pre-existing test-target clippy issues are not introduced by this PR)
- [x] `cargo fmt --check` clean
- [x] No public API changes (`SubstitutionResolver` is `pub(crate)`; no new public types/enums)

## Pre-existing bugs surfaced (out of scope, see xx.hocon#27)

Round 2 review discovered 4 pre-existing resolver bugs beyond S13a.13 strict:
- Nested external ref crash (`foo.a = ${?foo.a}bar; foo.b = ${foo.a}`)
- Cache pollution on prior-with-external-ref
- Same-field double-self-ref crash
- Order-dependent ref-before-self-ref

These are filed as cross-impl follow-ups; not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)