### PR TITLE
release(v1.4.0): finalize CHANGELOG — E11 + E12 + CI cache fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,40 +60,39 @@ surface is purely additive. Closes [#99](https://github.com/o3co/rs.hocon/issues
 **Spec source:** [xx.hocon#37](https://github.com/o3co/xx.hocon/issues/37) /
 E12 in `docs/extra-spec-conventions.md`.
 
+### Added — E11 `include package("id", "file")` qualifier (feature-gated, default off)
+
+New optional Cargo feature `include-package` (no new dependencies — uses `std` only)
+enables the `include package(...)` syntax per xx.hocon cross-impl convention E11.
+Spaced form `include package ("id", "file")` is also supported for consistency with
+the existing `file(...)` qualifier.
+
+Public API additions (only compiled when `features = ["include-package"]`):
+
+- **`hocon::Parser`** — new public struct with consuming builder API:
+  - `Parser::new() -> Self`
+  - `Parser::register_package(self, identifier, file, content) -> Self`
+  - `Parser::parse(self, input: &str) -> Result<Config, HoconError>`
+  - `Parser::parse_file(self, path: impl AsRef<Path>) -> Result<Config, HoconError>`
+- **Cascade convention**: downstream packages expose `pub fn register(parser: Parser) -> Parser`
+  so callers can chain registrations: `pkg_b::register(pkg_a::register(Parser::new())).parse(…)`.
+- **`AstNode::PackageInclude`** (internal `pub(crate)` variant) — not public API.
+- **`IncludeKey::Package`** variant on the resolver's internal cycle-detection enum.
+
+Behaviour:
+
+- Registry miss is always a `HoconError` (required semantics apply unconditionally per E11 decision 7).
+- Empty registered content returns an empty merge object (not a parse error — E11 carve-out).
+- Circular package includes are detected and rejected (`ResolveError`).
+- File argument is validated post-unescaping: non-empty, forward-slash separators, no absolute path.
+- Identifier and file lookups are case-sensitive (E11 decision 5).
+- Panic on duplicate `(identifier, file)` registration with different content; idempotent re-registration of byte-identical content is allowed.
+
+### Changed
+
+- **CI: content-addressable testdata cache** (closes [#101](https://github.com/o3co/rs.hocon/issues/101)). `.github/workflows/test.yml` and `publish.yml` previously used `actions/cache@v5` with `key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}`. The hash evaluated BEFORE the cache restore step ran, but `.xx-hocon-version` is gitignored and absent on fresh checkouts — so the key collapsed to a constant and cache entries shared the same slot. Split into `actions/cache/restore@v5` (matches via `restore-keys`) + `actions/cache/save@v5` (writes with the post-fetch hash, gated on `make testdata` success). No production code touched.
+
 [1.4.0]: https://github.com/o3co/rs.hocon/compare/v1.3.0...v1.4.0
-
-## [1.3.0] - 2026-05-21
-
-v1.3 is a spec-compliance bugfix release. The implementation has been corrected to match the HOCON spec and Lightbend typesafe-config reference behavior across several previously-divergent areas (E8 value-position lexing + leading-zero canonicalization, single-letter byte units, `include` key reservation, concat type-checking, empty-file rejection, `.properties` object-wins, duration/bytes default unit, S13c env-var list). The spec did not change; the parser was simply wrong in places.
-
-A subset of these fixes change observable runtime behavior. The most likely user-visible change is **S21.4** — single-letter byte units (`K`/`M`/`G`/`T`/`P`/`E`) now map to powers of two instead of SI decimal (`1K` was 1,000; now 1,024 — per HOCON.md L1385 java `-Xmx` convention, confirmed against Lightbend 1.4.3). If your `.conf` files use single-letter units and you rely on the numeric result, audit `get_bytes` call sites. Multi-letter forms (`KB`/`MB`/`GB`/`TB`) remain SI decimal and are unchanged. Other fixes have narrow practical impact — read `### Changed` / `### Fixed` below if your CI fails to upgrade cleanly. We elected MINOR (not MAJOR) because no API or architectural changes occurred; v2.0 is reserved for parser/lexer rewrites or similar structural shifts.
-
-### Added
-
-- **E11 — `include package("id", "file")` qualifier** (feature-gated, default off):
-  New optional Cargo feature `include-package` (no new dependencies — uses `std` only)
-  enables the `include package(...)` syntax per xx.hocon cross-impl convention E11.
-  Spaced form `include package ("id", "file")` is also supported for consistency with
-  the existing `file(...)` qualifier.
-
-  Public API additions (only compiled when `features = ["include-package"]`):
-  - **`hocon::Parser`** — new public struct with consuming builder API:
-    - `Parser::new() -> Self`
-    - `Parser::register_package(self, identifier, file, content) -> Self`
-    - `Parser::parse(self, input: &str) -> Result<Config, HoconError>`
-    - `Parser::parse_file(self, path: impl AsRef<Path>) -> Result<Config, HoconError>`
-  - **Cascade convention**: downstream packages expose `pub fn register(parser: Parser) -> Parser`
-    so callers can chain registrations: `pkg_b::register(pkg_a::register(Parser::new())).parse(…)`.
-  - **`AstNode::PackageInclude`** (internal `pub(crate)` variant) — not public API.
-  - **`IncludeKey::Package`** variant on the resolver's internal cycle-detection enum.
-
-  Behaviour:
-  - Registry miss is always a `HoconError` (required semantics apply unconditionally per E11 decision 7).
-  - Empty registered content returns an empty merge object (not a parse error — E11 carve-out).
-  - Circular package includes are detected and rejected (`ResolveError`).
-  - File argument is validated post-unescaping: non-empty, forward-slash separators, no absolute path.
-  - Identifier and file lookups are case-sensitive (E11 decision 5).
-  - Panic on duplicate `(identifier, file)` registration with different content; idempotent re-registration of byte-identical content is allowed.
 
 ## [1.3.0] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ Behaviour:
 
 ### Changed
 
-- **CI: content-addressable testdata cache** (closes [#101](https://github.com/o3co/rs.hocon/issues/101)). `.github/workflows/test.yml` and `publish.yml` previously used `actions/cache@v5` with `key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}`. The hash evaluated BEFORE the cache restore step ran, but `.xx-hocon-version` is gitignored and absent on fresh checkouts — so the key collapsed to a constant and cache entries shared the same slot. Split into `actions/cache/restore@v5` (matches via `restore-keys`) + `actions/cache/save@v5` (writes with the post-fetch hash, gated on `make testdata` success). No production code touched.
+- **CI: content-addressable testdata cache** (closes [#101](https://github.com/o3co/rs.hocon/issues/101)). `.github/workflows/test.yml` and `.github/workflows/publish.yml` previously used `actions/cache@v5` with `key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}`. The hash evaluated BEFORE the cache restore step ran, but `.xx-hocon-version` is gitignored and absent on fresh checkouts — so the key collapsed to a constant and cache entries shared the same slot. Split into `actions/cache/restore@v5` (matches via `restore-keys`) + `actions/cache/save@v5` (writes with the post-fetch hash, gated on `make testdata` success). No production code touched.
 
 [1.4.0]: https://github.com/o3co/rs.hocon/compare/v1.3.0...v1.4.0
 


### PR DESCRIPTION
## Summary

Release prep for v1.4.0. CHANGELOG only.

- Move E11 entry into canonical `[1.4.0]` section (was misplaced in a spurious duplicate `[1.3.0]`)
- Delete the spurious duplicate `[1.3.0]` header + duplicate narrative
- Add `### Changed — CI: content-addressable testdata cache (#101)` to `[1.4.0]`

Cargo.toml is already `version = "1.4.0"`.

Part of v1.4.0 cross-impl cut alongside go.hocon and ts.hocon release branches.

## Test plan

- [x] No code change — CHANGELOG only
- [ ] CI green