### PR TITLE
fix(config): get_string on null scalar must error per S17.6 (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,8 @@ Behaviour:
 
 - **CI: content-addressable testdata cache** (closes [#101](https://github.com/o3co/rs.hocon/issues/101)). `.github/workflows/test.yml` and `.github/workflows/publish.yml` previously used `actions/cache@v5` with `key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}`. The hash evaluated BEFORE the cache restore step ran, but `.xx-hocon-version` is gitignored and absent on fresh checkouts — so the key collapsed to a constant and cache entries shared the same slot. Split into `actions/cache/restore@v5` (matches via `restore-keys`) + `actions/cache/save@v5` (writes with the post-fetch hash, gated on `make testdata` success). No production code touched.
 
-[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/o3co/rs.hocon/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/o3co/rs.hocon/compare/v1.3.0...v1.4.0
 
 ## [1.3.0] - 2026-05-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — S17.6 spec compliance
+
+- **`get_string()` on a null-typed scalar now errors instead of returning `Ok("null")`** ([#80](https://github.com/o3co/rs.hocon/issues/80)). Per HOCON spec L1252, "if the application asks for a specific type and finds null instead, that should usually result in an error" — including `String`. Previously `get_i64` and `get_bool` on null correctly errored but `get_string` returned the raw `"null"` literal. The fix adds a `ScalarType::Null` guard at the top of `get_string`, matching the existing behaviour of the other typed getters.
+
 ## [1.4.1] - 2026-05-22
 
 Cross-impl bugfix release: addresses [go.hocon#105](https://github.com/o3co/go.hocon/issues/105) (cgordon-reported Lightbend divergence on empty/comment-only includes) at the rs.hocon layer, and pins go.hocon#106 (include-ordering / self-ref-through-include) which already worked correctly here. Pure include-path behaviour; no public API changes; safe drop-in upgrade from v1.4.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Behaviour:
 
 - **CI: content-addressable testdata cache** (closes [#101](https://github.com/o3co/rs.hocon/issues/101)). `.github/workflows/test.yml` and `.github/workflows/publish.yml` previously used `actions/cache@v5` with `key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}`. The hash evaluated BEFORE the cache restore step ran, but `.xx-hocon-version` is gitignored and absent on fresh checkouts — so the key collapsed to a constant and cache entries shared the same slot. Split into `actions/cache/restore@v5` (matches via `restore-keys`) + `actions/cache/save@v5` (writes with the post-fetch hash, gated on `make testdata` success). No production code touched.
 
+[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.4.0...HEAD
 [1.4.0]: https://github.com/o3co/rs.hocon/compare/v1.3.0...v1.4.0
 
 ## [1.3.0] - 2026-05-21

--- a/src/config.rs
+++ b/src/config.rs
@@ -316,14 +316,20 @@ impl Config {
 
     /// Return the value at `path` as a `String`.
     ///
-    /// Returns the raw string for any scalar value (string, number, boolean,
-    /// or null). Returns [`ConfigError`] if the path is missing or the value
-    /// is an Object or Array.
+    /// Returns the raw string for any non-null scalar (string, number,
+    /// boolean). Returns [`ConfigError`] if the path is missing, the value
+    /// is an Object or Array, or the value is `null` (spec L1252: null →
+    /// any non-null type is an error).
     pub fn get_string(&self, path: &str) -> Result<String, ConfigError> {
         match self.lookup_node(path) {
             None => Err(missing(path)),
             Some(HoconValue::Placeholder(_)) => Err(not_resolved(path)),
-            Some(HoconValue::Scalar(sv)) => Ok(sv.raw.clone()),
+            Some(HoconValue::Scalar(sv)) => {
+                if sv.value_type == ScalarType::Null {
+                    return Err(type_mismatch(path, "String"));
+                }
+                Ok(sv.raw.clone())
+            }
             _ => Err(type_mismatch(path, "String")),
         }
     }
@@ -1089,9 +1095,10 @@ mod tests {
     }
 
     #[test]
-    fn get_string_coerces_null() {
+    fn get_string_error_on_null() {
+        // Spec L1252: null → any non-null type is an error.
         let c = make_config(vec![("v", HoconValue::Scalar(ScalarValue::null()))]);
-        assert_eq!(c.get_string("v").unwrap(), "null");
+        assert!(c.get_string("v").is_err());
     }
 
     #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -256,9 +256,11 @@ fn test_get_string_coerces_bool() {
 }
 
 #[test]
-fn test_get_string_coerces_null() {
+fn test_get_string_on_null_errors() {
+    // Spec L1252: null → any non-null type is an error. get_string on a null
+    // scalar now errors instead of returning Ok("null"). See #80.
     let cfg = hocon::parse("val = null").unwrap();
-    assert_eq!(cfg.get_string("val").unwrap(), "null");
+    assert!(cfg.get_string("val").is_err());
 }
 
 // Task 10: object concatenation deep-merge
@@ -1434,9 +1436,6 @@ fn s17_5_null_string_stored_as_string_not_null() {
 }
 
 // --- S17.6: null → other type: error (spec L1252) ----------------------------------
-//
-// Partial conformance: get_i64 and get_bool on null correctly error.
-// get_string on null incorrectly returns Ok("null") — bug, see #80.
 #[test]
 fn s17_6_null_to_numeric_and_bool_errors() {
     let cfg = hocon::parse_with_env(r#"v = null"#, &HashMap::new()).unwrap();
@@ -1451,19 +1450,9 @@ fn s17_6_null_to_numeric_and_bool_errors() {
 }
 
 #[test]
-fn s17_6_null_to_string_pin() {
-    let cfg = hocon::parse_with_env(r#"v = null"#, &HashMap::new()).unwrap();
-    // [pin] Buggy: get_string on a null value returns Ok("null") instead of Err.
-    // The spec (L1252) requires null → any type to be an error.
-    assert!(
-        cfg.get_string("v").is_ok(),
-        "[pin] get_string on null currently returns Ok(\"null\") — update when fixed"
-    );
-}
-
-#[ignore = "spec violation: null → string must error per HOCON L1252, but get_string returns Ok(\"null\"), see #80"]
-#[test]
-fn s17_6_null_to_string_spec() {
+fn s17_6_null_to_string_errors() {
+    // Fix for #80: get_string on a null scalar now errors per HOCON L1252.
+    // Previously this returned Ok("null") via the raw-string passthrough.
     let cfg = hocon::parse_with_env(r#"v = null"#, &HashMap::new()).unwrap();
     assert!(
         cfg.get_string("v").is_err(),

--- a/tests/spec_phase5.rs
+++ b/tests/spec_phase5.rs
@@ -464,11 +464,18 @@ fn s22_3_null_clears_earlier_object_in_merge() {
         merged.get_i64("a.x").is_err(),
         "S22.3: a.x must not be accessible after a=null clears the earlier object (spec L1436)"
     );
-    // a itself is null (get_string returns "null" due to S17.6 bug, which is separate)
-    assert!(
-        merged.get_string("a").is_ok(),
-        "S22.3: a is still present as null value"
-    );
+    // a itself is the null scalar. After #80 (S17.6 compliance), get_string
+    // on null errors, so probe via get() to assert the null is structurally
+    // present — this distinguishes "null cleared the object" from
+    // "field was removed entirely".
+    match merged.get("a") {
+        Some(hocon::HoconValue::Scalar(ref s)) => assert_eq!(
+            s.value_type,
+            hocon::ScalarType::Null,
+            "S22.3: a must be the explicit null scalar after merge"
+        ),
+        other => panic!("S22.3: a must be Scalar(Null), got {:?}", other),
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/value_factory.rs
+++ b/tests/value_factory.rs
@@ -27,14 +27,22 @@ mod from_map_tests {
         assert_eq!(c.get_i64("count").unwrap(), 42);
         assert!((c.get_f64("ratio").unwrap() - 2.72).abs() < 1e-10);
         assert_eq!(c.get_string("label").unwrap(), "hello");
-        // null scalar -> get_string returns "null", get_string_option returns Some("null")
-        // The plan says null -> None but rs.hocon treats null as a scalar string "null".
-        // Verify the value is present and is "null".
-        assert_eq!(
-            c.get_string("nothing").unwrap(),
-            "null",
-            "null scalar -> raw string 'null'"
+        // null scalar -> get_string errors per S17.6 (HOCON L1252, fixed in #80).
+        // Probe via get() to confirm the field is structurally present as a
+        // null scalar — the round-trip preserves null, the typed accessor
+        // refuses to coerce it.
+        assert!(
+            c.get_string("nothing").is_err(),
+            "null scalar -> get_string must error (S17.6)"
         );
+        match c.get("nothing") {
+            Some(hocon::HoconValue::Scalar(ref s)) => assert_eq!(
+                s.value_type,
+                hocon::ScalarType::Null,
+                "null scalar must round-trip as Scalar(Null)"
+            ),
+            other => panic!("expected Scalar(Null), got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes [#80](https://github.com/o3co/rs.hocon/issues/80). Per HOCON spec L1252 (\"if the application asks for a specific type and finds null instead, that should usually result in an error\"), \`get_string()\` on a null scalar must error. Previously it returned \`Ok(\"null\")\` because the raw-string passthrough did not check the type discriminator.

## Changes

- \`src/config.rs\` — \`get_string\` adds a \`ScalarType::Null\` guard, matching \`get_i64\` / \`get_bool\`.
- \`tests/integration_test.rs\` — \`test_get_string_coerces_null\` renamed to \`test_get_string_on_null_errors\`. S17.6 pin/spec test pair collapsed into a single positive assertion; \`#[ignore]\` marker removed.
- Internal \`src/config.rs\` unit test \`get_string_coerces_null\` renamed to \`get_string_error_on_null\`.
- \`CHANGELOG.md\` — Unreleased / Fixed entry.

## Semver

Spec-compliance fix; not a breaking change under the doctrine for libraries implementing external specs.

## Test plan

- [x] \`cargo test\` — full suite green (no remaining FAILED)
- [ ] Maintainer: confirm CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)