### PR TITLE
feat(e11): include package(...) — per-parser registry (feature-gated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.0] - 2026-05-21
+### Added
 
-v1.3 is a spec-compliance bugfix release. The implementation has been corrected to match the HOCON spec and Lightbend typesafe-config reference behavior across several previously-divergent areas (E8 value-position lexing + leading-zero canonicalization, single-letter byte units, `include` key reservation, concat type-checking, empty-file rejection, `.properties` object-wins, duration/bytes default unit, S13c env-var list). The spec did not change; the parser was simply wrong in places.
+- **E11 — `include package("id", "file")` qualifier** (feature-gated, default off):
+  New optional Cargo feature `include-package` (no new dependencies — uses `std` only)
+  enables the `include package(...)` syntax per xx.hocon cross-impl convention E11.
+  Spaced form `include package ("id", "file")` is also supported for consistency with
+  the existing `file(...)` qualifier.
 
-A subset of these fixes change observable runtime behavior. The most likely user-visible change is **S21.4** — single-letter byte units (`K`/`M`/`G`/`T`/`P`/`E`) now map to powers of two instead of SI decimal (`1K` was 1,000; now 1,024 — per HOCON.md L1385 java `-Xmx` convention, confirmed against Lightbend 1.4.3). If your `.conf` files use single-letter units and you rely on the numeric result, audit `get_bytes` call sites. Multi-letter forms (`KB`/`MB`/`GB`/`TB`) remain SI decimal and are unchanged. Other fixes have narrow practical impact — read `### Changed` / `### Fixed` below if your CI fails to upgrade cleanly. We elected MINOR (not MAJOR) because no API or architectural changes occurred; v2.0 is reserved for parser/lexer rewrites or similar structural shifts.
+  Public API additions (only compiled when `features = ["include-package"]`):
+  - **`hocon::Parser`** — new public struct with consuming builder API:
+    - `Parser::new() -> Self`
+    - `Parser::register_package(self, identifier, file, content) -> Self`
+    - `Parser::parse(self, input: &str) -> Result<Config, HoconError>`
+    - `Parser::parse_file(self, path: impl AsRef<Path>) -> Result<Config, HoconError>`
+  - **Cascade convention**: downstream packages expose `pub fn register(parser: Parser) -> Parser`
+    so callers can chain registrations: `pkg_b::register(pkg_a::register(Parser::new())).parse(…)`.
+  - **`AstNode::PackageInclude`** (internal `pub(crate)` variant) — not public API.
+  - **`IncludeKey::Package`** variant on the resolver's internal cycle-detection enum.
+
+  Behaviour:
+  - Registry miss is always a `HoconError` (required semantics apply unconditionally per E11 decision 7).
+  - Empty registered content returns an empty merge object (not a parse error — E11 carve-out).
+  - Circular package includes are detected and rejected (`ResolveError`).
+  - File argument is validated post-unescaping: non-empty, forward-slash separators, no absolute path.
+  - Identifier and file lookups are case-sensitive (E11 decision 5).
+  - Panic on duplicate `(identifier, file)` registration with different content; idempotent re-registration of byte-identical content is allowed.
 
 ## [1.3.0] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-05-21
+
+v1.3 is a spec-compliance bugfix release. The implementation has been corrected to match the HOCON spec and Lightbend typesafe-config reference behavior across several previously-divergent areas (E8 value-position lexing + leading-zero canonicalization, single-letter byte units, `include` key reservation, concat type-checking, empty-file rejection, `.properties` object-wins, duration/bytes default unit, S13c env-var list). The spec did not change; the parser was simply wrong in places.
+
+A subset of these fixes change observable runtime behavior. The most likely user-visible change is **S21.4** — single-letter byte units (`K`/`M`/`G`/`T`/`P`/`E`) now map to powers of two instead of SI decimal (`1K` was 1,000; now 1,024 — per HOCON.md L1385 java `-Xmx` convention, confirmed against Lightbend 1.4.3). If your `.conf` files use single-letter units and you rely on the numeric result, audit `get_bytes` call sites. Multi-letter forms (`KB`/`MB`/`GB`/`TB`) remain SI decimal and are unchanged. Other fixes have narrow practical impact — read `### Changed` / `### Fixed` below if your CI fails to upgrade cleanly. We elected MINOR (not MAJOR) because no API or architectural changes occurred; v2.0 is reserved for parser/lexer rewrites or similar structural shifts.
 
 ## [1.3.0] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.3.0] - 2026-05-21
 
 v1.3 is a spec-compliance bugfix release. The implementation has been corrected to match the HOCON spec and Lightbend typesafe-config reference behavior across several previously-divergent areas (E8 value-position lexing + leading-zero canonicalization, single-letter byte units, `include` key reservation, concat type-checking, empty-file rejection, `.properties` object-wins, duration/bytes default unit, S13c env-var list). The spec did not change; the parser was simply wrong in places.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ name = "hocon"
 [features]
 default = []
 serde = ["dep:serde", "dep:serde_json"]
+include-package = []
 
 [dependencies]
 indexmap = "2"

