### PR TITLE
test(resolver): cross-impl regression tests for include ordering (go.hocon#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Tests
+
+- **Cross-impl regression tests for include ordering ([go.hocon#106](https://github.com/o3co/go.hocon/issues/106))**. Pin Lightbend-equivalent semantics for `include` directives — scalar override, parent-after-include, self-referential append through include, both-object deep-merge, nested-include scope isolation, and sequential includes — so the existing correct behaviour does not regress when the merge logic is touched. No production-code change; `rs.hocon`'s `deep_merge_res_obj_into` already implements src-wins + prior-capture.
+
 ## [1.4.0] - 2026-05-21
 
 ### Added — E12 deferred substitution resolution (closes [#99](https://github.com/o3co/rs.hocon/issues/99))

--- a/tests/issue106_include_ordering.rs
+++ b/tests/issue106_include_ordering.rs
@@ -41,7 +41,12 @@ fn issue106_self_ref_append_through_include() {
     );
     let cfg = hocon::parse(&input).unwrap();
     let steps = cfg.get_list("steps").unwrap();
-    assert_eq!(steps.len(), 2, "expected 2 steps (base + child), got {}", steps.len());
+    assert_eq!(
+        steps.len(),
+        2,
+        "expected 2 steps (base + child), got {}",
+        steps.len()
+    );
 }
 
 #[test]

--- a/tests/issue106_include_ordering.rs
+++ b/tests/issue106_include_ordering.rs
@@ -47,6 +47,23 @@ fn issue106_self_ref_append_through_include() {
         "expected 2 steps (base + child), got {}",
         steps.len()
     );
+    // Pin element order + content: a reversed-order or duplicate-element bug
+    // would also produce len()==2 but break the spec semantics. Each element
+    // must be an object with the expected `name` field.
+    let name_at = |i: usize| -> String {
+        let item = &steps[i];
+        if let hocon::HoconValue::Object(fields) = item {
+            if let Some(hocon::HoconValue::Scalar(s)) = fields.get("name") {
+                return s.raw.clone();
+            }
+        }
+        panic!(
+            "steps[{}] is not an object with a 'name' field: {:?}",
+            i, item
+        );
+    };
+    assert_eq!(name_at(0), "base", "steps[0].name");
+    assert_eq!(name_at(1), "child", "steps[1].name");
 }
 
 #[test]

--- a/tests/issue106_include_ordering.rs
+++ b/tests/issue106_include_ordering.rs
@@ -1,0 +1,102 @@
+//! Cross-impl regression tests for go.hocon#106 — include ordering and
+//! self-referential append through include. `rs.hocon`'s
+//! `deep_merge_res_obj_into` (src wins + prior capture) already implements
+//! Lightbend-equivalent semantics; these tests pin that behaviour so a
+//! future refactor cannot regress to go.hocon's pre-fix shape.
+
+use tempfile::tempdir;
+
+#[test]
+fn issue106_include_scalar_overrides_parent() {
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(dir.path().join("child.conf"), "a = 2\n").unwrap();
+    let input = format!("a = 1\ninclude \"{}/child.conf\"\n", dir_str);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("a").unwrap(), 2);
+}
+
+#[test]
+fn issue106_parent_scalar_after_include_wins() {
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(dir.path().join("child.conf"), "a = 2\n").unwrap();
+    let input = format!("include \"{}/child.conf\"\na = 5\n", dir_str);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("a").unwrap(), 5);
+}
+
+#[test]
+fn issue106_self_ref_append_through_include() {
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(
+        dir.path().join("child.conf"),
+        "steps = ${steps} [\n  { name = child }\n]\n",
+    )
+    .unwrap();
+    let input = format!(
+        "steps = [\n  {{ name = base }}\n]\n\ninclude \"{}/child.conf\"\n",
+        dir_str,
+    );
+    let cfg = hocon::parse(&input).unwrap();
+    let steps = cfg.get_list("steps").unwrap();
+    assert_eq!(steps.len(), 2, "expected 2 steps (base + child), got {}", steps.len());
+}
+
+#[test]
+fn issue106_control_same_file_self_ref_append() {
+    let cfg = hocon::parse(
+        "steps = [\n  { name = base }\n]\n\nsteps = ${steps} [\n  { name = child }\n]\n",
+    )
+    .unwrap();
+    let steps = cfg.get_list("steps").unwrap();
+    assert_eq!(steps.len(), 2);
+}
+
+#[test]
+fn issue106_object_collision_deep_merge_through_include() {
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(dir.path().join("child.conf"), "server { port = 8080 }\n").unwrap();
+    let input = format!(
+        "server {{ host = \"localhost\" }}\ninclude \"{}/child.conf\"\n",
+        dir_str,
+    );
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_string("server.host").unwrap(), "localhost");
+    assert_eq!(cfg.get_i64("server.port").unwrap(), 8080);
+}
+
+#[test]
+fn issue106_nested_include_does_not_leak_to_top_level() {
+    // Multi-agent-review regression scenario from go.hocon: nested-include
+    // override must NOT leak the prior under the bare leaf key into the
+    // resolver-wide scope. An unrelated top-level self-ref with the same
+    // leaf must see "no prior" and drop (when optional) — not the nested
+    // value.
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(dir.path().join("leaf.conf"), "a = innerB\n").unwrap();
+    let input = format!(
+        "nested {{\n  a = innerA\n  include \"{}/leaf.conf\"\n}}\na = ${{?a}}suffix\n",
+        dir_str,
+    );
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_string("nested.a").unwrap(), "innerB");
+    assert_eq!(cfg.get_string("a").unwrap(), "suffix");
+}
+
+#[test]
+fn issue106_sequential_includes_chain_priors() {
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(dir.path().join("c1.conf"), "a = 2\n").unwrap();
+    std::fs::write(dir.path().join("c2.conf"), "a = 3\n").unwrap();
+    let input = format!(
+        "a = 1\ninclude \"{}/c1.conf\"\ninclude \"{}/c2.conf\"\n",
+        dir_str, dir_str,
+    );
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("a").unwrap(), 3);
+}


### PR DESCRIPTION
## Summary

Cross-impl regression tests for the include-ordering bug reported in [go.hocon#106](https://github.com/o3co/go.hocon/issues/106). `rs.hocon`'s `deep_merge_res_obj_into` already implements the correct Lightbend semantics (src wins on non-object collision + `prior_values` capture for self-ref lookback), so these tests pass without any production-code change. They pin the behaviour so a future refactor cannot silently regress.

## Test plan

- [x] `cargo test --test issue106_include_ordering` — 7 PASS
- [x] `cargo test` — full suite green
- [ ] Maintainer: confirm CI green

## Scenarios covered

- scalar override through include (Lightbend inline-equivalent)
- parent scalar after include (last write wins)
- self-referential append through include
- same-file self-ref control case
- both-object deep-merge through include
- nested-include override must not leak top-level `prior_values`
- sequential includes chain priors correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)