### PR TITLE
docs: fix codecov badge URL (main → develop)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/hocon-parser.svg)](https://crates.io/crates/hocon-parser)
 [![docs.rs](https://docs.rs/hocon-parser/badge.svg)](https://docs.rs/hocon-parser)
 [![CI](https://github.com/o3co/rs.hocon/actions/workflows/test.yml/badge.svg)](https://github.com/o3co/rs.hocon/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/o3co/rs.hocon/branch/main/graph/badge.svg)](https://codecov.io/gh/o3co/rs.hocon)
+[![codecov](https://codecov.io/gh/o3co/rs.hocon/branch/develop/graph/badge.svg)](https://codecov.io/gh/o3co/rs.hocon)
 [![License](https://img.shields.io/crates/l/hocon-parser.svg)](LICENSE)
 
 [Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) の Rust パーサー。手書きレキサー、再帰下降パーサー、型付き `Config` API を備え、オプションで Serde 統合に対応。現在の準拠率は [仕様準拠](#仕様準拠) を参照。

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/hocon-parser.svg)](https://crates.io/crates/hocon-parser)
 [![docs.rs](https://docs.rs/hocon-parser/badge.svg)](https://docs.rs/hocon-parser)
 [![CI](https://github.com/o3co/rs.hocon/actions/workflows/test.yml/badge.svg)](https://github.com/o3co/rs.hocon/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/o3co/rs.hocon/branch/main/graph/badge.svg)](https://codecov.io/gh/o3co/rs.hocon)
+[![codecov](https://codecov.io/gh/o3co/rs.hocon/branch/develop/graph/badge.svg)](https://codecov.io/gh/o3co/rs.hocon)
 [![License](https://img.shields.io/crates/l/hocon-parser.svg)](LICENSE)
 
 A [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md)


### PR DESCRIPTION
## Summary

- README.md + README.ja.md の codecov badge URL を `branch/main` から `branch/develop` に修正
- このリポは default branch が `develop` で、`main` branch は存在しない

## Why

`https://codecov.io/gh/o3co/rs.hocon/branch/main/graph/badge.svg` を fetch すると codecov は存在しない branch を resolve できず badge が **"unknown"** を返していた。

`branch/develop` に修正後、empirically 85% (実際の develop coverage) を返すことを確認済。

## Cross-repo

同じ修正を [ts.hocon](https://github.com/o3co/ts.hocon) と [go.hocon](https://github.com/o3co/go.hocon) にも並列 PR で適用。

## Test plan

- [x] curl で新 URL が正しい値を返すことを確認
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)