### PR TITLE
docs(changelog): correct v1.4.0 E12 cross-reference (#99 → go.hocon#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Cross-impl bugfix release: addresses [go.hocon#105](https://github.com/o3co/go.h
 This release adds the Lightbend-aligned `parse_string_with_options` →
 `with_fallback` → `resolve()` lifecycle. Existing `parse` / `parse_file`
 behaviour is unchanged (still parse-and-resolve in one call); the new API
-surface is purely additive. Requested by [@cgordon](https://github.com/cgordon) (see [go.hocon#99](https://github.com/o3co/go.hocon/issues/99) — the cross-impl ask landed in the go.hocon issue tracker; ts.hocon/rs.hocon issues numbered 99 are unrelated CI PRs).
+surface is purely additive. Requested by [@cgordon](https://github.com/cgordon) (see [go.hocon#99](https://github.com/o3co/go.hocon/issues/99) — the cross-impl ask landed in the go.hocon issue tracker; ts.hocon/rs.hocon PRs numbered 99 are unrelated CI PRs).
 
 **New entry points:**
 - `parse_string_with_options(input, ParseOptions)` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,12 @@ Cross-impl bugfix release: addresses [go.hocon#105](https://github.com/o3co/go.h
 
 ## [1.4.0] - 2026-05-21
 
-### Added — E12 deferred substitution resolution (closes [#99](https://github.com/o3co/rs.hocon/issues/99))
+### Added — E12 deferred substitution resolution (external request via [go.hocon#99](https://github.com/o3co/go.hocon/issues/99))
 
 This release adds the Lightbend-aligned `parse_string_with_options` →
 `with_fallback` → `resolve()` lifecycle. Existing `parse` / `parse_file`
 behaviour is unchanged (still parse-and-resolve in one call); the new API
-surface is purely additive. Closes [#99](https://github.com/o3co/rs.hocon/issues/99)
-(requested by [@cgordon](https://github.com/cgordon)).
+surface is purely additive. Requested by [@cgordon](https://github.com/cgordon) (see [go.hocon#99](https://github.com/o3co/go.hocon/issues/99) — the cross-impl ask landed in the go.hocon issue tracker; ts.hocon/rs.hocon issues numbered 99 are unrelated CI PRs).
 
 **New entry points:**
 - `parse_string_with_options(input, ParseOptions)` and


### PR DESCRIPTION
## Summary

The v1.4.0 CHANGELOG cited `closes [#99]` (twice) linking to rs.hocon#99, but [rs.hocon#99](https://github.com/o3co/rs.hocon/pull/99) is actually `ci(release): add make testdata before Test — fixes v1.2.0 publish`, **NOT** the cgordon E12 request. The actual external request issue is [go.hocon#99](https://github.com/o3co/go.hocon/issues/99), filed by @cgordon in the go.hocon tracker as the cross-impl ask landing site.

## Change

- Heading citation: `(closes [#99](.../rs.hocon/issues/99))` → `(external request via [go.hocon#99](.../go.hocon/issues/99))`
- Body sentence: `Closes [#99](.../rs.hocon/issues/99) (requested by @cgordon).` → `Requested by [@cgordon](https://github.com/cgordon) (see [go.hocon#99](.../go.hocon/issues/99) — the cross-impl ask landed in the go.hocon issue tracker; ts.hocon/rs.hocon issues numbered 99 are unrelated CI PRs).`

## Impact

- git tag `v1.4.0` and the crates.io package `hocon-parser/1.4.0` are unaffected — this is a CHANGELOG.md historical correction only.
- No code change.

## Test plan

- [ ] Verify the new go.hocon#99 links resolve correctly
- [ ] Confirm no other `#99`-style refs in CHANGELOG.md need similar correction (`grep '#99' CHANGELOG.md` showed only the two fixed locations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)