### PR TITLE
fix(resolver): null in config blocks env fallback for ${?} per S13.9 (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`get_string()` on a null-typed scalar now errors instead of returning `Ok("null")`** ([#80](https://github.com/o3co/rs.hocon/issues/80)). Per HOCON spec L1252, "if the application asks for a specific type and finds null instead, that should usually result in an error" — including `String`. Previously `get_i64` and `get_bool` on null correctly errored but `get_string` returned the raw `"null"` literal. The fix adds a `ScalarType::Null` guard at the top of `get_string`, matching the existing behaviour of the other typed getters.
 
+### Fixed — S13.9 spec compliance
+
+- **`null` in config blocks env-var fallback for optional substitutions** ([#74](https://github.com/o3co/rs.hocon/issues/74)). Per HOCON spec L618, "if the same variable is set in the config and in the environment, the config value wins"; for an optional substitution `${?key}` whose config value is null, the null is treated as "not present" and the parent field is dropped. Previously `rs.hocon` blocked the env-var fallback but still yielded `Scalar(null)`, so the field remained present with a null value. Required substitutions are unchanged — `${HOME}` against `HOME = null` still yields the explicit null scalar (the getter layer applies S17.6 coercion).
+
 ## [1.4.1] - 2026-05-22
 
 Cross-impl bugfix release: addresses [go.hocon#105](https://github.com/o3co/go.hocon/issues/105) (cgordon-reported Lightbend divergence on empty/comment-only includes) at the rs.hocon layer, and pins go.hocon#106 (include-ordering / self-ref-through-include) which already worked correctly here. Pure include-path behaviour; no public API changes; safe drop-in upgrade from v1.4.0.

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -288,6 +288,23 @@ impl<'a> SubstitutionResolver<'a> {
             }
             let mut result = self.resolve_val(&found, scope)?;
 
+            // S13.9 (HOCON.md L618): an optional substitution `${?key}` whose
+            // config value is null treats the null as "not present" — the
+            // field is dropped. The env-var fallback is still suppressed
+            // (config wins over env) because we already found a value in the
+            // config tree above; this guard converts that found-null into a
+            // dropped field for optional substitutions. Required substitutions
+            // still yield the null scalar so an explicit `${HOME}` against
+            // `HOME = null` produces a typed-coercion error at the getter
+            // layer (S17.6).
+            if s.optional {
+                if let Some(HoconValue::Scalar(ref sv)) = result {
+                    if sv.value_type == crate::value::ScalarType::Null {
+                        return Ok(None);
+                    }
+                }
+            }
+
             // Delayed merge: if the resolved value is an Object and there is a prior
             // value for the root segment, resolve the prior and deep merge underneath.
             // Only apply for single-segment paths; for multi-segment paths (e.g. foo.bar),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1114,8 +1114,8 @@ fn s13_9_required_substitution_to_null_yields_null() {
     // optional-substitution drop). The getter layer applies S17.6 coercion.
     let mut env = std::collections::HashMap::new();
     env.insert("HOME".to_string(), "/x/y".to_string());
-    let cfg = hocon::parse_with_env("HOME = null\nresult = ${HOME}", &env)
-        .expect("parse should succeed");
+    let cfg =
+        hocon::parse_with_env("HOME = null\nresult = ${HOME}", &env).expect("parse should succeed");
     let v = cfg
         .get("result")
         .expect("required substitution must yield a value");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1090,36 +1090,13 @@ fn s13_5_no_subst_in_quoted_string() {
 }
 
 // --- S13.9: `null` in config blocks env var lookup (spec L618) ------------------
-// Spec: if the config tree has `key = null`, an optional substitution `${?key}`
-// must NOT fall back to the environment; the explicit null takes precedence.
-// BUG: rs.hocon currently falls through to the env var.
+// Fixed in #74: optional substitution `${?key}` against a config-null value
+// now drops the field instead of yielding Scalar(null). Env-var fallback is
+// suppressed (config wins) and the null is treated as "not present" per the
+// optional-substitution semantics. Required substitutions still yield the
+// null scalar (so the getter layer can apply S17.6 type-coercion error).
 #[test]
-fn s13_9_null_blocks_env_var_lookup_pin() {
-    // [pin] Current behaviour: rs.hocon does NOT leak the env value, but it
-    // also does NOT treat null-as-missing (which would erase the field per
-    // L618). Instead it resolves ${?HOME} to the explicit null scalar, so
-    // `result` ends up present with value null. The spec wants the field
-    // absent. Pinning the exact Some(Scalar(null)) shape catches both
-    // (a) regression to env leak ("/x/y") and
-    // (b) accidental progress to None (which the spec test would then catch).
-    let mut env = std::collections::HashMap::new();
-    env.insert("HOME".to_string(), "/x/y".to_string());
-    let cfg = hocon::parse_with_env("HOME = null\nresult = ${?HOME}", &env)
-        .expect("parse should succeed");
-    let v = cfg.get("result").expect("[pin] result must be present");
-    match v {
-        hocon::HoconValue::Scalar(s) => assert_eq!(
-            s.value_type,
-            hocon::ScalarType::Null,
-            "[pin] result must be the explicit null scalar — env value must not leak"
-        ),
-        other => panic!("[pin] result must be a null scalar, got {:?}", other),
-    }
-}
-
-#[test]
-#[ignore = "spec violation: null in config must block env fallback per HOCON L618, see #74"]
-fn s13_9_null_blocks_env_var_lookup_spec() {
+fn s13_9_null_blocks_env_var_lookup() {
     let mut env = std::collections::HashMap::new();
     env.insert("HOME".to_string(), "/x/y".to_string());
     let cfg = hocon::parse_with_env("HOME = null\nresult = ${?HOME}", &env)
@@ -1128,6 +1105,28 @@ fn s13_9_null_blocks_env_var_lookup_spec() {
         cfg.get("result").is_none(),
         "null in config must block env var fallback; result must be absent per HOCON L618"
     );
+}
+
+#[test]
+fn s13_9_required_substitution_to_null_yields_null() {
+    // Cross-check: a required substitution ${HOME} against `HOME = null` must
+    // still yield the explicit null scalar (it is not subject to the
+    // optional-substitution drop). The getter layer applies S17.6 coercion.
+    let mut env = std::collections::HashMap::new();
+    env.insert("HOME".to_string(), "/x/y".to_string());
+    let cfg = hocon::parse_with_env("HOME = null\nresult = ${HOME}", &env)
+        .expect("parse should succeed");
+    let v = cfg
+        .get("result")
+        .expect("required substitution must yield a value");
+    match v {
+        hocon::HoconValue::Scalar(s) => assert_eq!(
+            s.value_type,
+            hocon::ScalarType::Null,
+            "required ${{HOME}} against null config must yield null scalar — env value must not leak",
+        ),
+        other => panic!("expected null scalar, got {:?}", other),
+    }
 }
 
 // --- S13.13: optional undefined in string concat → empty string (spec L636) -----


### PR DESCRIPTION
## Summary

Closes [#74](https://github.com/o3co/rs.hocon/issues/74). Per HOCON spec L618, an optional substitution \`\${?key}\` against a config value of \`null\` must treat the null as \"not present\" and drop the parent field. \`rs.hocon\` already suppressed the env-var fallback (config wins) but still yielded \`Scalar(null)\`, so the field remained present.

## Changes

- \`src/resolver/substitution_resolver.rs\` — \`resolve_subst_inner\` adds a null-drop guard after \`resolve_val(&found, scope)\` for optional substitutions. Required substitutions are unaffected.
- \`tests/integration_test.rs\` — \`s13_9_null_blocks_env_var_lookup_pin\` (buggy-behaviour pin) + \`#[ignore]\`-d \`s13_9_null_blocks_env_var_lookup_spec\` collapsed into \`s13_9_null_blocks_env_var_lookup\` (positive). New \`s13_9_required_substitution_to_null_yields_null\` pins the asymmetry: required substitutions still yield the null scalar so the getter layer can apply S17.6.
- \`CHANGELOG.md\` — Unreleased / Fixed entry.

## Semver

Spec-compliance fix; not a breaking change under the doctrine for libraries implementing external specs.

## Test plan

- [x] \`cargo test\` — full suite green
- [ ] Maintainer: confirm CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)