### PR TITLE
fix(resolver): empty/comment-only include is no-op (cross-impl go.hocon#105)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ docs/superpowers/
 
 # Fetched testdata from xx.hocon (run `make testdata` to populate)
 tests/testdata/expected/
+tests/testdata/hocon/
 .xx-hocon-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Cross-impl regression tests for include ordering ([go.hocon#106](https://github.com/o3co/go.hocon/issues/106))**. Pin Lightbend-equivalent semantics for `include` directives — scalar override, parent-after-include, self-referential append through include, both-object deep-merge, nested-include scope isolation, and sequential includes — so the existing correct behaviour does not regress when the merge logic is touched. No production-code change; `rs.hocon`'s `deep_merge_res_obj_into` already implements src-wins + prior-capture.
 
+### Changed — include path
+
+- **Empty / comment-only / whitespace-only included files contribute an empty config** ([go.hocon#105](https://github.com/o3co/go.hocon/issues/105), Lightbend compatibility). Previously, `include "empty.conf"` (or comment-only / whitespace-only / BOM-only content) errored with `empty file is not a valid HOCON document (HOCON.md L130)`. This blocked the common optional-override-file pattern. The carve-out is **narrow** — applies only to the file-include code path in `load_file_include`; top-level parses (`parse("")`, `parse_file` on a top-level empty file) and E11 `include package(...)` are unchanged. Cross-impl with [go.hocon PR #110](https://github.com/o3co/go.hocon/pull/110) and [ts.hocon PR #122](https://github.com/o3co/ts.hocon/pull/122).
+
 ## [1.4.0] - 2026-05-21
 
 ### Added — E12 deferred substitution resolution (closes [#99](https://github.com/o3co/rs.hocon/issues/99))

--- a/src/resolver/include_loader.rs
+++ b/src/resolver/include_loader.rs
@@ -130,7 +130,8 @@ fn load_single_include(
 
     // Lightbend-compat carve-out (#105 cross-impl): an empty / whitespace-only /
     // comment-only included file contributes an empty config rather than
-    // erroring with S3.1. Top-level parses (parse_string / parse_file on a
+    // erroring with S3.1. Top-level parses (`parse` / `parse_with_env` /
+    // `parse_string_with_options` / `parse_file_with_options` on a
     // top-level empty document) continue to enforce S3.1 in `parse_with_env` /
     // `parse_file_with_env` (src/lib.rs); the carve-out is scoped to the
     // file-include path only. E11 package includes are unchanged.

--- a/src/resolver/include_loader.rs
+++ b/src/resolver/include_loader.rs
@@ -128,8 +128,12 @@ fn load_single_include(
         col: e.col,
     })?;
 
-    // S3.1 empty-file guard: empty included files are invalid (HOCON.md L130).
-    // Mirrors the guard in `parse_with_env` / `parse_file_with_env` in src/lib.rs.
+    // Lightbend-compat carve-out (#105 cross-impl): an empty / whitespace-only /
+    // comment-only included file contributes an empty config rather than
+    // erroring with S3.1. Top-level parses (parse_string / parse_file on a
+    // top-level empty document) continue to enforce S3.1 in `parse_with_env` /
+    // `parse_file_with_env` (src/lib.rs); the carve-out is scoped to the
+    // file-include path only. E11 package includes are unchanged.
     let has_content = tokens.iter().any(|t| {
         !matches!(
             t.kind,
@@ -137,12 +141,7 @@ fn load_single_include(
         )
     });
     if !has_content {
-        return Err(ResolveError {
-            message: "empty file is not a valid HOCON document (HOCON.md L130)".into(),
-            path: candidate.display().to_string(),
-            line: 1,
-            col: 1,
-        });
+        return Ok(ResObj::new());
     }
 
     let ast = crate::parser::parse_tokens(&tokens).map_err(|e| ResolveError {

--- a/tests/issue105_empty_include.rs
+++ b/tests/issue105_empty_include.rs
@@ -1,0 +1,98 @@
+//! Cross-impl fix for go.hocon#105 — empty / whitespace-only / comment-only /
+//! BOM-only INCLUDED files contribute an empty config instead of erroring
+//! with S3.1's "empty file is not a valid HOCON document". Top-level parses
+//! (parse_string / parse_file on a top-level empty file) continue to error
+//! per S3.1.
+
+use tempfile::tempdir;
+
+#[test]
+fn issue105_zero_byte_include_is_noop() {
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(dir.path().join("empty.conf"), "").unwrap();
+    let input = format!("include \"{}/empty.conf\"\na = 1\n", dir_str);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
+}
+
+#[test]
+fn issue105_hash_comment_only_include_is_noop() {
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(dir.path().join("c.conf"), "# only a comment\n# another\n").unwrap();
+    let input = format!("include \"{}/c.conf\"\na = 1\n", dir_str);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
+}
+
+#[test]
+fn issue105_slash_comment_only_include_is_noop() {
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(dir.path().join("c.conf"), "// only a comment\n").unwrap();
+    let input = format!("include \"{}/c.conf\"\na = 1\n", dir_str);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
+}
+
+#[test]
+fn issue105_whitespace_only_include_is_noop() {
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(dir.path().join("ws.conf"), "   \n\t\n\n").unwrap();
+    let input = format!("include \"{}/ws.conf\"\na = 1\n", dir_str);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
+}
+
+#[test]
+fn issue105_unicode_whitespace_only_include_is_noop() {
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    // NBSP (U+00A0) + en-quad (U+2000) + line separator (U+2028) + LF
+    std::fs::write(dir.path().join("uws.conf"), "\u{A0}\u{2000}\u{2028}\n").unwrap();
+    let input = format!("include \"{}/uws.conf\"\na = 1\n", dir_str);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
+}
+
+#[test]
+fn issue105_bom_only_include_is_noop() {
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    // UTF-8 BOM bytes + newline
+    std::fs::write(dir.path().join("bom.conf"), [0xEF, 0xBB, 0xBF, b'\n']).unwrap();
+    let input = format!("include \"{}/bom.conf\"\na = 1\n", dir_str);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
+}
+
+#[test]
+fn issue105_top_level_empty_still_rejected() {
+    // S3.1 enforcement for top-level parses must remain intact.
+    assert!(hocon::parse("").is_err(), "empty top-level must error");
+    assert!(
+        hocon::parse("   \n\t  ").is_err(),
+        "whitespace-only top-level must error",
+    );
+    assert!(
+        hocon::parse("# only a comment\n").is_err(),
+        "hash-comment-only top-level must error",
+    );
+    assert!(
+        hocon::parse("// only a comment\n").is_err(),
+        "slash-comment-only top-level must error",
+    );
+}
+
+#[test]
+fn issue105_non_empty_include_still_parses() {
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(dir.path().join("c.conf"), "# leading\nb = 2\n# trailing\n").unwrap();
+    let input = format!("include \"{}/c.conf\"\na = 1\n", dir_str);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
+    assert_eq!(cfg.get_i64("b").unwrap(), 2);
+}

--- a/tests/issue105_empty_include.rs
+++ b/tests/issue105_empty_include.rs
@@ -1,7 +1,8 @@
 //! Cross-impl fix for go.hocon#105 — empty / whitespace-only / comment-only /
 //! BOM-only INCLUDED files contribute an empty config instead of erroring
 //! with S3.1's "empty file is not a valid HOCON document". Top-level parses
-//! (parse_string / parse_file on a top-level empty file) continue to error
+//! (`parse` / `parse_with_env` / `parse_file_with_options` on a top-level
+//! empty file) continue to error
 //! per S3.1.
 
 use tempfile::tempdir;

--- a/tests/spec_s3_1_empty_include.rs
+++ b/tests/spec_s3_1_empty_include.rs
@@ -1,8 +1,11 @@
-//! S3.1 — Empty-file guard applies to included files (rs-T1 / HOCON.md L130).
+//! Lightbend-compat carve-out for go.hocon#105 — empty / whitespace-only /
+//! comment-only / BOM-only INCLUDED files contribute an empty config
+//! instead of erroring with S3.1.
 //!
-//! Regression for the include-loader path: when `include required("empty.conf")` is
-//! processed, the S3.1 guard must fire just as it does for top-level `parse_file`.
-//! Convergent with ts Codex P2 (same issue shape in the TypeScript implementation).
+//! S3.1 (HOCON.md L130) "empty files are invalid documents" remains
+//! enforced for TOP-LEVEL parses — see `tests/spec_s3_1_empty_file.rs`.
+//! This file pins the narrower include-path carve-out and serves as a
+//! regression guard against the previous strict-reject behaviour returning.
 
 use std::io::Write;
 use tempfile::Builder;
@@ -11,97 +14,92 @@ use tempfile::NamedTempFile;
 /// Write content to a NamedTempFile with a `.conf` suffix and return the file (keeping it alive).
 ///
 /// Using `.conf` suffix ensures the include loader uses the exact-path code path (has_extension)
-/// rather than the probe-extensions path, so the empty-file guard fires correctly.
-fn tmp_conf(content: &str) -> NamedTempFile {
+/// rather than the probe-extensions path.
+fn tmp_conf_bytes(content: &[u8]) -> NamedTempFile {
     let mut f = Builder::new().suffix(".conf").tempfile().expect("tempfile");
-    f.write_all(content.as_bytes()).expect("write");
+    f.write_all(content).expect("write");
     f
 }
 
-/// Build a top-level conf string that includes the given file path.
-fn required_include_conf(path: &str) -> String {
-    // Escape backslashes for Windows paths in HOCON string literals.
+fn tmp_conf(content: &str) -> NamedTempFile {
+    tmp_conf_bytes(content.as_bytes())
+}
+
+/// Build a top-level conf string that includes the given file path and a
+/// field after it so the test can assert the include itself didn't error.
+fn include_with_after(path: &str) -> String {
     let escaped = path.replace('\\', "/");
-    format!(r#"include required("{}")"#, escaped)
+    format!(r#"include required("{}")
+a = 1"#, escaped)
 }
 
 // ---------------------------------------------------------------------------
-// Negative cases — included empty-ish files must error
+// Carve-out cases — included empty-ish files contribute empty (no-op)
 // ---------------------------------------------------------------------------
 
-/// s3_1_inc_1: include required of a completely empty file must error.
 #[test]
-fn s3_1_inc_1_empty_required_include_errors() {
+fn s3_1_inc_1_empty_required_include_is_noop() {
     let included = tmp_conf("");
-    let top = required_include_conf(included.path().to_str().unwrap());
-    assert!(
-        hocon::parse(&top).is_err(),
-        "S3.1: include required of empty file must error (HOCON.md L130)"
-    );
+    let top = include_with_after(included.path().to_str().unwrap());
+    let cfg = hocon::parse(&top).expect("empty included file must be no-op (Lightbend-compat #105)");
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
 }
 
-/// s3_1_inc_2: include required of a whitespace-only file must error.
 #[test]
-fn s3_1_inc_2_whitespace_only_required_include_errors() {
+fn s3_1_inc_2_whitespace_only_required_include_is_noop() {
     let included = tmp_conf("   \n  \n");
-    let top = required_include_conf(included.path().to_str().unwrap());
-    assert!(
-        hocon::parse(&top).is_err(),
-        "S3.1: include required of whitespace-only file must error (HOCON.md L130)"
-    );
+    let top = include_with_after(included.path().to_str().unwrap());
+    let cfg = hocon::parse(&top).expect("whitespace-only included file must be no-op");
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
 }
 
-/// s3_1_inc_3: include required of a comment-only file must error.
 #[test]
-fn s3_1_inc_3_comment_only_required_include_errors() {
+fn s3_1_inc_3_hash_comment_only_required_include_is_noop() {
     let included = tmp_conf("# only a comment\n");
-    let top = required_include_conf(included.path().to_str().unwrap());
-    assert!(
-        hocon::parse(&top).is_err(),
-        "S3.1: include required of comment-only file must error (HOCON.md L130)"
-    );
+    let top = include_with_after(included.path().to_str().unwrap());
+    let cfg = hocon::parse(&top).expect("hash-comment-only included file must be no-op");
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
 }
 
-/// s3_1_inc_4: include required of a BOM-only file must error.
 #[test]
-fn s3_1_inc_4_bom_only_required_include_errors() {
-    let included = tmp_conf("\u{FEFF}");
-    let top = required_include_conf(included.path().to_str().unwrap());
-    assert!(
-        hocon::parse(&top).is_err(),
-        "S3.1: include required of BOM-only file must error (HOCON.md L130)"
-    );
+fn s3_1_inc_3b_slash_comment_only_required_include_is_noop() {
+    let included = tmp_conf("// only a comment\n");
+    let top = include_with_after(included.path().to_str().unwrap());
+    let cfg = hocon::parse(&top).expect("slash-comment-only included file must be no-op");
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
 }
 
-/// s3_1_inc_5: bare (non-required) include of an empty file must also error.
-///
-/// S3.1 is unconditional — "empty file is not a valid HOCON document" regardless of
-/// whether the include keyword is `required(...)` or bare.  An empty *existing* file is
-/// always invalid; the optional-silencing rule only applies to *missing* files.
 #[test]
-fn s3_1_inc_5_bare_include_of_empty_file_errors() {
+fn s3_1_inc_4_bom_only_required_include_is_noop() {
+    let included = tmp_conf_bytes(&[0xEF, 0xBB, 0xBF, b'\n']);
+    let top = include_with_after(included.path().to_str().unwrap());
+    let cfg = hocon::parse(&top).expect("BOM-only included file must be no-op");
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
+}
+
+#[test]
+fn s3_1_inc_5_bare_include_of_empty_file_is_noop() {
     let included = tmp_conf("");
     let escaped = included.path().to_str().unwrap().replace('\\', "/");
-    let top = format!(r#"include "{}""#, escaped);
-    assert!(
-        hocon::parse(&top).is_err(),
-        "S3.1: bare include of empty *existing* file must error (HOCON.md L130)"
-    );
+    let top = format!(r#"include "{}"
+a = 1"#, escaped);
+    let cfg = hocon::parse(&top).expect("bare include of empty file must be no-op");
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
 }
 
 // ---------------------------------------------------------------------------
-// Positive case — include of a file with real content must succeed
+// Positive control — include of a file with real content must succeed
 // ---------------------------------------------------------------------------
 
-/// s3_1_inc_pos1: include required of a file with `a = 1` must succeed.
 #[test]
 fn s3_1_inc_pos1_non_empty_include_succeeds() {
     let included = tmp_conf("a = 1\n");
-    let top = required_include_conf(included.path().to_str().unwrap());
+    let escaped = included.path().to_str().unwrap().replace('\\', "/");
+    let top = format!(r#"include required("{}")"#, escaped);
     let cfg = hocon::parse(&top).expect("S3.1 (positive): non-empty include must succeed");
     assert_eq!(
         cfg.get_string("a").unwrap(),
         "1",
-        "S3.1 (positive): included field must be accessible"
+        "included field must be accessible",
     );
 }

--- a/tests/spec_s3_1_empty_include.rs
+++ b/tests/spec_s3_1_empty_include.rs
@@ -29,8 +29,11 @@ fn tmp_conf(content: &str) -> NamedTempFile {
 /// field after it so the test can assert the include itself didn't error.
 fn include_with_after(path: &str) -> String {
     let escaped = path.replace('\\', "/");
-    format!(r#"include required("{}")
-a = 1"#, escaped)
+    format!(
+        r#"include required("{}")
+a = 1"#,
+        escaped
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -41,7 +44,8 @@ a = 1"#, escaped)
 fn s3_1_inc_1_empty_required_include_is_noop() {
     let included = tmp_conf("");
     let top = include_with_after(included.path().to_str().unwrap());
-    let cfg = hocon::parse(&top).expect("empty included file must be no-op (Lightbend-compat #105)");
+    let cfg =
+        hocon::parse(&top).expect("empty included file must be no-op (Lightbend-compat #105)");
     assert_eq!(cfg.get_i64("a").unwrap(), 1);
 }
 
@@ -81,8 +85,11 @@ fn s3_1_inc_4_bom_only_required_include_is_noop() {
 fn s3_1_inc_5_bare_include_of_empty_file_is_noop() {
     let included = tmp_conf("");
     let escaped = included.path().to_str().unwrap().replace('\\', "/");
-    let top = format!(r#"include "{}"
-a = 1"#, escaped);
+    let top = format!(
+        r#"include "{}"
+a = 1"#,
+        escaped
+    );
     let cfg = hocon::parse(&top).expect("bare include of empty file must be no-op");
     assert_eq!(cfg.get_i64("a").unwrap(), 1);
 }


### PR DESCRIPTION
## Summary

Cross-impl fix for the same issue reported in [go.hocon#105](https://github.com/o3co/go.hocon/issues/105) (cgordon). Lightbend Config treats an empty / whitespace-only / comment-only / BOM-only included file as a no-op; `rs.hocon` previously errored at the include-loader's S3.1 guard. This blocks the optional-override-file pattern:

```hocon
include \"optional-overrides.conf\"
a = 1
```

## Scope

**Narrow:** only the file-include path (`load_file_include`). Top-level parses (`parse(\"\")`, `parse_file` on a top-level empty file) continue to error per S3.1 — see `tests/spec_s3_1_empty_file.rs`. E11 `include package(...)` is unchanged.

## Changes

- `src/resolver/include_loader.rs` — replace the S3.1 ResolveError with `Ok(ResObj::new())` when the included file has no content tokens.
- `tests/issue105_empty_include.rs` — 8 new scenarios pinning the carve-out + top-level reject guard.
- `tests/spec_s3_1_empty_include.rs` — updated to assert the new Lightbend-compat contract (carve-out cases now expect no-op; non-empty regression guard preserved).
- `.gitignore` — add `tests/testdata/hocon/` so `make testdata`-fetched fixtures aren't accidentally staged (matches the existing `tests/testdata/expected/` rule).
- `CHANGELOG.md` — Unreleased entry.

## Cross-impl

Pairs with:
- `o3co/go.hocon#105` (fix, [PR #110](https://github.com/o3co/go.hocon/pull/110))
- `o3co/ts.hocon` (fix, [PR #122](https://github.com/o3co/ts.hocon/pull/122))

## Test plan

- [x] `cargo test --test issue105_empty_include` — 8 PASS
- [x] `cargo test --test spec_s3_1_empty_include` — all green after update
- [x] `cargo test` — full suite green
- [ ] Maintainer: confirm CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)