### PR TITLE
ci(publish): add make testdata step to fix v1.3.0 publish regression

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,18 @@ jobs:
             cargo set-version "$TAG_VERSION"
           fi
 
+      - name: Cache expected JSON
+        # Mirror the cache pattern from test.yml so the publish job doesn't
+        # re-fetch fixtures on every tag push (avoids GitHub API rate-limit
+        # and transient network failures during release).
+        uses: actions/cache@v5
+        with:
+          path: |
+            tests/testdata/expected
+            .xx-hocon-version
+          key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}
+          restore-keys: xx-hocon-expected-
+
       - name: Fetch expected JSON sidecars from xx.hocon
         # tests/concat_errors_test.rs, tests/s8_unquoted_starts.rs, and
         # other sidecar-driven conformance tests need `tests/testdata/expected/`
@@ -33,7 +45,8 @@ jobs:
         # fetched, not vendored), so without this step the publish-time
         # `cargo test` fails with "no expected sidecar" panics on ce01-ce15
         # / us02-us30 etc. Mirrors ts.hocon release.yml fix from v1.2.0
-        # publish regression.
+        # publish regression. The Makefile's early-exit on matching pin SHA
+        # makes this a no-op when the cache hit above is fresh.
         run: make testdata
 
       - run: cargo test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,16 @@ jobs:
             cargo set-version "$TAG_VERSION"
           fi
 
+      - name: Fetch expected JSON sidecars from xx.hocon
+        # tests/concat_errors_test.rs, tests/s8_unquoted_starts.rs, and
+        # other sidecar-driven conformance tests need `tests/testdata/expected/`
+        # populated. That dir is gitignored (repo convention — sidecars are
+        # fetched, not vendored), so without this step the publish-time
+        # `cargo test` fails with "no expected sidecar" panics on ce01-ce15
+        # / us02-us30 etc. Mirrors ts.hocon release.yml fix from v1.2.0
+        # publish regression.
+        run: make testdata
+
       - run: cargo test
       - run: cargo test --features serde
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-05-21
+
+v1.3 is a spec-compliance bugfix release. The implementation has been corrected to match the HOCON spec and Lightbend typesafe-config reference behavior across several previously-divergent areas (E8 value-position lexing + leading-zero canonicalization, single-letter byte units, `include` key reservation, concat type-checking, empty-file rejection, `.properties` object-wins, duration/bytes default unit, S13c env-var list). The spec did not change; the parser was simply wrong in places.
+
+A subset of these fixes change observable runtime behavior. The most likely user-visible change is **S21.4** — single-letter byte units (`K`/`M`/`G`/`T`/`P`/`E`) now map to powers of two instead of SI decimal (`1K` was 1,000; now 1,024 — per HOCON.md L1385 java `-Xmx` convention, confirmed against Lightbend 1.4.3). If your `.conf` files use single-letter units and you rely on the numeric result, audit `get_bytes` call sites. Multi-letter forms (`KB`/`MB`/`GB`/`TB`) remain SI decimal and are unchanged. Other fixes have narrow practical impact — read `### Changed` / `### Fixed` below if your CI fails to upgrade cleanly. We elected MINOR (not MAJOR) because no API or architectural changes occurred; v2.0 is reserved for parser/lexer rewrites or similar structural shifts.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.3.0] - 2026-05-21
 
 v1.3 is a spec-compliance bugfix release. The implementation has been corrected to match the HOCON spec and Lightbend typesafe-config reference behavior across several previously-divergent areas (E8 value-position lexing + leading-zero canonicalization, single-letter byte units, `include` key reservation, concat type-checking, empty-file rejection, `.properties` object-wins, duration/bytes default unit, S13c env-var list). The spec did not change; the parser was simply wrong in places.
@@ -197,7 +199,7 @@ A subset of these fixes change observable runtime behavior. The most likely user
 
 - **BREAKING (S8.6)**: `a = -foo`, `a = -bar`, `a = -` and other `-`-not-followed-by-digit inputs are now lex errors. Per HOCON.md L270–276, a leading `-` must begin a number literal (i.e. be followed by a digit). Previously these were silently accepted as unquoted strings (`"-foo"`, `"-"`). The same rule is applied to substitution paths (`${-foo}` rejected) and dotted key segments (`a.-foo = 1` rejected). Mitigation: quote the value (`a = "-foo"`). Note: this is intentionally stricter than Lightbend's reference implementation, which falls back to unquoted on number-parse failure. Digit-leading inputs (e.g. `123abc`, `01`, `1e+x`) are unaffected — rs.hocon's token model has no separate `Number` kind, so the resolved value continues to match Lightbend's value-concat output for the common cases (see `docs/spec-compliance.md` §S8.6 for the remaining gaps tracked under #63).
 
-  > **⚠ Retracted by E8 amendment (2026-05-20)**: the value-position `-` reject described above was reverted in the [Unreleased] section. xx.hocon E8 was rewritten to adopt Lightbend's pragmatic reading of HOCON.md L270-276 ([xx.hocon#31](https://github.com/o3co/xx.hocon/issues/31), driven by external report @cgordon). The substitution-body and dotted-key-segment strict checks are NOT retracted — those remain in force as out-of-E8-scope path-element rules.
+  > **⚠ Retracted by E8 amendment (2026-05-20)**: the value-position `-` reject described above was reverted in the [1.3.0] section. xx.hocon E8 was rewritten to adopt Lightbend's pragmatic reading of HOCON.md L270-276 ([xx.hocon#31](https://github.com/o3co/xx.hocon/issues/31), driven by external report @cgordon). The substitution-body and dotted-key-segment strict checks are NOT retracted — those remain in force as out-of-E8-scope path-element rules.
 - Substitution body tokenization: `${...}` internals are now tokenized
   by a dedicated `parse_subst_body` in the lexer, matching Lightbend
   `PathParser` + `WhitespaceSaver` semantics. Quoted segments receive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hocon-parser"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "criterion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hocon-parser"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 rust-version = "1.82"
 description = "Full Lightbend HOCON specification-compliant parser for Rust"


### PR DESCRIPTION
## Summary

`publish.yml` was running \`cargo test\` without first fetching the expected JSON sidecars from xx.hocon. \`tests/testdata/expected/\` is gitignored (repo convention — sidecars are fetched, not vendored), so without this step the publish-time test run fails with "no expected sidecar" panics on ce01-ce15 (concat-errors), us02/us03/us13/us17-us30 (unquoted-starts), etc.

This mirrors the ts.hocon release.yml fix from the v1.2.0 publish regression (commit a2823ea on ts.hocon). \`test.yml\` already has the same step.

## Background

Caught by **v1.3.0 publish attempt**: tag was pushed to develop, all 14 ce* tests panicked at sidecar-pre-check, publish job failed (no artifact made it to crates.io). Tag \`v1.3.0\` was then **deleted from origin** (no consumer impact since publish never succeeded). After this PR merges, v1.3.0 will be re-tagged on develop and publish will run again with the fix.

## Test plan

- [x] Mirrors test.yml's existing \`Fetch expected JSON\` step
- [x] `make testdata` target is well-tested (used on every CI run for PRs)
- [x] Will be validated end-to-end when v1.3.0 is re-tagged after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)