### PR TITLE
fix: parse_duration overflow guards (closes #95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`parse_duration` overflow guards** (closes #95, non-breaking):
+  Integer path now uses `checked_mul` on `u64` instead of `(n as f64 * unit) as u64`
+  which silently saturated for large `n` values. Fractional path now checks the
+  product against `2f64.powi(64)` (the exact f64 value of 2^64) before the
+  `as u64` cast — `(n as f64 * unit) as u64` previously rounded up `u64::MAX` to
+  `2^64` on cast, masking overflow. Inputs like `"9223372036854775807 weeks"` and
+  `"1e30 d"` now correctly return `None` instead of saturating to `Duration::from_nanos(u64::MAX)`.
+  Same pattern as the cluster #3h fractional byte overflow fix in `parse_bytes`.
+
+  Additionally, the integer fast-path now parses via `i128` to range-check both
+  negatives (rejected per rs's unsigned-`Duration` limitation) AND values up to
+  `u64::MAX` — previously the upper half of the representable nanos range was
+  rejected as "parse error" rather than overflow.
+
 - **S3.1 — Empty file is invalid** (Phase 6 #3h):
   `parse` and `parse_file` (and their `_with_env` variants) now return a `ParseError` for
   empty documents — including empty strings, whitespace-only, newlines-only, comment-only,

--- a/src/config.rs
+++ b/src/config.rs
@@ -560,13 +560,21 @@ fn parse_duration(s: &str) -> Option<std::time::Duration> {
 
     // Integer fast-path (matches Lightbend `Long.parseLong`).
     if is_integer_str(num_str) {
-        let n: i64 = num_str.parse().ok()?;
-        // rs-specific: std::time::Duration is unsigned; negative values are rejected.
-        // Lightbend's java.time.Duration is signed. See CHANGELOG for rs-specific note.
-        if n < 0 {
+        // Parse as i128 so we can range-check both negatives (rejected per rs's
+        // unsigned-Duration limitation) AND values in [i64::MAX, u64::MAX] before
+        // narrowing to u64. The prior i64 parse rejected the entire upper half of
+        // the representable nanos range as "parse error" rather than overflow.
+        let n_i128: i128 = num_str.parse().ok()?;
+        if n_i128 < 0 {
             return None;
         }
-        let nanos = (n as f64 * nanos_per_unit) as u64;
+        let n_u64: u64 = n_i128.try_into().ok()?;
+        // Overflow guard via checked_mul on u64. The table values are exact small
+        // integers (max = 604_800_000_000_000 for weeks), so the f64 → u64 cast
+        // is lossless. The prior `(n as f64 * nanos_per_unit) as u64` lost precision
+        // for large n (~2^53+) and silently saturated on overflow.
+        let unit_u64 = nanos_per_unit as u64;
+        let nanos = n_u64.checked_mul(unit_u64)?;
         return Some(std::time::Duration::from_nanos(nanos));
     }
 
@@ -575,8 +583,16 @@ fn parse_duration(s: &str) -> Option<std::time::Duration> {
     if f < 0.0 || !f.is_finite() {
         return None;
     }
-    let nanos = (f * nanos_per_unit) as u64;
-    Some(std::time::Duration::from_nanos(nanos))
+    // Precision-safe upper bound: u64::MAX = 2^64 - 1 cannot be represented exactly
+    // in f64 (rounds up to 2^64). Compare against `2f64.powi(64)` — the exact float64
+    // value of 2^64 — so the boundary check fires for any value that would saturate
+    // the subsequent `as u64` cast. Same approach as the cluster #3h fractional byte
+    // overflow fix (rs `parse_bytes` 2^63, go `math.Exp2(63)`).
+    let product = f * nanos_per_unit;
+    if !product.is_finite() || product >= 2f64.powi(64) {
+        return None;
+    }
+    Some(std::time::Duration::from_nanos(product as u64))
 }
 
 /// Parse a HOCON period string into a `(years, months, days)` tuple.
@@ -1167,6 +1183,53 @@ mod tests {
     #[test]
     fn parse_duration_unit_only_is_none() {
         assert!(parse_duration("ms").is_none());
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Issue #95 — parse_duration overflow guards (integer + fractional)
+    //
+    // Pre-fix: `(n as f64 * nanos_per_unit) as u64` silently saturated for
+    // large n; `(f * nanos_per_unit) as u64` silently saturated for fractional
+    // overflow. Lightbend errors in both cases — we now match.
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_duration_integer_overflow_weeks_is_none() {
+        // i64::MAX weeks would require ~5.6e33 nanos, far past u64::MAX.
+        assert!(parse_duration("9223372036854775807 weeks").is_none());
+    }
+
+    #[test]
+    fn parse_duration_integer_overflow_days_is_none() {
+        // i64::MAX days × 86_400_000_000_000 ns/day overflows u64 (2^64 ≈ 1.8e19).
+        assert!(parse_duration("9223372036854775807 days").is_none());
+    }
+
+    #[test]
+    fn parse_duration_integer_max_u64_nanos_succeeds() {
+        // u64::MAX nanos should be representable (boundary success).
+        let d = parse_duration("18446744073709551615ns").unwrap();
+        assert_eq!(d.as_nanos(), u64::MAX as u128);
+    }
+
+    #[test]
+    fn parse_duration_fractional_overflow_is_none() {
+        // 1e30 days is wildly past u64::MAX nanos.
+        assert!(parse_duration("1e30 d").is_none());
+    }
+
+    #[test]
+    fn parse_duration_fractional_above_u64_max_is_none() {
+        // 2^64 nanos exactly — boundary just past representable range.
+        // f64 rounds u64::MAX up to 2^64, so the strict-< check at 2^64 catches both.
+        assert!(parse_duration("18446744073709551616ns").is_none());
+    }
+
+    #[test]
+    fn parse_duration_fractional_succeeds_below_boundary() {
+        // 1.5 weeks = ~907_200_000_000_000 ns, well within u64.
+        let d = parse_duration("1.5w").unwrap();
+        assert_eq!(d.as_nanos(), 907_200_000_000_000u128);
     }
 
     // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Mirror the cluster #3h fractional byte overflow fix on the duration path.

- **Integer**: `u64::checked_mul` instead of `(n as f64 * unit) as u64` (was silent saturation + f64 precision loss for n ~ 2^53+). Parse via `i128` to accept values in `[i64::MAX+1, u64::MAX]`.
- **Fractional**: precision-safe boundary `product >= 2f64.powi(64)` before `as u64` cast (was silent saturation; same f64 precision shape as the cluster #3h `parse_bytes` 2^63 boundary).

## Test plan

- [x] 6 new regression tests:
  - Integer overflow: `9223372036854775807 weeks` / `9223372036854775807 days` → None
  - Integer success boundary: `18446744073709551615ns` (u64::MAX nanos) → succeeds
  - Fractional overflow: `1e30 d` / `18446744073709551616ns` → None
  - Fractional success: `1.5w` → 907_200_000_000_000 ns
- [x] All 14 parse_duration tests pass (+6 new, 8 pre-existing all green)
- [x] CHANGELOG entry added under [Unreleased] Fixed
- [x] Non-BREAKING: prior behavior was silent saturation (Duration::from_nanos(u64::MAX)); no caller can rely on silent corruption

## Background

Surfaced during Phase 6 #3h multi-agent review (Claude rs#94 Important #2) as parallel to the `parse_bytes` overflow fix that landed in cluster #3h. Filed as #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)