--- a/docs/proposals/E11-include-package-design.md
+++ b/docs/proposals/E11-include-package-design.md
@@ -1,0 +1,429 @@
+# E11 `include package(...)` — rs.hocon Design Notes
+
+**Status**: Design / pre-implementation (★1 user review pending)
+**Branch**: `feat/include-package-design`
+**Spec ref**: `xx.hocon/docs/extra-spec-conventions.md` §E11
+
+---
+
+## 1. Crate survey summary
+
+| Aspect | Current state |
+|---|---|
+| Crate name | `hocon-parser`, lib name `hocon` |
+| MSRV | 1.82 |
+| Features | `default = []`, `serde = [dep:serde, dep:serde_json]` — one optional feature today |
+| `no_std` | **No.** `std` is used throughout (`std::fs`, `std::path::PathBuf`, `std::collections::HashMap`, `std::io`). No `#![no_std]` attribute anywhere. |
+| Async | **No.** No tokio/futures dep, no async fn anywhere. |
+| Builder pattern | None currently. The public API is free functions: `parse`, `parse_file`, `parse_with_env`, `parse_file_with_env`. `ResolveOptions` uses a consuming builder (`pub fn with_base_dir(mut self, …) -> Self`). |
+| Error types | `ParseError`, `ResolveError`, `ConfigError`, `HoconError` (enum wrapping the three). All use `#[non_exhaustive]`. |
+| Include handling | `AstNode::Include { path, required, is_file, pos }` — all include kinds fold into this one variant. Include loading is in `src/resolver/include_loader.rs`. Cycle detection uses `opts.include_stack: Vec<PathBuf>` carried through `ResolveOptions`. |
+| Module structure | `src/lib.rs` re-exports public surface. Internal: `lexer`, `parser`, `resolver/{mod, include_loader, structure_builder, substitution_resolver, types, utils}`. `pub mod config`, `pub mod error`, `pub mod value`, optionally `pub mod serde`. |
+
+---
+
+## 2. Design decisions
+
+### 2.1 Builder method signature for `register_package`
+
+**Decision**: consuming builder, returns `Self`.
+
+```rust
+pub fn Parser(/* private fields */) { ... }
+
+impl Parser {
+    pub fn new() -> Self { ... }
+
+    pub fn register_package(
+        mut self,
+        identifier: impl Into<String>,
+        file: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
+        // insert into registry, return self
+        self
+    }
+
+    pub fn parse(self, input: &str) -> Result<Config, HoconError> { ... }
+    pub fn parse_file(self, path: impl AsRef<Path>) -> Result<Config, HoconError> { ... }
+}
+```
+
+**Justification**: `ResolveOptions` already uses the consuming-builder style (`with_base_dir(mut self) -> Self`). Consistent. `&mut self -> &mut Self` (mutable-ref builder) is usable but is the secondary convention in the Rust ecosystem for types that don't need to be stored in a variable mid-construction. `impl Into<String>` for all three args (see §2.2 for content lifetime rationale) keeps the site ergonomic: `include_str!` gives `&'static str` which coerces to `String` via `Into`; runtime-loaded `String` passes through unchanged.
+
+**On `Cow`**: `Cow<'static, str>` is the most flexible, but adds cognitive overhead at the call site and requires callers to import `std::borrow::Cow`. Since the crate is fully `std`-dependent already and the primary use case is `include_str!` (which allocates once at registration time via `String::from(&str)`), `String` is the right choice — it unifies both cases without a new type at the surface.
+
+---
+
+### 2.2 Content lifetime
+
+**Decision**: `impl Into<String>` — stored as owned `String`.
+
+**Rationale**:
+- `include_str!` produces `&'static str`. `impl Into<String>` accepts this via `String: From<&str>` — it allocates and copies the bytes once at registration time (not per-parse). Cost is one startup allocation; negligible.
+- Owned `String` allows runtime-loaded content (file read, test fixtures). `&'static str` only would block testability without `leak` hacks.
+- `Cow<'static, str>` would avoid the allocation for `include_str!` callers, but the ergonomic benefit is small and the API surface cost is real (callers must manage `Cow` at the call site, or the impl must accept `impl Into<Cow<'static, str>>` which is not `impl Into<String>`-compatible).
+- **Consequence for `include_str!` callers**: `parser.register_package("id", "file", include_str!("foo.conf"))` — the `&'static str` converts to `String` via `Into`. No explicit cast needed. This is the primary use-case pattern.
+
+---
+
+### 2.3 Cascade convention design
+
+**Decision**: free function convention — no trait.
+
+**Recommended convention**:
+
+```rust
+// In pkg_a/src/hocon.rs (or lib.rs)
+pub fn register(parser: hocon::Parser) -> hocon::Parser {
+    // register pkg_a's own files
+    let parser = parser
+        .register_package("github.com/org/pkg_a", "reference.conf", include_str!("../conf/reference.conf"));
+    // cascade to deps
+    let parser = pkg_b::hocon::register(parser);
+    parser
+}
+```
+
+Caller side:
+```rust
+let config = pkg_a::hocon::register(hocon::Parser::new())
+    .parse_file("app.conf")?;
+```
+
+**Why free function, not trait**:
+
+The primary reason is ergonomics, not Rust coherence. A `pub trait HoconPackage { fn register(parser: Parser) -> Parser; }` defined in `hocon-parser` *can* be implemented by downstream crates without violating coherence rules (orphan rule applies to blanket impls over foreign types, not to concrete impls — downstream crates can implement upstream traits for their own types). However:
+
+- Dynamic dispatch on the trait is not useful here — callers name the packages explicitly at registration time, not via a vtable.
+- Callers still write `pkg_a::hocon::register(p)` either way — the trait adds no abstraction benefit at the call site.
+- Free functions compose naturally with the consuming-builder chain without requiring an `impl HoconPackage for SomeMarkerType` boilerplate in each package crate.
+- A macro (`register_hocon_package!(pkg_a, pkg_b)`) could auto-cascade but adds complexity with no benefit; free function calls are readable and greppable.
+- Free functions parallel the Go-style `init()` side-effect pattern without global state.
+
+**Convention location**: the `register` function should be in a dedicated module within the package crate (`pub mod hocon` or `pub mod config`), not in `lib.rs` root. This avoids polluting the package's top-level API with a HOCON-specific symbol that most users of that package may not need.
+
+---
+
+### 2.4 Error type
+
+**Decision**: no new exported error type. Existing types cover all E11 error paths.
+
+**Detailed error placement**:
+
+- **Resolve-time lookup miss** (E11 decision 4): fires inside `load_package_include` in `resolver/include_loader.rs` when the resolver encounters `AstNode::PackageInclude` and the registry does not contain the `(identifier, file)` pair. This is a `ResolveError` (not a `ParseError`) because the registry is threaded through `ResolveOptions`, which is only available at resolve-time — not at parse-time when the AST is being built. `ResolveError { message: format!("include package not found: ({:?}, {:?}) — was Parser::register_package called?", id, file), ... }`. No new error variant needed; the existing `ResolveError { message, path, line, col }` struct covers it.
+
+  *Note*: validation of argument shape (arity, non-string args, empty identifier, file constraints per E11 decision 6) fires at **parse-time** inside `parse_include` in `parser.rs` and produces `ParseError`. But registry lookup is **resolve-time** and produces `ResolveError`. These two error origins are different; do not conflate them.
+
+- **Registration-time collision** (E11 decision 3): fires inside `register_package()` on `Parser`. Options:
+  - **Option A**: `register_package` panics on collision. Simple; matches Rust convention for setup-time programming errors (e.g. `std::env::set_var` invariant failures, `HashMap`-backed registry patterns in `inventory`/Bevy). Idempotent re-registration of byte-equal content is allowed (no panic).
+  - **Option B**: `register_package` returns `Result<Self, HoconError>`. Call site becomes `let parser = parser.register_package(…)?;` — works in `fn main() -> Result<…>` but awkward in `lazy_static!` / `OnceLock` / test harness contexts.
+  - **Option C**: builder stores pending errors, surfaces on `.parse()`.
+
+  **Recommendation**: **Option A** (panic on collision). Collision is a programming error (two package crates registering the same `(id, file)` key with different content), not a recoverable runtime error. Panic is the Rust convention for "invariant violated during initialization." Document: "Panics if different content is registered for the same `(identifier, file)` pair. Re-registering byte-identical content is idempotent."
+
+**No new exported type for E11 errors** — the existing error surface (`ParseError` for syntax/arity errors, `ResolveError` for registry misses, panic for collision) is sufficient.
+
+---
+
+### 2.5 Feature flag
+
+**Decision**: `include-package` optional feature flag, default off.
+
+**Rationale**:
+- Current default features: none (empty `default = []`). The `serde` feature is the only optional feature today. This is deliberate: the crate stays lean by default.
+- `package(...)` support requires a `HashMap<(String, String), String>` registry on `Parser`. This adds ~48 bytes to `Parser` even when unused (the `HashMap` exists but is empty). With a feature flag, users who do not need `package(...)` pay zero cost.
+- A `Parser` struct with the registry field is only introduced under `include-package`. Without the feature, the current free-function API (`parse`, `parse_file`, etc.) remains the entire public surface.
+- **Trade-off against discoverability**: users who don't know about `package(...)` won't find `Parser::register_package` in docs unless they enable the feature. This is acceptable — `package(...)` is a cross-impl extension (E11), not a core HOCON feature. Users of cross-impl portable configs will know to opt in.
+- **Cargo feature unification hazard**: Cargo unifies features across the dependency graph — if *any* crate in the build graph depends on `hocon-parser` with `features = ["include-package"]`, all other dependees also build with that feature enabled. The "zero cost for users who don't need it" claim holds only when *no* transitive dependency enables the feature. This is the standard Cargo feature trade-off: feature flags add complexity at the ecosystem level even when individual users don't opt in. Document this in crate-level docs. Since `include-package` adds no new `[dependencies]` entries (only `std` types), the unification hazard is limited to code-size/API-surface rather than dependency graph pollution.
+- **Cargo.toml addition**: `include-package = []` (no new dep — `HashMap` is already in scope from `std`). No indirect dependency changes.
+
+---
+
+### 2.6 Module placement
+
+**Decision**: `pub mod registry` nested under a new `pub mod include` in lib root, behind the `include-package` feature flag.
+
+```
+src/
+  lib.rs
+  include/           ← new, feature-gated
+    mod.rs           ← pub use registry::PackageRegistry; re-exports
+    registry.rs      ← PackageRegistry struct + impl
+  parser.rs          ← existing; gains package(...) parse branch
+  resolver/
+    include_loader.rs ← gains load_package_include() fn
+    ...
+```
+
+**Why `pub mod include` not `pub mod registry` at root**:
+- `include` is the vocabulary the HOCON spec and the E11 spec use. Future `include`-related extensions (e.g., a custom include hook/callback) belong under this module.
+- `registry` nested under `include` matches the scope of responsibility: it is the include-system's registry, not a general registry.
+- However, the `PackageRegistry` type and `Parser` struct are re-exported from `hocon::` (lib root) so callers don't need to reach into `hocon::include::registry::`.
+
+**Naming note**: `Parser` struct is the new public type introduced by this feature. It wraps the current `ResolveOptions`-based pipeline. The name `Parser` is slightly overloaded (there's already an internal `parser::Parser` struct, which is `pub(crate)`), but the public `hocon::Parser` is unambiguous at the consumer level.
+
+---
+
+### 2.7 `no_std` and Wasm
+
+**Finding**: rs.hocon does **not** support `no_std`. The crate uses `std::fs`, `std::path`, `std::io`, `std::collections::HashMap` throughout. No `#![no_std]` and no `alloc` import.
+
+**Implication for E11**: the registry (`HashMap<(String, String), String>`) is entirely `std` — no special `no_std` path needed or possible. If a future `no_std` effort is undertaken, the registry would need to switch to `alloc::collections::BTreeMap` and the `include_str!`-loaded content would stay as `&'static str` rather than `String`. That is a future concern, not in scope for E11.
+
+**Wasm**: `wasm32-unknown-unknown` does not have a filesystem; `parse_file` already fails on Wasm. `package(...)` resolution via the in-parser registry (no `fs::read`) **does work on Wasm** — a key advantage over `include file(...)`. This should be documented as a use case: Wasm consumers can embed config via `include_str!` and `register_package`.
+
+---
+
+### 2.8 Async support
+
+**Finding**: no async API. All parse functions are synchronous. No tokio/futures in `Cargo.toml`.
+
+**Implication for E11**: `package(...)` resolution reads from an in-memory registry, not from disk or network. No async path is needed — registry lookup is a `HashMap::get` which is always synchronous and `O(1)`. Even if an async `parse_file` is added in the future, `package(...)` resolution stays sync (memory lookup inside the registry).
+
+---
+
+### 2.9 File argument validation (E11 decision 6)
+
+**Decision**: validate at the parser layer (`parse_include` in `parser.rs`), not in the include loader.
+
+**Validation shape** (illustrative, not implementation):
+
+```rust
+fn validate_package_file_arg(file: &str, line: usize, col: usize) -> Result<(), ParseError> {
+    if file.is_empty() {
+        return Err(ParseError { message: "package() file argument must be non-empty".into(), line, col });
+    }
+    if file.starts_with('/') {
+        return Err(ParseError { message: "package() file argument must not be an absolute path".into(), line, col });
+    }
+    if file.contains('\\') {
+        return Err(ParseError { message: "package() file argument must use forward-slash separators".into(), line, col });
+    }
+    for segment in file.split('/') {
+        if segment.is_empty() {
+            return Err(ParseError { message: "package() file argument must not contain consecutive slashes".into(), line, col });
+        }
+        if segment == "." || segment == ".." {
+            return Err(ParseError { message: "package() file argument must not contain '.' or '..' segments".into(), line, col });
+        }
+    }
+    Ok(())
+}
+```
+
+**Why parser layer**: validation is syntactic (shape of the string literal argument), not semantic (does the content exist). Errors here are parse errors. Placing it in the include loader would delay the error to resolve-time, which is late and confusing — the `file` argument is visible in source; the parser should reject it immediately.
+
+---
+
+### 2.10 Cycle detection (E11 decision 8)
+
+**Current mechanism**: `ResolveOptions::include_stack: Vec<PathBuf>`. Each include call checks whether the candidate `PathBuf` is already in the stack (`opts.include_stack.iter().any(|p| p.as_path() == candidate)`). The `PathBuf`-keyed stack does not accommodate `package(...)` includes (no filesystem path).
+
+**Decision**: introduce a parallel `package_include_stack: Vec<(String, String)>` field on `ResolveOptions` to hold `(identifier, file)` pairs already being processed. Alternatively, use a unified `IncludeKey` enum:
+
+```rust
+#[derive(PartialEq, Eq, Clone)]
+pub(crate) enum IncludeKey {
+    Path(PathBuf),
+    Package { identifier: String, file: String },
+}
+```
+
+and change `include_stack: Vec<PathBuf>` to `include_stack: Vec<IncludeKey>`. This is cleaner — one stack, one cycle check, no duplication.
+
+**Cycle check** in `load_package_include` (new function in `include_loader.rs`):
+
+```rust
+let key = IncludeKey::Package { identifier: identifier.to_string(), file: file.to_string() };
+if opts.include_stack.contains(&key) {
+    return Err(ResolveError {
+        message: format!("circular package include: ({:?}, {:?})", identifier, file),
+        ...
+    });
+}
+// clone opts, push key, recurse
+let mut child_opts = opts.clone_for_child();
+child_opts.include_stack.push(key);
+```
+
+**Where this lands**: `IncludeKey` is a `pub(crate)` type in `resolver/types.rs`. `ResolveOptions::include_stack` changes from `Vec<PathBuf>` to `Vec<IncludeKey>`. The existing file-include path wraps its `PathBuf` in `IncludeKey::Path`. This is a purely internal change.
+
+**Note on `ResolveOptions` field visibility**: `ResolveOptions` is defined as `pub struct` inside `pub(crate) mod resolver`. It is accessible within the crate via `pub use types::ResolveOptions` in `resolver/mod.rs`, and from `resolver::ResolveOptions` in `lib.rs`. It is **not** part of the external public API (the `pub use` at `lib.rs` level does not re-export it). Therefore `include_stack`'s type change from `Vec<PathBuf>` to `Vec<IncludeKey>` has zero external API impact.
+
+**Final decision**: unified `IncludeKey` (not dual stacks). Removing this from open questions — it is an internal-only refactor with no ambiguity for callers.
+
+---
+
+### 2.11 Grammar validation in `parse_include` (E11 decisions 1, 2, 6)
+
+The `parse_include` function in `parser.rs` must validate the `package(...)` qualifier fully at parse-time before producing an `AstNode::PackageInclude`. This covers argument shape — not registry lookup (which is resolve-time per §2.4).
+
+**Mandatory parse-time checks**:
+
+1. **Two-arg form** (E11 decision 2): after consuming `package(`, the parser must find exactly two `TokenKind::QuotedString` tokens separated by a comma. One-arg form (single string or path, no comma), zero-arg form, and three-or-more-arg form are all `ParseError`. Non-string args (unquoted tokens in the arg positions) are `ParseError`.
+
+2. **Non-empty identifier** (E11 decision 1): the first argument, after HOCON string unescaping, must be non-empty. An empty identifier `""` is a `ParseError`.
+
+3. **File argument constraints** (E11 decision 6): see §2.9 — validated by calling `validate_package_file_arg` on the second argument at parse-time.
+
+**Parse-time validation shape** (illustrative, extending `parse_include`):
+
+```rust
+// Inside parse_include, after detecting "package(" prefix:
+// Consume first quoted string (identifier)
+let identifier = expect_quoted_string(self)?;  // ParseError if non-QuotedString
+if identifier.is_empty() {
+    return Err(ParseError { message: "package() identifier must be non-empty".into(), line, col });
+}
+// Consume comma separator
+expect_comma(self)?;  // ParseError if absent
+// Consume second quoted string (file)
+let file_arg = expect_quoted_string(self)?;  // ParseError if non-QuotedString
+validate_package_file_arg(&file_arg, line, col)?;
+// Consume closing ")"
+expect_close_paren(self)?;
+```
+
+---
+
+## 3. `AstNode::Include` extension
+
+The current variant:
+```rust
+AstNode::Include {
+    path: String,
+    required: bool,
+    is_file: bool,
+    pos: Pos,
+}
+```
+
+For `package(...)`, we need to carry `identifier` and `file` separately. Two options:
+
+**Option A**: Add a `qualifier` field to the existing variant:
+```rust
+AstNode::Include {
+    qualifier: IncludeQualifier,  // enum: Bare, File, Url, Package { identifier, file }
+    path: String,                 // for Bare/File/Url; empty for Package
+    required: bool,
+    pos: Pos,
+}
+```
+
+**Option B**: Add a new variant `AstNode::PackageInclude { identifier, file, required, pos }`.
+
+**Decision**: **Option A** (extend with a `qualifier` enum). Rationale: all include forms share `required` and position. An enum qualifier follows the principle of "make the set of valid states representable" — the `path` field is only meaningful for non-Package qualifiers. However, the `path: String` field becomes meaningless for `Package` — this is the code smell. Therefore, **Option B** is actually cleaner: a dedicated variant with no `path` field.
+
+**Revised decision: Option B**. Add a dedicated variant:
+
+```rust
+AstNode::PackageInclude {
+    identifier: String,
+    file: String,
+    required: bool,
+    pos: Pos,
+}
+```
+
+**On `#[non_exhaustive]` for `PackageInclude`**: `AstNode` is defined in `pub(crate) mod parser` — it is not part of the external public API. Adding `#[non_exhaustive]` to the new variant (as was done for `AstNode::Substitution`) is optional here, since all match arms are internal. The `#[non_exhaustive]` on `Substitution` was added for forward-compatibility within the internal codebase (making it easier to add fields later without updating every internal match site). The same rationale applies to `PackageInclude` — applying `#[non_exhaustive]` is recommended for consistency with `Substitution`, but is not a safety requirement. Critically, `#[non_exhaustive]` on a *variant* does NOT protect against exhaustive matches on the *enum* — all internal `match ast { ... }` arms must be updated to handle `PackageInclude` regardless. There is no need to add `#[non_exhaustive]` to `AstNode` itself; it remains a plain enum (internal only).
+
+The `StructureBuilder::apply_field` match arm already handles `AstNode::Include` by calling `load_include`. A new arm handles `AstNode::PackageInclude` by calling `load_package_include`. Both arms are guarded by `field.key.is_empty()`.
+
+---
+
+## 4. `Parser` public type
+
+Since `package(...)` requires pre-registering content before parsing, the current free-function API must be extended or a new entry point introduced. The cleanest approach is a new `Parser` struct (builder-style) under the `include-package` feature:
+
+```rust
+#[cfg(feature = "include-package")]
+pub struct Parser {
+    registry: HashMap<(String, String), String>,
+}
+
+#[cfg(feature = "include-package")]
+impl Parser {
+    pub fn new() -> Self {
+        Parser { registry: HashMap::new() }
+    }
+
+    pub fn register_package(
+        mut self,
+        identifier: impl Into<String>,
+        file: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
+        let id = identifier.into();
+        let f = file.into();
+        let c = content.into();
+        if let Some(existing) = self.registry.get(&(id.clone(), f.clone())) {
+            if existing != &c {
+                panic!(
+                    "hocon: conflicting content registered for package ({:?}, {:?})",
+                    id, f
+                );
+            }
+            // byte-identical: idempotent, no-op
+        } else {
+            self.registry.insert((id, f), c);
+        }
+        self
+    }
+
+    pub fn parse(self, input: &str) -> Result<Config, HoconError> { ... }
+    pub fn parse_file(self, path: impl AsRef<Path>) -> Result<Config, HoconError> { ... }
+    pub fn parse_with_env(self, input: &str, env: &HashMap<String, String>) -> Result<Config, HoconError> { ... }
+    pub fn parse_file_with_env(self, path: impl AsRef<Path>, env: &HashMap<String, String>) -> Result<Config, HoconError> { ... }
+}
+```
+
+The `registry` is threaded into `ResolveOptions` (new optional field under the feature flag, `#[cfg(feature = "include-package")]`) so `load_package_include` can read it.
+
+**`Default` impl**: `impl Default for Parser` (delegates to `Parser::new()`) — conventional for builder types.
+
+**Empty content handling**: E11 decision 4 states that registered empty content (zero bytes, or content that parses to an empty document) is NOT a lookup failure — it succeeds and merges `{}`. However, the existing `assert_non_empty_document` guard in `parse_with_env` / `load_single_include` would reject an empty string. Therefore `load_package_include` must NOT call `assert_non_empty_document` on package-registered content. Instead it must handle the empty-token-stream case explicitly:
+
+```rust
+// In load_package_include:
+let tokens = crate::lexer::tokenize(content)?;
+// E11 decision 4: empty registered content => empty merge object, not an error
+let has_content = tokens.iter().any(|t| !matches!(t.kind, TokenKind::Newline | TokenKind::Eof));
+if !has_content {
+    return Ok(ResObj::new());  // empty doc => {} merge, not an error
+}
+// continue with normal parse + resolve pipeline
+```
+
+This is the only place where the empty-document rule is intentionally relaxed.
+
+---
+
+## 5. Open questions for ★1
+
+The following decisions are **not yet resolved** and require Yoshi's call before implementation can begin.
+
+1. **`Parser` struct name**: the internal `parser::Parser` is `pub(crate)`. The public `hocon::Parser` does not collide at the public API level, but may be confusing to contributors reading source alongside the internal `parser::Parser`. Alternatives: `hocon::ParserBuilder` or `hocon::HoconParser`. Which does Yoshi prefer?
+
+2. **Panic vs `Result` for registration collision**: the design recommends panic (§2.4 Option A). If `register_package` should return `Result<Self, HoconError>` instead (Option B), the cascade convention changes to `fn register(parser: Parser) -> Result<Parser, HoconError>`. Trade-off: call-site ergonomics vs explicit error propagation. Which policy?
+
+3. **Feature flag default**: the design proposes `include-package` is not in `default`. If this feature is considered core to the non-JVM HOCON story, it could join `default`. Consequences: all users build with the `Parser` struct and registry even if they don't use `package(...)` syntax. Confirm `default = []` stays (recommended) or `include-package` joins it.
+
+4. **`AstNode::PackageInclude` match arm update scope**: adding the variant requires updating all internal `match ast_node { ... }` exhaustive match arms in `structure_builder.rs` and anywhere else `AstNode` is matched. Is this acceptable scope for the E11 impl PR, or should a prep commit add `#[non_exhaustive]` to `AstNode` first to make the existing matches forward-compatible? (Note: `#[non_exhaustive]` on an internal `pub(crate)` type has limited benefit — it only silences `non_exhaustive_omitted_patterns` warnings, not compiler errors. The choice is a code-hygiene call, not a correctness one.)
+
+**Resolved by design (not open questions)**:
+- `IncludeKey` unification: decided in §2.10 — unified `IncludeKey` enum, not dual stacks. `ResolveOptions` is internal only (not externally public), so no API-impact concern.
+- Lookup miss fires at **resolve-time** (in `load_package_include`), not parse-time — §2.4 clarified.
+- Empty registered content handled in `load_package_include` without `assert_non_empty_document` — §4 specified.
+- Grammar/arity validation fires at **parse-time** in `parse_include` — §2.11 specified.
+
+---
+
+## 6. Non-goals (per E11 spec)
+
+Not designed for and must not be inferred:
+- Auto-discovery, auto-`reference.conf` merge, transitive auto-resolution.
+- Wildcard/glob lookups.
+- Identifier shape validation at parse time.
+- `url(...)` or `classpath(...)` qualifiers.
+- Any async parse path.

--- a/docs/proposals/E11-include-package-design.md
+++ b/docs/proposals/E11-include-package-design.md
@@ -1,23 +1,28 @@
 # E11 `include package(...)` — rs.hocon Design Notes
 
-**Status**: Design / pre-implementation (★1 user review pending)
+**Status**: Implemented — `feat/include-package-design` (PR #103, pending merge)
 **Branch**: `feat/include-package-design`
 **Spec ref**: `xx.hocon/docs/extra-spec-conventions.md` §E11
 
+> **Historical note**: The table below reflects the crate state *before* this PR landed.
+> Post-implementation state: `include-package` feature added; `hocon::Parser` builder
+> (`new`, `register_package`, `parse`, `parse_file`) added behind the feature flag;
+> `IncludeKey` unified enum for cycle detection; `AstNode::PackageInclude` variant (internal).
+
 ---
 
-## 1. Crate survey summary
+## 1. Crate survey summary (pre-implementation snapshot)
 
-| Aspect | Current state |
+| Aspect | State before this PR |
 |---|---|
 | Crate name | `hocon-parser`, lib name `hocon` |
 | MSRV | 1.82 |
 | Features | `default = []`, `serde = [dep:serde, dep:serde_json]` — one optional feature today |
 | `no_std` | **No.** `std` is used throughout (`std::fs`, `std::path::PathBuf`, `std::collections::HashMap`, `std::io`). No `#![no_std]` attribute anywhere. |
 | Async | **No.** No tokio/futures dep, no async fn anywhere. |
-| Builder pattern | None currently. The public API is free functions: `parse`, `parse_file`, `parse_with_env`, `parse_file_with_env`. `ResolveOptions` uses a consuming builder (`pub fn with_base_dir(mut self, …) -> Self`). |
+| Builder pattern | None (pre-E11). This PR adds `hocon::Parser` with consuming builder behind `include-package` feature. |
 | Error types | `ParseError`, `ResolveError`, `ConfigError`, `HoconError` (enum wrapping the three). All use `#[non_exhaustive]`. |
-| Include handling | `AstNode::Include { path, required, is_file, pos }` — all include kinds fold into this one variant. Include loading is in `src/resolver/include_loader.rs`. Cycle detection uses `opts.include_stack: Vec<PathBuf>` carried through `ResolveOptions`. |
+| Include handling | `AstNode::Include { path, required, is_file, pos }` — all include kinds fold into this one variant. Include loading is in `src/resolver/include_loader.rs`. Cycle detection uses `opts.include_stack: Vec<PathBuf>` carried through `ResolveOptions`. (Post-E11: `IncludeKey` enum replaces `Vec<PathBuf>`; `PackageInclude` variant added.) |
 | Module structure | `src/lib.rs` re-exports public surface. Internal: `lexer`, `parser`, `resolver/{mod, include_loader, structure_builder, substitution_resolver, types, utils}`. `pub mod config`, `pub mod error`, `pub mod value`, optionally `pub mod serde`. |
 
 ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,200 @@ pub use serde::DeserializeError;
 use std::collections::HashMap;
 use std::path::Path;
 
+// ── include-package feature: public Parser builder ───────────────────────────
+
+/// Builder-style parser with a per-instance package registry for
+/// `include package(...)` support (E11).
+///
+/// # Feature flag
+///
+/// This type is only available when the `include-package` Cargo feature is
+/// enabled:
+///
+/// ```toml
+/// [dependencies]
+/// hocon-parser = { version = "...", features = ["include-package"] }
+/// ```
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// # #[cfg(feature = "include-package")]
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let config = hocon::Parser::new()
+///     .register_package("github.com/org/pkg", "reference.conf", include_str!("conf/reference.conf"))
+///     .parse_file("app.conf")?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Cascade convention
+///
+/// For packages that depend on other HOCON-config-providing packages, follow
+/// this convention to cascade registrations:
+///
+/// ```rust,ignore
+/// // In your package (e.g., pkg_a/src/hocon.rs):
+/// pub fn register(parser: hocon::Parser) -> hocon::Parser {
+///     let parser = parser
+///         .register_package("github.com/org/pkg_a", "reference.conf", include_str!("../conf/reference.conf"));
+///     // Cascade to dependencies:
+///     // let parser = pkg_b::hocon::register(parser);
+///     parser
+/// }
+/// ```
+///
+/// Callers:
+/// ```rust,ignore
+/// let config = pkg_a::hocon::register(hocon::Parser::new())
+///     .parse_file("app.conf")?;
+/// ```
+///
+/// # Collision policy
+///
+/// Registering two **different** content strings for the same `(identifier, file)`
+/// key **panics** — this is a programming error (setup-time invariant). Re-registering
+/// **byte-identical** content is idempotent (no panic).
+#[cfg(feature = "include-package")]
+pub struct Parser {
+    registry: HashMap<(String, String), String>,
+}
+
+#[cfg(feature = "include-package")]
+impl Default for Parser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "include-package")]
+impl Parser {
+    /// Create a new `Parser` with an empty package registry.
+    pub fn new() -> Self {
+        Parser {
+            registry: HashMap::new(),
+        }
+    }
+
+    /// Register HOCON content for an `include package("identifier", "file")`
+    /// include statement.
+    ///
+    /// # Arguments
+    ///
+    /// * `identifier` — the package identifier (e.g., `"github.com/org/pkg"`).
+    ///   Should follow Go-module-path style for cross-impl portability (E11 decision 1),
+    ///   but any non-empty string is accepted by the parser.
+    /// * `file` — the file path within the package (e.g., `"reference.conf"`).
+    ///   Must satisfy E11 decision 6 constraints.
+    /// * `content` — the HOCON source text. Typically loaded via `include_str!`.
+    ///   Empty content is valid and contributes `{}` to the merge.
+    ///
+    /// # Panics
+    ///
+    /// Panics if different content is registered for the same `(identifier, file)` pair.
+    /// Re-registering byte-identical content is idempotent (no panic).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let parser = hocon::Parser::new()
+    ///     .register_package("github.com/org/pkg", "reference.conf", include_str!("conf/reference.conf"))
+    ///     .register_package("github.com/org/pkg", "overrides.conf", include_str!("conf/overrides.conf"));
+    /// ```
+    pub fn register_package(
+        mut self,
+        identifier: impl Into<String>,
+        file: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
+        let id = identifier.into();
+        let f = file.into();
+        let c = content.into();
+        if let Some(existing) = self.registry.get(&(id.clone(), f.clone())) {
+            if existing != &c {
+                panic!(
+                    "hocon: conflicting content registered for package ({:?}, {:?}): \
+                     different content already registered for this (identifier, file) pair",
+                    id, f
+                );
+            }
+            // byte-identical: idempotent, no-op
+        } else {
+            self.registry.insert((id, f), c);
+        }
+        self
+    }
+
+    /// Parse a HOCON string using the registered package registry.
+    pub fn parse(self, input: &str) -> Result<Config, HoconError> {
+        self.parse_with_env(input, &std::env::vars().collect())
+    }
+
+    /// Parse a HOCON file using the registered package registry.
+    pub fn parse_file(self, path: impl AsRef<Path>) -> Result<Config, HoconError> {
+        self.parse_file_with_env(path, &std::env::vars().collect())
+    }
+
+    /// Parse a HOCON string with a custom environment map and the registered registry.
+    pub fn parse_with_env(
+        self,
+        input: &str,
+        env: &HashMap<String, String>,
+    ) -> Result<Config, HoconError> {
+        let tokens = lexer::tokenize(input)?;
+        assert_non_empty_document(&tokens)?;
+        let ast = parser::parse_tokens(&tokens)?;
+        let opts = self.into_resolve_opts(env.clone(), None);
+        let value = resolver::resolve(ast, &opts)?;
+        match value {
+            HoconValue::Object(fields) => Ok(Config::new(fields)),
+            _ => Err(HoconError::Parse(ParseError {
+                message: "root must be an object".into(),
+                line: 1,
+                col: 1,
+            })),
+        }
+    }
+
+    /// Parse a HOCON file with a custom environment map and the registered registry.
+    pub fn parse_file_with_env(
+        self,
+        path: impl AsRef<Path>,
+        env: &HashMap<String, String>,
+    ) -> Result<Config, HoconError> {
+        let path = path.as_ref();
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {}", path.display(), e)))?;
+        let tokens = lexer::tokenize(&content)?;
+        assert_non_empty_document(&tokens)?;
+        let ast = parser::parse_tokens(&tokens)?;
+        let opts = self.into_resolve_opts(env.clone(), path.parent().map(|p| p.to_path_buf()));
+        let value = resolver::resolve(ast, &opts)?;
+        match value {
+            HoconValue::Object(fields) => Ok(Config::new(fields)),
+            _ => Err(HoconError::Parse(ParseError {
+                message: "root must be an object".into(),
+                line: 1,
+                col: 1,
+            })),
+        }
+    }
+
+    /// Convert this `Parser` into `ResolveOptions`, threading the registry in.
+    fn into_resolve_opts(
+        self,
+        env: HashMap<String, String>,
+        base_dir: Option<std::path::PathBuf>,
+    ) -> resolver::ResolveOptions {
+        let mut opts = resolver::ResolveOptions::new(env);
+        if let Some(dir) = base_dir {
+            opts = opts.with_base_dir(dir);
+        }
+        opts.package_registry = std::sync::Arc::new(self.registry);
+        opts
+    }
+}
+
 /// Parse a HOCON string into a Config.
 pub fn parse(input: &str) -> Result<Config, HoconError> {
     parse_with_env(input, &std::env::vars().collect())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -51,6 +51,19 @@ pub enum AstNode {
         is_file: bool,
         pos: Pos,
     },
+    /// `include package("identifier", "file")` — E11 package-include qualifier.
+    ///
+    /// Only produced when the `include-package` feature is enabled; the variant
+    /// exists behind `#[cfg(feature = "include-package")]` so downstream
+    /// exhaustive matches are unaffected on the default feature set.
+    #[cfg(feature = "include-package")]
+    #[non_exhaustive]
+    PackageInclude {
+        identifier: String,
+        file: String,
+        required: bool,
+        pos: Pos,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -402,6 +415,7 @@ impl<'a> Parser<'a> {
         //   "required("          — from `required(`
         //   "required(file("     — from `required(file(`
         //   "required"           — from `required` (space before `(`)
+        //   "required(package("  — from `required(package(`  [E11]
         //
         // We normalise all of these into: required=true, cursor pointing at the
         // inner content after the `(` of `required(`.
@@ -417,19 +431,19 @@ impl<'a> Parser<'a> {
         // Tracks whether `file(` has already been consumed as part of the
         // `required(file(` mega-token.
         let mut file_prefix_consumed = false;
+        // Tracks whether `package(` has already been consumed (E11).
+        let mut package_prefix_consumed = false;
 
         if required {
             if raw == "required" {
-                // Separate tokens: consume "required", then expect "(" (possibly fused with "file(")
+                // Separate tokens: consume "required", then expect "(" (possibly fused with "file(" or "package(")
                 self.advance();
                 if self.peek_kind() == TokenKind::Unquoted && self.peek_value().starts_with('(') {
                     let val = self.peek_value().to_string();
                     if val == "(" {
                         self.advance(); // standalone "(" — inner content is next token
                     } else {
-                        // Token is "(file(...)" or similar — strip leading "(" and treat
-                        // the remainder as if it were emitted without "required(".
-                        // We do this by rewriting the token in place via file_prefix_consumed.
+                        // Token is "(file(...)" or "(package(..." or similar — strip leading "("
                         let after_paren = &val[1..]; // strip leading "("
                         if after_paren == "file("
                             || after_paren.starts_with("file(")
@@ -437,13 +451,18 @@ impl<'a> Parser<'a> {
                         {
                             file_prefix_consumed = true;
                             self.advance(); // consume "(file(..." token; path follows
+                        } else if after_paren == "package("
+                            || after_paren.starts_with("package(")
+                        {
+                            package_prefix_consumed = true;
+                            self.advance();
                         }
                         // else: bare "(content" — inner content; fall through to path reading below
                     }
                 }
             } else {
                 // raw starts with "required(" — consume this token.
-                // Check if `file(` is also embedded (e.g. "required(file(").
+                // Check if `file(` or `package(` is also embedded.
                 let after_req = &raw["required(".len()..];
                 if after_req == "file(" || after_req.starts_with("file(") {
                     file_prefix_consumed = true;
@@ -452,9 +471,130 @@ impl<'a> Parser<'a> {
                 if after_req == "file" {
                     file_prefix_consumed = true; // next token will be "("
                 }
+                // E11: "required(package(" fused token
+                if after_req == "package(" || after_req.starts_with("package(") {
+                    package_prefix_consumed = true;
+                }
                 self.advance(); // consume "required(..." token
             }
         }
+
+        // ── E11: package("identifier", "file") qualifier ─────────────────────
+        #[cfg(feature = "include-package")]
+        {
+            // Detect "package(" in current token (without required) OR already consumed
+            let is_package = package_prefix_consumed
+                || (self.peek_kind() == TokenKind::Unquoted
+                    && (self.peek_value() == "package("
+                        || self.peek_value().starts_with("package(")));
+
+            if is_package {
+                let err_line = self.peek_line();
+                let err_col = self.peek_col();
+
+                if !package_prefix_consumed {
+                    // Consume "package(" token
+                    self.advance();
+                }
+
+                // Expect first quoted string: identifier
+                if self.peek_kind() != TokenKind::QuotedString {
+                    return Err(ParseError {
+                        message: format!(
+                            "include package(): expected quoted identifier as first argument, got {:?}",
+                            self.peek_kind()
+                        ),
+                        line: err_line,
+                        col: err_col,
+                    });
+                }
+                let identifier = self.peek_value().to_string();
+                self.advance();
+
+                // E11 decision 1: identifier must be non-empty
+                if identifier.is_empty() {
+                    return Err(ParseError {
+                        message: "include package(): identifier must be non-empty".into(),
+                        line: err_line,
+                        col: err_col,
+                    });
+                }
+
+                // Expect comma separator
+                if self.peek_kind() != TokenKind::Comma {
+                    // One-arg form — reject per E11 decision 2
+                    return Err(ParseError {
+                        message: "include package() requires two arguments (identifier, file); \
+                                  one-arg form is not supported (E11 decision 2)"
+                            .into(),
+                        line: err_line,
+                        col: err_col,
+                    });
+                }
+                self.advance(); // consume comma
+
+                // Expect second quoted string: file
+                if self.peek_kind() != TokenKind::QuotedString {
+                    return Err(ParseError {
+                        message: format!(
+                            "include package(): expected quoted file as second argument, got {:?}",
+                            self.peek_kind()
+                        ),
+                        line: err_line,
+                        col: err_col,
+                    });
+                }
+                let file_arg = self.peek_value().to_string();
+                self.advance();
+
+                // E11 decision 6: validate file argument (on the unescaped string value
+                // already produced by the lexer — lexer unescapes quoted strings).
+                validate_package_file_arg(&file_arg, err_line, err_col)?;
+
+                // Consume closing ")" — will be part of the next Unquoted token
+                // (e.g. ")" or "))" for required form)
+                if self.peek_kind() == TokenKind::Unquoted
+                    && self.peek_value().starts_with(')')
+                {
+                    self.advance();
+                }
+
+                return Ok(AstField {
+                    key: vec![],
+                    value: AstNode::PackageInclude {
+                        identifier,
+                        file: file_arg,
+                        required,
+                        pos: p.clone(),
+                    },
+                    append: false,
+                    pos: p,
+                });
+            }
+        }
+
+        // ── Non-E11: detect one-arg package() form and reject it even without feature ──
+        // When include-package feature is OFF, package(...)  must still parse cleanly
+        // and not crash. We check for "package(" and emit a parse error.
+        #[cfg(not(feature = "include-package"))]
+        {
+            let is_package = self.peek_kind() == TokenKind::Unquoted
+                && (self.peek_value() == "package("
+                    || self.peek_value().starts_with("package("));
+            if is_package || (required && {
+                // Check if already consumed "required(package("
+                let _ = package_prefix_consumed;
+                false // can't be true without the feature flag
+            }) {
+                return Err(ParseError {
+                    message: "include package(...) requires the 'include-package' feature".into(),
+                    line: self.peek_line(),
+                    col: self.peek_col(),
+                });
+            }
+        }
+
+        // ── Standard include forms: bare / file() ────────────────────────────
 
         let path;
         let mut is_file = false;
@@ -525,6 +665,8 @@ impl<'a> Parser<'a> {
             pos: p,
         })
     }
+
+    // No helper methods for package validation in parser — it's a module-level fn.
 
     fn parse_value(&mut self) -> Result<AstNode, ParseError> {
         let p = self.current_pos();
@@ -659,6 +801,69 @@ impl<'a> Parser<'a> {
 
         Ok(AstNode::Array { items, pos: p })
     }
+}
+
+/// Validate the `file` argument of `include package("id", "file")` per E11 decision 6.
+///
+/// Validation runs on the HOCON-unescaped string (the value the lexer returns for
+/// `TokenKind::QuotedString`, which is already unescaped). This means `"x\\y.conf"`
+/// in source becomes `x\y.conf` (one backslash) at the parser level — and that
+/// single backslash is what the validator checks.
+///
+/// Rules (E11 decision 6):
+/// - non-empty string
+/// - forward-slash separators only (backslash `\` rejected)
+/// - no leading `/` (absolute paths rejected)
+/// - no `.` or `..` segments (path traversal rejected)
+/// - no consecutive `/` (e.g., `a//b.conf` rejected)
+#[cfg(feature = "include-package")]
+fn validate_package_file_arg(file: &str, line: usize, col: usize) -> Result<(), ParseError> {
+    if file.is_empty() {
+        return Err(ParseError {
+            message: "include package(): file argument must be non-empty (E11 decision 6)".into(),
+            line,
+            col,
+        });
+    }
+    if file.contains('\\') {
+        return Err(ParseError {
+            message: "include package(): file argument must use forward-slash separators only; \
+                      backslash is not allowed (E11 decision 6)"
+                .into(),
+            line,
+            col,
+        });
+    }
+    if file.starts_with('/') {
+        return Err(ParseError {
+            message: "include package(): file argument must not be an absolute path (E11 decision 6)".into(),
+            line,
+            col,
+        });
+    }
+    for segment in file.split('/') {
+        if segment.is_empty() {
+            return Err(ParseError {
+                message: "include package(): file argument must not contain consecutive slashes \
+                          (E11 decision 6)"
+                    .into(),
+                line,
+                col,
+            });
+        }
+        if segment == "." || segment == ".." {
+            return Err(ParseError {
+                message: format!(
+                    "include package(): file argument must not contain '.' or '..' segments; \
+                     got {:?} (E11 decision 6)",
+                    segment
+                ),
+                line,
+                col,
+            });
+        }
+    }
+    Ok(())
 }
 
 fn parse_scalar_value(raw: &str) -> ScalarValue {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -551,12 +551,20 @@ impl<'a> Parser<'a> {
                 // already produced by the lexer — lexer unescapes quoted strings).
                 validate_package_file_arg(&file_arg, err_line, err_col)?;
 
-                // Consume closing ")" — will be part of the next Unquoted token
-                // (e.g. ")" or "))" for required form)
+                // Consume closing ")" — required; must be the next Unquoted token.
+                // (e.g. ")" for bare form or "))" for required(package(...)) form)
                 if self.peek_kind() == TokenKind::Unquoted
                     && self.peek_value().starts_with(')')
                 {
                     self.advance();
+                } else {
+                    return Err(ParseError {
+                        message: "include package(): expected closing ')' after file argument \
+                                  (E11 syntax)"
+                            .into(),
+                        line: err_line,
+                        col: err_col,
+                    });
                 }
 
                 return Ok(AstField {
@@ -573,19 +581,18 @@ impl<'a> Parser<'a> {
             }
         }
 
-        // ── Non-E11: detect one-arg package() form and reject it even without feature ──
-        // When include-package feature is OFF, package(...)  must still parse cleanly
-        // and not crash. We check for "package(" and emit a parse error.
+        // ── Non-E11: detect package() form and reject it when feature is disabled ──
+        // When include-package feature is OFF, `include package(...)` and
+        // `include required(package(...))` must error with a clear message rather than
+        // silently falling through to standard include parsing.
         #[cfg(not(feature = "include-package"))]
         {
-            let is_package = self.peek_kind() == TokenKind::Unquoted
+            let is_package_token = self.peek_kind() == TokenKind::Unquoted
                 && (self.peek_value() == "package("
                     || self.peek_value().starts_with("package("));
-            if is_package || (required && {
-                // Check if already consumed "required(package("
-                let _ = package_prefix_consumed;
-                false // can't be true without the feature flag
-            }) {
+            // package_prefix_consumed can be true when required(package(... was tokenized
+            // as a fused token; the normalization above sets it regardless of feature flag.
+            if is_package_token || package_prefix_consumed {
                 return Err(ParseError {
                     message: "include package(...) requires the 'include-package' feature".into(),
                     line: self.peek_line(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -482,19 +482,43 @@ impl<'a> Parser<'a> {
         // ── E11: package("identifier", "file") qualifier ─────────────────────
         #[cfg(feature = "include-package")]
         {
-            // Detect "package(" in current token (without required) OR already consumed
-            let is_package = package_prefix_consumed
-                || (self.peek_kind() == TokenKind::Unquoted
-                    && (self.peek_value() == "package("
-                        || self.peek_value().starts_with("package(")));
+            // Detect "package(" in current token (without required) OR already consumed.
+            //
+            // The lexer fuses `package(` into one Unquoted token when there is no space.
+            // When the user writes `include package ("id", "file")` (space before `(`),
+            // the lexer emits `package` as a standalone Unquoted token — handle that form
+            // for consistency with how `file(...)` accepts the spaced `file (...)` form.
+            let is_package_fused = self.peek_kind() == TokenKind::Unquoted
+                && (self.peek_value() == "package("
+                    || self.peek_value().starts_with("package("));
+            let is_package_spaced = !package_prefix_consumed
+                && self.peek_kind() == TokenKind::Unquoted
+                && self.peek_value() == "package";
+            let is_package = package_prefix_consumed || is_package_fused || is_package_spaced;
 
             if is_package {
                 let err_line = self.peek_line();
                 let err_col = self.peek_col();
 
                 if !package_prefix_consumed {
-                    // Consume "package(" token
+                    // Consume "package" or "package(" token
                     self.advance();
+                    // Spaced form: "package" was consumed as a standalone token.
+                    // The next token must be "(" (possibly fused with other chars, but
+                    // for the spaced case the lexer emits a bare "(" Unquoted token).
+                    if is_package_spaced {
+                        if self.peek_kind() == TokenKind::Unquoted
+                            && self.peek_value().starts_with('(')
+                        {
+                            self.advance(); // consume the "(" token
+                        } else {
+                            return Err(ParseError {
+                                message: "include package: expected '(' after 'package'".into(),
+                                line: err_line,
+                                col: err_col,
+                            });
+                        }
+                    }
                 }
 
                 // Expect first quoted string: identifier
@@ -589,7 +613,8 @@ impl<'a> Parser<'a> {
         {
             let is_package_token = self.peek_kind() == TokenKind::Unquoted
                 && (self.peek_value() == "package("
-                    || self.peek_value().starts_with("package("));
+                    || self.peek_value().starts_with("package(")
+                    || self.peek_value() == "package"); // spaced form: `include package (...)`
             // package_prefix_consumed can be true when required(package(... was tokenized
             // as a fused token; the normalization above sets it regardless of feature flag.
             if is_package_token || package_prefix_consumed {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -451,9 +451,7 @@ impl<'a> Parser<'a> {
                         {
                             file_prefix_consumed = true;
                             self.advance(); // consume "(file(..." token; path follows
-                        } else if after_paren == "package("
-                            || after_paren.starts_with("package(")
-                        {
+                        } else if after_paren == "package(" || after_paren.starts_with("package(") {
                             package_prefix_consumed = true;
                             self.advance();
                         }
@@ -489,8 +487,7 @@ impl<'a> Parser<'a> {
             // the lexer emits `package` as a standalone Unquoted token — handle that form
             // for consistency with how `file(...)` accepts the spaced `file (...)` form.
             let is_package_fused = self.peek_kind() == TokenKind::Unquoted
-                && (self.peek_value() == "package("
-                    || self.peek_value().starts_with("package("));
+                && (self.peek_value() == "package(" || self.peek_value().starts_with("package("));
             let is_package_spaced = !package_prefix_consumed
                 && self.peek_kind() == TokenKind::Unquoted
                 && self.peek_value() == "package";
@@ -577,9 +574,7 @@ impl<'a> Parser<'a> {
 
                 // Consume closing ")" — required; must be the next Unquoted token.
                 // (e.g. ")" for bare form or "))" for required(package(...)) form)
-                if self.peek_kind() == TokenKind::Unquoted
-                    && self.peek_value().starts_with(')')
-                {
+                if self.peek_kind() == TokenKind::Unquoted && self.peek_value().starts_with(')') {
                     self.advance();
                 } else {
                     return Err(ParseError {
@@ -615,8 +610,8 @@ impl<'a> Parser<'a> {
                 && (self.peek_value() == "package("
                     || self.peek_value().starts_with("package(")
                     || self.peek_value() == "package"); // spaced form: `include package (...)`
-            // package_prefix_consumed can be true when required(package(... was tokenized
-            // as a fused token; the normalization above sets it regardless of feature flag.
+                                                        // package_prefix_consumed can be true when required(package(... was tokenized
+                                                        // as a fused token; the normalization above sets it regardless of feature flag.
             if is_package_token || package_prefix_consumed {
                 return Err(ParseError {
                     message: "include package(...) requires the 'include-package' feature".into(),
@@ -868,7 +863,9 @@ fn validate_package_file_arg(file: &str, line: usize, col: usize) -> Result<(), 
     }
     if file.starts_with('/') {
         return Err(ParseError {
-            message: "include package(): file argument must not be an absolute path (E11 decision 6)".into(),
+            message:
+                "include package(): file argument must not be an absolute path (E11 decision 6)"
+                    .into(),
             line,
             col,
         });

--- a/src/resolver/include_loader.rs
+++ b/src/resolver/include_loader.rs
@@ -3,7 +3,7 @@ use crate::value::HoconValue;
 use std::fs;
 
 use super::structure_builder::StructureBuilder;
-use super::types::{ResObj, ResolveOptions, ResolverValue};
+use super::types::{IncludeKey, ResObj, ResolveOptions, ResolverValue};
 use super::utils::deep_merge_res_obj_into;
 
 pub(crate) fn load_include(
@@ -90,8 +90,9 @@ fn load_single_include(
     candidate: &std::path::Path,
     opts: &ResolveOptions,
 ) -> Result<ResObj, ResolveError> {
-    // Circular include detection
-    if opts.include_stack.iter().any(|p| p.as_path() == candidate) {
+    // Circular include detection — check against IncludeKey::Path entries
+    let candidate_key = IncludeKey::Path(candidate.to_path_buf());
+    if opts.include_stack.contains(&candidate_key) {
         return Err(ResolveError {
             message: format!("circular include: {}", candidate.display()),
             path: candidate.display().to_string(),
@@ -156,7 +157,96 @@ fn load_single_include(
         child_opts = child_opts.with_base_dir(parent.to_path_buf());
     }
     child_opts.include_stack = opts.include_stack.clone();
-    child_opts.include_stack.push(candidate.to_path_buf());
+    child_opts.include_stack.push(candidate_key);
+    #[cfg(feature = "include-package")]
+    {
+        child_opts.package_registry = opts.package_registry.clone();
+    }
+
+    StructureBuilder::new(&child_opts).build(ast, &[])
+}
+
+/// Load a `package(...)` include — E11.
+///
+/// Looks up `(identifier, file)` in the per-parser registry, parses the
+/// registered content, and returns the resolved object. Cycle detection
+/// uses `IncludeKey::Package { identifier, file }` (E11 decision 8).
+#[cfg(feature = "include-package")]
+pub(crate) fn load_package_include(
+    identifier: &str,
+    file: &str,
+    required: bool,
+    line: usize,
+    col: usize,
+    opts: &ResolveOptions,
+) -> Result<ResObj, ResolveError> {
+    // Cycle detection (E11 decision 8)
+    let key = IncludeKey::Package {
+        identifier: identifier.to_string(),
+        file: file.to_string(),
+    };
+    if opts.include_stack.contains(&key) {
+        return Err(ResolveError {
+            message: format!(
+                "circular package include: ({:?}, {:?})",
+                identifier, file
+            ),
+            path: format!("package({:?}, {:?})", identifier, file),
+            line,
+            col,
+        });
+    }
+
+    // Registry lookup (E11 decision 4)
+    let content = match opts.package_registry.get(&(identifier.to_string(), file.to_string())) {
+        Some(c) => c.clone(),
+        None => {
+            let _ = required; // required semantics: miss is always an error for package includes
+            return Err(ResolveError {
+                message: format!(
+                    "include package not found: ({:?}, {:?}) — was Parser::register_package called?",
+                    identifier, file
+                ),
+                path: format!("package({:?}, {:?})", identifier, file),
+                line,
+                col,
+            });
+        }
+    };
+
+    // E11 decision 4 note: empty registered content => empty merge object, not an error.
+    // Do NOT call assert_non_empty_document here.
+    let tokens = crate::lexer::tokenize(&content).map_err(|e| ResolveError {
+        message: e.message,
+        path: format!("package({:?}, {:?})", identifier, file),
+        line: e.line,
+        col: e.col,
+    })?;
+
+    let has_content = tokens.iter().any(|t| {
+        !matches!(
+            t.kind,
+            crate::lexer::TokenKind::Newline | crate::lexer::TokenKind::Eof
+        )
+    });
+    if !has_content {
+        // Empty registered content → empty merge object (E11 decision 4 note)
+        return Ok(ResObj::new());
+    }
+
+    let ast = crate::parser::parse_tokens(&tokens).map_err(|e| ResolveError {
+        message: e.message,
+        path: format!("package({:?}, {:?})", identifier, file),
+        line: e.line,
+        col: e.col,
+    })?;
+
+    // Build child ResolveOptions: inherit env + registry; push cycle key
+    let mut child_opts = ResolveOptions::new(opts.env.clone());
+    child_opts.package_registry = opts.package_registry.clone();
+    // No base_dir for package includes (content is in-memory, not filesystem)
+    child_opts.include_stack = opts.include_stack.clone();
+    child_opts.include_stack.push(key);
 
     StructureBuilder::new(&child_opts).build(ast, &[])
 }

--- a/src/resolver/include_loader.rs
+++ b/src/resolver/include_loader.rs
@@ -198,8 +198,10 @@ pub(crate) fn load_package_include(
     }
 
     // Registry lookup (E11 decision 4)
-    let content = match opts.package_registry.get(&(identifier.to_string(), file.to_string())) {
-        Some(c) => c.clone(),
+    // Borrow &str from the Arc-owned map to avoid cloning the content String on every
+    // include call — tokenize/parse work on &str, so no owned copy is needed here.
+    let content: &str = match opts.package_registry.get(&(identifier.to_string(), file.to_string())) {
+        Some(c) => c.as_str(),
         None => {
             let _ = required; // required semantics: miss is always an error for package includes
             return Err(ResolveError {
@@ -216,7 +218,7 @@ pub(crate) fn load_package_include(
 
     // E11 decision 4 note: empty registered content => empty merge object, not an error.
     // Do NOT call assert_non_empty_document here.
-    let tokens = crate::lexer::tokenize(&content).map_err(|e| ResolveError {
+    let tokens = crate::lexer::tokenize(content).map_err(|e| ResolveError {
         message: e.message,
         path: format!("package({:?}, {:?})", identifier, file),
         line: e.line,

--- a/src/resolver/include_loader.rs
+++ b/src/resolver/include_loader.rs
@@ -187,10 +187,7 @@ pub(crate) fn load_package_include(
     };
     if opts.include_stack.contains(&key) {
         return Err(ResolveError {
-            message: format!(
-                "circular package include: ({:?}, {:?})",
-                identifier, file
-            ),
+            message: format!("circular package include: ({:?}, {:?})", identifier, file),
             path: format!("package({:?}, {:?})", identifier, file),
             line,
             col,
@@ -200,7 +197,10 @@ pub(crate) fn load_package_include(
     // Registry lookup (E11 decision 4)
     // Borrow &str from the Arc-owned map to avoid cloning the content String on every
     // include call — tokenize/parse work on &str, so no owned copy is needed here.
-    let content: &str = match opts.package_registry.get(&(identifier.to_string(), file.to_string())) {
+    let content: &str = match opts
+        .package_registry
+        .get(&(identifier.to_string(), file.to_string()))
+    {
         Some(c) => c.as_str(),
         None => {
             let _ = required; // required semantics: miss is always an error for package includes

--- a/src/resolver/structure_builder.rs
+++ b/src/resolver/structure_builder.rs
@@ -3,6 +3,8 @@ use crate::parser::{AstField, AstNode};
 use crate::value::{HoconValue, ScalarValue};
 
 use super::include_loader::load_include;
+#[cfg(feature = "include-package")]
+use super::include_loader::load_package_include;
 use super::types::{
     AppendPlaceholder, ConcatPlaceholder, ResObj, ResolveOptions, ResolverValue, SubstPlaceholder,
 };
@@ -63,7 +65,34 @@ impl<'a> StructureBuilder<'a> {
                     relativize_res_obj(&mut included, path_prefix);
                 }
                 deep_merge_res_obj_into(obj, included);
+                return Ok(());
             }
+
+            // PackageInclude directive — E11
+            #[cfg(feature = "include-package")]
+            if let AstNode::PackageInclude {
+                identifier,
+                file,
+                required,
+                pos,
+                ..
+            } = &field.value
+            {
+                let mut included = load_package_include(
+                    identifier,
+                    file,
+                    *required,
+                    pos.line,
+                    pos.col,
+                    self.opts,
+                )?;
+                if !path_prefix.is_empty() {
+                    relativize_res_obj(&mut included, path_prefix);
+                }
+                deep_merge_res_obj_into(obj, included);
+                return Ok(());
+            }
+
             return Ok(());
         }
 
@@ -203,6 +232,12 @@ impl<'a> StructureBuilder<'a> {
                 }))
             }
             AstNode::Include { .. } => Ok(ResolverValue::Resolved(HoconValue::Scalar(
+                ScalarValue::null(),
+            ))),
+            // PackageInclude in value position is unreachable: the parser only
+            // emits PackageInclude as an include directive (key=[]), not as a value.
+            #[cfg(feature = "include-package")]
+            AstNode::PackageInclude { .. } => Ok(ResolverValue::Resolved(HoconValue::Scalar(
                 ScalarValue::null(),
             ))),
         }

--- a/src/resolver/structure_builder.rs
+++ b/src/resolver/structure_builder.rs
@@ -79,12 +79,7 @@ impl<'a> StructureBuilder<'a> {
             } = &field.value
             {
                 let mut included = load_package_include(
-                    identifier,
-                    file,
-                    *required,
-                    pos.line,
-                    pos.col,
-                    self.opts,
+                    identifier, file, *required, pos.line, pos.col, self.opts,
                 )?;
                 if !path_prefix.is_empty() {
                     relativize_res_obj(&mut included, path_prefix);

--- a/src/resolver/types.rs
+++ b/src/resolver/types.rs
@@ -4,12 +4,37 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+// ---- Include cycle detection key ----
+
+/// Unified key for include-cycle detection.
+///
+/// Covers both filesystem-path includes (`include "..."` / `include file(...)`)
+/// and package includes (`include package("id", "file")`). A single stack of
+/// `IncludeKey` values replaces the former `Vec<PathBuf>` in `ResolveOptions`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum IncludeKey {
+    /// A filesystem-path include (bare or `file(...)` qualifier).
+    Path(PathBuf),
+    /// A package include (`package("identifier", "file")` qualifier) — E11.
+    #[cfg(feature = "include-package")]
+    Package {
+        identifier: String,
+        file: String,
+    },
+}
+
 // ---- Public types ----
 
 pub struct ResolveOptions {
     pub env: HashMap<String, String>,
     pub base_dir: Option<PathBuf>,
-    pub include_stack: Vec<PathBuf>,
+    /// Include-cycle detection stack. Each entry represents a file/package
+    /// currently being loaded in the call chain above this resolver invocation.
+    pub include_stack: Vec<IncludeKey>,
+    /// Package registry for `include package(...)` — E11.
+    /// Only present when the `include-package` feature is enabled.
+    #[cfg(feature = "include-package")]
+    pub package_registry: std::sync::Arc<std::collections::HashMap<(String, String), String>>,
 }
 
 impl ResolveOptions {
@@ -18,6 +43,8 @@ impl ResolveOptions {
             env,
             base_dir: None,
             include_stack: Vec::new(),
+            #[cfg(feature = "include-package")]
+            package_registry: std::sync::Arc::new(std::collections::HashMap::new()),
         }
     }
 

--- a/src/resolver/types.rs
+++ b/src/resolver/types.rs
@@ -17,10 +17,7 @@ pub(crate) enum IncludeKey {
     Path(PathBuf),
     /// A package include (`package("identifier", "file")` qualifier) — E11.
     #[cfg(feature = "include-package")]
-    Package {
-        identifier: String,
-        file: String,
-    },
+    Package { identifier: String, file: String },
 }
 
 // ---- Public types ----

--- a/tests/include_package_test.rs
+++ b/tests/include_package_test.rs
@@ -1,0 +1,324 @@
+//! E11 — `include package(...)` qualifier — conformance tests.
+//!
+//! Covers all 14 ipk* fixtures from:
+//!   xx.hocon/testdata/hocon/include-package/
+//!
+//! This test file is only compiled when the `include-package` feature is enabled.
+//! Run with: `cargo test --features include-package --test include_package_test`
+//!
+//! Per-impl override: ipk03 (collision) is n/a for ts.hocon but IS tested here
+//! since rs.hocon uses an explicit registry with panic-on-collision semantics
+//! (E11 decision 3, per-impl recommendation 2).
+
+#![cfg(feature = "include-package")]
+
+use hocon::Parser;
+
+// ── Package content (inlined as string literals) ──────────────────────────────
+
+/// ipk01: ("github.com/example/lib", "reference.conf")
+const PKG_LIB_REFERENCE: &str = r#"
+host = "example.com"
+port = 8080
+app.name = "lib"
+"#;
+
+/// ipk03 variant A: first registration
+const PKG_IPK03_A: &str = r#"
+version = "1.0.0"
+source = "package-A"
+"#;
+
+/// ipk03 variant B: different content — triggers collision panic
+const PKG_IPK03_B: &str = r#"
+version = "2.0.0"
+source = "package-B"
+"#;
+
+/// ipk06: ("Foo/Bar", "x.conf") — uppercase identifier
+const PKG_FOO_BAR_X: &str = r#"
+registered = true
+"#;
+
+/// ipk07: ("github.com/example/lib", "Reference.conf") — uppercase R
+const PKG_LIB_REFERENCE_UPPER: &str = r#"
+registered = true
+"#;
+
+/// ipk08: ("github.com/example/lib", "empty.conf") — empty content
+const PKG_EMPTY: &str = "";
+
+/// ipk13: ("foo", "self.conf") — self-referential cycle
+const PKG_SELF: &str = r#"include package("foo", "self.conf")"#;
+
+/// ipk14: ("foo", "a.conf") — includes b.conf
+const PKG_CYCLE_A: &str = r#"include package("foo", "b.conf")"#;
+
+/// ipk14: ("foo", "b.conf") — includes a.conf
+const PKG_CYCLE_B: &str = r#"include package("foo", "a.conf")"#;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Build a Parser for ipk01: registers ("github.com/example/lib", "reference.conf").
+fn parser_ipk01() -> Parser {
+    Parser::new().register_package("github.com/example/lib", "reference.conf", PKG_LIB_REFERENCE)
+}
+
+// ── ipk01: happy-path basic include ──────────────────────────────────────────
+
+#[test]
+fn ipk01_basic_success() {
+    let input = r#"include package("github.com/example/lib", "reference.conf")"#;
+    let cfg = parser_ipk01()
+        .parse(input)
+        .expect("ipk01: should parse successfully");
+    assert_eq!(cfg.get_string("host").unwrap(), "example.com");
+    assert_eq!(cfg.get_i64("port").unwrap(), 8080);
+    assert_eq!(cfg.get_string("app.name").unwrap(), "lib");
+}
+
+// ── ipk02: one-arg form rejected ─────────────────────────────────────────────
+
+#[test]
+fn ipk02_one_arg_rejected() {
+    let input = r#"include package("github.com/example/lib/reference.conf")"#;
+    let result = Parser::new().parse(input);
+    assert!(
+        result.is_err(),
+        "ipk02: one-arg package(...) must be a parse error (E11 decision 2)"
+    );
+}
+
+// ── ipk03: collision panics ───────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "conflicting content")]
+fn ipk03_collision_panics() {
+    // First registration succeeds
+    let parser = Parser::new()
+        .register_package("github.com/example/lib", "reference.conf", PKG_IPK03_A);
+    // Second registration with different content must panic
+    let _parser = parser
+        .register_package("github.com/example/lib", "reference.conf", PKG_IPK03_B);
+}
+
+#[test]
+fn ipk03_idempotent_registration_ok() {
+    // Re-registering byte-identical content is idempotent (no panic)
+    let _parser = Parser::new()
+        .register_package("github.com/example/lib", "reference.conf", PKG_IPK03_A)
+        .register_package("github.com/example/lib", "reference.conf", PKG_IPK03_A);
+}
+
+// ── ipk04: lookup miss with empty registry ────────────────────────────────────
+
+#[test]
+fn ipk04_lookup_miss() {
+    let input = r#"include package("github.com/example/missing", "x.conf")"#;
+    let result = Parser::new().parse(input);
+    assert!(
+        result.is_err(),
+        "ipk04: registry miss must be an error (E11 decision 4)"
+    );
+}
+
+// ── ipk05: required(package(...)) + miss ─────────────────────────────────────
+
+#[test]
+fn ipk05_required_miss() {
+    let input = r#"include required(package("github.com/example/missing", "x.conf"))"#;
+    let result = Parser::new().parse(input);
+    assert!(
+        result.is_err(),
+        "ipk05: required(package(...)) with registry miss must be an error (E11 decision 7)"
+    );
+}
+
+// ── ipk06: case-sensitive identifier ─────────────────────────────────────────
+
+#[test]
+fn ipk06_case_sensitive_id() {
+    // Register uppercase "Foo/Bar" — fixture uses lowercase "foo/bar"
+    let input = r#"include package("foo/bar", "x.conf")"#;
+    let result = Parser::new()
+        .register_package("Foo/Bar", "x.conf", PKG_FOO_BAR_X)
+        .parse(input);
+    assert!(
+        result.is_err(),
+        "ipk06: identifier is case-sensitive; 'foo/bar' != 'Foo/Bar' (E11 decision 5)"
+    );
+}
+
+// ── ipk07: case-sensitive file argument ──────────────────────────────────────
+
+#[test]
+fn ipk07_case_sensitive_file() {
+    // Register "Reference.conf" (uppercase R) — fixture uses "reference.conf" (lowercase r)
+    let input = r#"include package("github.com/example/lib", "reference.conf")"#;
+    let result = Parser::new()
+        .register_package("github.com/example/lib", "Reference.conf", PKG_LIB_REFERENCE_UPPER)
+        .parse(input);
+    assert!(
+        result.is_err(),
+        "ipk07: file argument is case-sensitive; 'reference.conf' != 'Reference.conf' (E11 decision 5)"
+    );
+}
+
+// ── ipk08: empty registered content succeeds ─────────────────────────────────
+
+#[test]
+fn ipk08_empty_content_succeeds() {
+    let input = r#"
+        app = host
+        include package("github.com/example/lib", "empty.conf")
+    "#;
+    let cfg = Parser::new()
+        .register_package("github.com/example/lib", "empty.conf", PKG_EMPTY)
+        .parse(input)
+        .expect("ipk08: empty registered content should succeed (E11 decision 4 note)");
+    assert_eq!(
+        cfg.get_string("app").unwrap(),
+        "host",
+        "ipk08: 'app' key from outer conf must survive empty-content include"
+    );
+}
+
+// ── ipk09: empty string file argument ────────────────────────────────────────
+
+#[test]
+fn ipk09_file_arg_empty() {
+    let input = r#"include package("foo", "")"#;
+    let result = Parser::new().parse(input);
+    assert!(
+        result.is_err(),
+        "ipk09: empty file argument must be a parse error (E11 decision 6)"
+    );
+}
+
+// ── ipk10: absolute path file argument ───────────────────────────────────────
+
+#[test]
+fn ipk10_file_arg_absolute() {
+    let input = r#"include package("foo", "/etc/passwd")"#;
+    let result = Parser::new().parse(input);
+    assert!(
+        result.is_err(),
+        "ipk10: absolute path file argument must be a parse error (E11 decision 6)"
+    );
+}
+
+// ── ipk11: traversal in file argument ────────────────────────────────────────
+
+#[test]
+fn ipk11_file_arg_traversal() {
+    let input = r#"include package("foo", "../escape.conf")"#;
+    let result = Parser::new().parse(input);
+    assert!(
+        result.is_err(),
+        "ipk11: '..' traversal in file argument must be a parse error (E11 decision 6)"
+    );
+}
+
+// ── ipk12: backslash in file argument (after HOCON unescape) ─────────────────
+
+#[test]
+fn ipk12_file_arg_backslash() {
+    // HOCON string "x\\y.conf" unescapes to x\y.conf (one backslash)
+    // E11 decision 6: backslash is rejected (after HOCON unescape)
+    let input = r#"include package("foo", "x\\y.conf")"#;
+    let result = Parser::new().parse(input);
+    assert!(
+        result.is_err(),
+        "ipk12: backslash in file argument (after unescape) must be a parse error (E11 decision 6)"
+    );
+}
+
+// ── ipk13: self-include cycle ─────────────────────────────────────────────────
+
+#[test]
+fn ipk13_cycle_self() {
+    let input = r#"include package("foo", "self.conf")"#;
+    let result = Parser::new()
+        .register_package("foo", "self.conf", PKG_SELF)
+        .parse(input);
+    assert!(
+        result.is_err(),
+        "ipk13: self-include cycle must be an error (E11 decision 8)"
+    );
+    // Optionally check the error message mentions cycle
+    if let Err(e) = result {
+        let msg = format!("{}", e);
+        // Accept if message contains "cycle", "circular", or "recursive"
+        assert!(
+            msg.to_lowercase().contains("cycle")
+                || msg.to_lowercase().contains("circular")
+                || msg.to_lowercase().contains("recursive"),
+            "ipk13: error message should mention cycle/circular (got: {})",
+            msg
+        );
+    }
+}
+
+// ── ipk14: mutual cycle ───────────────────────────────────────────────────────
+
+#[test]
+fn ipk14_cycle_mutual() {
+    let input = r#"include package("foo", "a.conf")"#;
+    let result = Parser::new()
+        .register_package("foo", "a.conf", PKG_CYCLE_A)
+        .register_package("foo", "b.conf", PKG_CYCLE_B)
+        .parse(input);
+    assert!(
+        result.is_err(),
+        "ipk14: mutual include cycle must be an error (E11 decision 8)"
+    );
+}
+
+// ── Additional unit tests for file-arg validation ─────────────────────────────
+
+#[test]
+fn file_arg_dot_segment_rejected() {
+    // "./x.conf" contains a "." segment — decision 6
+    let input = r#"include package("foo", "./x.conf")"#;
+    assert!(Parser::new().parse(input).is_err());
+}
+
+#[test]
+fn file_arg_consecutive_slash_rejected() {
+    // "a//b.conf" — decision 6
+    let input = r#"include package("foo", "a//b.conf")"#;
+    assert!(Parser::new().parse(input).is_err());
+}
+
+#[test]
+fn file_arg_valid_nested_accepted_with_registration() {
+    // "conf/reference.conf" — valid per decision 6
+    let input = r#"include package("foo", "conf/reference.conf")"#;
+    // Without registration it's a lookup miss, but parse step should accept the file arg
+    let result = Parser::new().parse(input);
+    // Should fail due to lookup miss, NOT parse error about file arg
+    assert!(result.is_err());
+    // Check it's a ResolveError (lookup miss) rather than ParseError (invalid file arg)
+    match result {
+        Err(hocon::HoconError::Resolve(_)) => { /* expected — lookup miss */ }
+        Err(hocon::HoconError::Parse(e)) => {
+            panic!(
+                "file_arg_valid_nested_accepted: got ParseError for valid file arg '{}': {}",
+                "conf/reference.conf", e
+            );
+        }
+        Err(e) => panic!("unexpected error type: {}", e),
+        Ok(_) => panic!("expected error for unregistered package"),
+    }
+}
+
+#[test]
+fn empty_identifier_rejected() {
+    // E11 decision 1 note: non-empty identifier required
+    let input = r#"include package("", "x.conf")"#;
+    let result = Parser::new().parse(input);
+    assert!(
+        result.is_err(),
+        "empty identifier must be a parse error (E11 decision 1)"
+    );
+}

--- a/tests/include_package_test.rs
+++ b/tests/include_package_test.rs
@@ -322,3 +322,27 @@ fn empty_identifier_rejected() {
         "empty identifier must be a parse error (E11 decision 1)"
     );
 }
+
+// ── Closing paren required (review fix) ──────────────────────────────────────
+
+#[test]
+fn missing_closing_paren_is_parse_error() {
+    // Without closing ")", must be a parse error, not a silent success.
+    let input = r#"include package("foo", "x.conf""#;
+    let result = Parser::new().parse(input);
+    assert!(
+        result.is_err(),
+        "missing closing ')' must be a parse error (review fix for Codex finding)"
+    );
+}
+
+#[test]
+fn required_missing_closing_paren_is_parse_error() {
+    // required(package(...) without closing )) must also be a parse error.
+    let input = r#"include required(package("foo", "x.conf")"#;
+    let result = Parser::new().parse(input);
+    assert!(
+        result.is_err(),
+        "missing outer closing ')' for required(package(...)) must be a parse error"
+    );
+}

--- a/tests/include_package_test.rs
+++ b/tests/include_package_test.rs
@@ -61,7 +61,11 @@ const PKG_CYCLE_B: &str = r#"include package("foo", "a.conf")"#;
 
 /// Build a Parser for ipk01: registers ("github.com/example/lib", "reference.conf").
 fn parser_ipk01() -> Parser {
-    Parser::new().register_package("github.com/example/lib", "reference.conf", PKG_LIB_REFERENCE)
+    Parser::new().register_package(
+        "github.com/example/lib",
+        "reference.conf",
+        PKG_LIB_REFERENCE,
+    )
 }
 
 // ── ipk01: happy-path basic include ──────────────────────────────────────────
@@ -95,11 +99,10 @@ fn ipk02_one_arg_rejected() {
 #[should_panic(expected = "conflicting content")]
 fn ipk03_collision_panics() {
     // First registration succeeds
-    let parser = Parser::new()
-        .register_package("github.com/example/lib", "reference.conf", PKG_IPK03_A);
+    let parser =
+        Parser::new().register_package("github.com/example/lib", "reference.conf", PKG_IPK03_A);
     // Second registration with different content must panic
-    let _parser = parser
-        .register_package("github.com/example/lib", "reference.conf", PKG_IPK03_B);
+    let _parser = parser.register_package("github.com/example/lib", "reference.conf", PKG_IPK03_B);
 }
 
 #[test]
@@ -156,7 +159,11 @@ fn ipk07_case_sensitive_file() {
     // Register "Reference.conf" (uppercase R) — fixture uses "reference.conf" (lowercase r)
     let input = r#"include package("github.com/example/lib", "reference.conf")"#;
     let result = Parser::new()
-        .register_package("github.com/example/lib", "Reference.conf", PKG_LIB_REFERENCE_UPPER)
+        .register_package(
+            "github.com/example/lib",
+            "Reference.conf",
+            PKG_LIB_REFERENCE_UPPER,
+        )
         .parse(input);
     assert!(
         result.is_err(),
@@ -355,7 +362,11 @@ fn spaced_package_qualifier_accepted() {
     // The lexer emits `package` as a separate Unquoted token; parser must handle it.
     let input = r#"include package ("github.com/example/lib", "reference.conf")"#;
     let result = Parser::new()
-        .register_package("github.com/example/lib", "reference.conf", PKG_LIB_REFERENCE)
+        .register_package(
+            "github.com/example/lib",
+            "reference.conf",
+            PKG_LIB_REFERENCE,
+        )
         .parse(input);
     assert!(
         result.is_ok(),
@@ -372,11 +383,17 @@ fn spaced_package_qualifier_lookup_miss() {
     // not fall through to a confusing standard-include error.
     let input = r#"include package ("github.com/example/lib", "reference.conf")"#;
     let result = Parser::new().parse(input);
-    assert!(result.is_err(), "unregistered spaced package must be an error");
+    assert!(
+        result.is_err(),
+        "unregistered spaced package must be an error"
+    );
     match result {
         Err(hocon::HoconError::Resolve(_)) => { /* expected — lookup miss */ }
         Err(hocon::HoconError::Parse(e)) => {
-            panic!("spaced package form: got ParseError instead of ResolveError: {}", e);
+            panic!(
+                "spaced package form: got ParseError instead of ResolveError: {}",
+                e
+            );
         }
         Err(e) => panic!("unexpected error type: {}", e),
         Ok(_) => panic!("expected error for unregistered package"),

--- a/tests/include_package_test.rs
+++ b/tests/include_package_test.rs
@@ -346,3 +346,39 @@ fn required_missing_closing_paren_is_parse_error() {
         "missing outer closing ')' for required(package(...)) must be a parse error"
     );
 }
+
+// ── Spaced form: `include package ("id", "file")` (Copilot review fix) ──────
+
+#[test]
+fn spaced_package_qualifier_accepted() {
+    // `include package ("id", "file")` — space between `package` and `(`.
+    // The lexer emits `package` as a separate Unquoted token; parser must handle it.
+    let input = r#"include package ("github.com/example/lib", "reference.conf")"#;
+    let result = Parser::new()
+        .register_package("github.com/example/lib", "reference.conf", PKG_LIB_REFERENCE)
+        .parse(input);
+    assert!(
+        result.is_ok(),
+        "spaced `include package (...)` must parse successfully (Copilot review fix): {:?}",
+        result.err()
+    );
+    let config = result.unwrap();
+    assert_eq!(config.get_string("host").unwrap(), "example.com");
+}
+
+#[test]
+fn spaced_package_qualifier_lookup_miss() {
+    // Spaced form with no registration — should fail with a ResolveError (lookup miss),
+    // not fall through to a confusing standard-include error.
+    let input = r#"include package ("github.com/example/lib", "reference.conf")"#;
+    let result = Parser::new().parse(input);
+    assert!(result.is_err(), "unregistered spaced package must be an error");
+    match result {
+        Err(hocon::HoconError::Resolve(_)) => { /* expected — lookup miss */ }
+        Err(hocon::HoconError::Parse(e)) => {
+            panic!("spaced package form: got ParseError instead of ResolveError: {}", e);
+        }
+        Err(e) => panic!("unexpected error type: {}", e),
+        Ok(_) => panic!("expected error for unregistered package"),
+    }
+}


### PR DESCRIPTION
## Summary

- Implement `include package("<id>", "<file>")` per xx.hocon **E11** spec (cross-impl tracking: [o3co/xx.hocon#33](https://github.com/o3co/xx.hocon/issues/33)).
- **Behind feature flag `include-package`, default OFF** (`default = []`) per cross-impl decision **X3** — binary size / dep surface for users who don't need it.
- Per-parser registry via `Arc<HashMap<(Identifier, File), &'static str>>` (clone is a refcount bump, not a map copy).
- Consuming builder method `Parser::register_package(self, identifier: &str, file: &str, content: &'static str) -> Self` — matches existing Parser builder style.
- **Panic on collision** — setup-time invariant per design recommendation; idempotent byte-equal re-registration allowed.
- `AstNode::PackageInclude` variant gated behind the `include-package` feature (cfg attributes applied at every layer).
- **Unified `IncludeKey` enum** for cycle detection — replaces `Vec<PathBuf>`; path and package stacks interleaved correctly.
- File argument validated **after HOCON string unescaping** (per E11 decision 5/6).
- Empty registered content (zero bytes) returns `ResObj::new()` and skips `assert_non_empty_document` (E11 carve-out).
- Cascade convention documented in rustdoc — free-function `pub fn register(parser: Parser) -> Parser` for downstream packages.

## Multi-agent-review

**Round 1 (Claude design + Codex security/perf)**: 2 medium-severity Codex findings — both fixed in commit `e3dc262`:

1. `src/parser.rs`: closing `)` was optional (e.g. `include package("foo", "x.conf"` without closing paren parsed successfully) → enforced
2. `src/parser.rs`: `#[cfg(not(feature="include-package"))]` block ignored `package_prefix_consumed` flag, causing `include required(package(...))` without the feature to fall through with wrong error → fixed

2 regression tests added to lock in the fixes. No security path-traversal vectors found.

## Test plan

- [ ] `cargo test` (default features, no `include-package`) — 226 lib tests pass, no regressions; `package(...)` parsing produces clear feature-gate error
- [ ] `cargo test --features include-package` — 21 package tests + 226 lib tests pass, all 14 ipk* fixtures behave per E11 spec
- [ ] Manual: use the cascade convention to register from a downstream dependency

Cross-impl spec at [o3co/xx.hocon#33](https://github.com/o3co/xx.hocon/issues/33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)