### PR TITLE
fix(resolver): += on non-array prior must error per S13b.2 (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`get_string()` on a null-typed scalar now errors instead of returning `Ok("null")`** ([#80](https://github.com/o3co/rs.hocon/issues/80)). Per HOCON spec L1252, "if the application asks for a specific type and finds null instead, that should usually result in an error" — including `String`. Previously `get_i64` and `get_bool` on null correctly errored but `get_string` returned the raw `"null"` literal. The fix adds a `ScalarType::Null` guard at the top of `get_string`, matching the existing behaviour of the other typed getters.
 
+### Fixed — S13b.2 spec compliance
+
+- **`+=` on a non-array prior value now errors instead of silently wrapping** ([#72](https://github.com/o3co/rs.hocon/issues/72)). Per HOCON spec L732, `a += b` is sugar for `a = ${?a} [b]`; when the prior value of `a` is not an array, this must produce a resolve-time error. Previously the resolver silently wrapped the non-array as a single-element array (`a = 42; a += 1` produced `Array([42, 1])`). The fix returns `ResolveError` in `resolve_append` when `existing` is not an array.
+
 ## [1.4.1] - 2026-05-22
 
 Cross-impl bugfix release: addresses [go.hocon#105](https://github.com/o3co/go.hocon/issues/105) (cgordon-reported Lightbend divergence on empty/comment-only includes) at the rs.hocon layer, and pins go.hocon#106 (include-ordering / self-ref-through-include) which already worked correctly here. Pure include-path behaviour; no public API changes; safe drop-in upgrade from v1.4.0.

--- a/src/resolver/structure_builder.rs
+++ b/src/resolver/structure_builder.rs
@@ -128,11 +128,15 @@ impl<'a> StructureBuilder<'a> {
             let mut child_prefix = path_prefix.to_vec();
             child_prefix.push(head.clone());
             let elem = self.ast_to_resolver_value(field.value, &child_prefix)?;
+            let field_line = field.pos.line;
+            let field_col = field.pos.col;
             obj.fields.insert(
                 head,
                 ResolverValue::Append(AppendPlaceholder {
                     existing: Box::new(existing),
                     elem: Box::new(elem),
+                    line: field_line,
+                    col: field_col,
                 }),
             );
             return Ok(());

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -582,16 +582,11 @@ impl<'a> SubstitutionResolver<'a> {
                 return Err(ResolveError {
                     message: format!(
                         "'+=' on non-array value: prior value is {} (spec L732)",
-                        match other {
-                            HoconValue::Object(_) => "object",
-                            HoconValue::Scalar(_) => "scalar",
-                            HoconValue::Placeholder(_) => "placeholder",
-                            HoconValue::Array(_) => unreachable!(),
-                        },
+                        type_name(&other),
                     ),
-                    path: String::new(),
-                    line: 0,
-                    col: 0,
+                    path: self.resolving_field_path.join("."),
+                    line: a.line,
+                    col: a.col,
                 });
             }
         };

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -570,6 +570,21 @@ impl<'a> SubstitutionResolver<'a> {
         let existing = self
             .resolve_val(&a.existing, scope)?
             .unwrap_or_else(|| HoconValue::Array(vec![]));
+
+        // E12: under allow_unresolved, if the prior value is itself an unresolved
+        // placeholder (e.g. `x = ${missing}\nx += 1`), defer the append by
+        // returning a sentinel Placeholder. Mirrors the resolve_concat short-
+        // circuit at the top of this file. Without this guard, the S13b.2
+        // non-array check below would classify the placeholder as a concrete
+        // non-array and throw, violating the E12 deferral contract.
+        if self.allow_unresolved && matches!(existing, HoconValue::Placeholder(_)) {
+            use crate::value::PlaceholderValue;
+            return Ok(HoconValue::Placeholder(PlaceholderValue {
+                path: "<unresolved-append>".into(),
+                optional: false,
+            }));
+        }
+
         let elem = self.resolve_val(&a.elem, scope)?;
 
         // S13b.2 (HOCON.md L732): `a += b` is sugar for `a = ${?a} [b]`. The

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -572,9 +572,28 @@ impl<'a> SubstitutionResolver<'a> {
             .unwrap_or_else(|| HoconValue::Array(vec![]));
         let elem = self.resolve_val(&a.elem, scope)?;
 
+        // S13b.2 (HOCON.md L732): `a += b` is sugar for `a = ${?a} [b]`. The
+        // prior value must be an array (or absent → empty array fallback). A
+        // non-array prior must produce a resolve-time error. Previously the
+        // resolver silently wrapped the non-array as a single-element array.
         let mut items: Vec<HoconValue> = match existing {
             HoconValue::Array(arr) => arr,
-            other => vec![other],
+            other => {
+                return Err(ResolveError {
+                    message: format!(
+                        "'+=' on non-array value: prior value is {} (spec L732)",
+                        match other {
+                            HoconValue::Object(_) => "object",
+                            HoconValue::Scalar(_) => "scalar",
+                            HoconValue::Placeholder(_) => "placeholder",
+                            HoconValue::Array(_) => unreachable!(),
+                        },
+                    ),
+                    path: String::new(),
+                    line: 0,
+                    col: 0,
+                });
+            }
         };
         if let Some(e) = elem {
             items.push(e);

--- a/src/resolver/types.rs
+++ b/src/resolver/types.rs
@@ -127,6 +127,11 @@ pub struct ConcatPlaceholder {
 pub struct AppendPlaceholder {
     pub existing: Box<ResolverValue>,
     pub elem: Box<ResolverValue>,
+    /// Source position of the `+=` field — populated by the structure
+    /// builder so resolve-time errors (e.g. S13b.2 non-array prior) can
+    /// report a useful location instead of `0:0`.
+    pub line: usize,
+    pub col: usize,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1008,23 +1008,10 @@ fn s12_5_include_as_key_spec() {
 }
 
 // --- S13b.2: `+=` on non-array prior value → error (HOCON L732) -------------
+// Fixed in #72: resolver previously wrapped the non-array as a single-element
+// array; now errors as the spec mandates.
 #[test]
-fn s13b_2_plus_eq_on_non_array_pin() {
-    // BUG: `a = 42 \n a += 1` should error because prior value is a number not an array.
-    // Currently rs.hocon silently produces Array([42, 1]).
-    assert!(
-        parse("a = 42\na += 1").is_ok(),
-        "[pin] += on non-array currently accepted — update when fixed"
-    );
-    assert!(
-        parse("a = \"str\"\na += 1").is_ok(),
-        "[pin] += on string currently accepted — update when fixed"
-    );
-}
-
-#[test]
-#[ignore = "spec violation: += on non-array prior value must error per HOCON L732, see #72"]
-fn s13b_2_plus_eq_on_non_array_spec() {
+fn s13b_2_plus_eq_on_non_array_errors() {
     assert!(
         parse("a = 42\na += 1").is_err(),
         "+= on numeric prior value must be a resolve-time error per HOCON L732"
@@ -1032,6 +1019,14 @@ fn s13b_2_plus_eq_on_non_array_spec() {
     assert!(
         parse("a = \"str\"\na += 1").is_err(),
         "+= on string prior value must be a resolve-time error per HOCON L732"
+    );
+}
+
+#[test]
+fn s13b_2_plus_eq_on_object_errors() {
+    assert!(
+        parse("a = { x = 1 }\na += 1").is_err(),
+        "+= on object prior value must be a resolve-time error per HOCON L732"
     );
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1030,6 +1030,36 @@ fn s13b_2_plus_eq_on_object_errors() {
     );
 }
 
+#[test]
+fn s13b_2_plus_eq_under_allow_unresolved_defers_on_unresolved_prior() {
+    // Codex P2 cross-impl finding: when allow_unresolved=true and the prior
+    // value of an appended key is itself an unresolved Placeholder (e.g.
+    // `x = ${missing}\nx += 1`), the S13b.2 non-array check must NOT fire —
+    // the append should defer for later resolution. Pre-fix this raised
+    // "'+=' on non-array value: prior value is placeholder (spec L732)".
+    use hocon::{parse_string_with_options, ParseOptions, ResolveOptions};
+    let cfg = parse_string_with_options(
+        "x = ${missing}\nx += 1",
+        ParseOptions::defaults().with_resolve_substitutions(false),
+    )
+    .expect("parse should succeed without resolution");
+    let resolved = cfg
+        .resolve(
+            ResolveOptions::defaults()
+                .with_allow_unresolved(true)
+                .with_use_system_environment(false),
+        )
+        .expect("allow_unresolved must defer, not error");
+    assert!(
+        !resolved.is_resolved(),
+        "result must remain unresolved (x's prior was unresolved)"
+    );
+    assert!(
+        resolved.get_string("x").is_err(),
+        "getter on unresolved path must error (NotResolved)"
+    );
+}
+
 // =============================================================================
 // Spec compliance Phase 3 (issue #73): substitution & include coverage (12 items)
 // S13.3, S13.5, S13.9, S13.13, S13.14, S13.16, S13a.10, S13a.13,


### PR DESCRIPTION
## Summary

Closes [#72](https://github.com/o3co/rs.hocon/issues/72). HOCON spec L732 mandates that \`a += b\` is sugar for \`a = \${?a} [b]\`, and if the prior value of \`a\` is not an array, the merge must fail. rs.hocon silently wrapped non-array priors as single-element arrays.

## Changes

- \`src/resolver/substitution_resolver.rs\` — \`resolve_append\` returns \`ResolveError\` when \`existing\` is not an Array.
- \`tests/integration_test.rs\` — \`s13b_2_plus_eq_on_non_array_pin\` (which asserted the buggy \`is_ok\`) + \`#[ignore]\`-d \`s13b_2_plus_eq_on_non_array_spec\` collapsed into a single positive \`s13b_2_plus_eq_on_non_array_errors\` test; object-prior case added.
- \`CHANGELOG.md\` — Unreleased / Fixed entry.

## Semver

Spec-compliance fix; not a breaking change under the doctrine for libraries implementing external specs.

## Test plan

- [x] \`cargo test\` — full suite green (no FAILED)
- [ ] Maintainer: confirm CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)