### PR TITLE
fix(parser): accept unquoted space-concat in field keys per S10.8 (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — S10.8 spec compliance
+
+- **Unquoted space-concat in field keys now accepted as a single key** ([#66](https://github.com/o3co/rs.hocon/issues/66)). Per HOCON spec L317 ("string value concatenation is allowed in field keys") and L553-560 (`a b c : 42` is equivalent to `"a b c" : 42`), space-separated unquoted tokens before the `:`/`=`/`{`/`+=` separator must merge into a single key. Previously `foo bar = 1` errored with `unexpected token after key: Unquoted`; now it parses as key `"foo bar"`. The fix extends `parse_key` in `src/parser.rs` with a space-concat continuation branch: when the next key token has `preceding_space`, the first dot-split piece merges into the LAST existing segment with a literal space; any remaining dot-split pieces become new path segments. Quoted+unquoted mixed concat (`"foo bar" baz = 1`) and inline-object shorthand (`a b { x = 1 }`) work transitively. A leading `.` in the spaced-in token still acts as a path separator per S11.1, not a literal: `a .b = 1` → `["a", "b"]` and `a.b .c = 1` → `["a", "b", "c"]` (the leading dot is NOT folded into the previous segment). Cross-impl with [ts.hocon PR #128](https://github.com/o3co/ts.hocon/pull/128).
+
 ### Fixed — S17.6 spec compliance
 
 - **`get_string()` on a null-typed scalar now errors instead of returning `Ok("null")`** ([#80](https://github.com/o3co/rs.hocon/issues/80)). Per HOCON spec L1252, "if the application asks for a specific type and finds null instead, that should usually result in an error" — including `String`. Previously `get_i64` and `get_bool` on null correctly errored but `get_string` returned the raw `"null"` literal. The fix adds a `ScalarType::Null` guard at the top of `get_string`, matching the existing behaviour of the other typed getters.

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -218,8 +218,8 @@ same item descriptions verbatim.
   tests: tests/integration_test.rs:689 (s10_7_concat_does_not_span_newline)
   status: ✅
 - **S10.8** String concat allowed in field keys — §Value concatenation (L317)
-  tests: tests/integration_test.rs:711 (s10_8_quoted_key_with_space_allowed); tests/integration_test.rs:722 (s10_8_unquoted_space_key_pin); tests/integration_test.rs:733 (s10_8_unquoted_space_key_spec)
-  status: ⚠️ quoted form ✅; unquoted space-concat key ❌ (see #66)
+  tests: tests/integration_test.rs (s10_8_* it blocks: quoted, basic, three-token, dotted-prefix concat, dotted-tail concat, quoted+unquoted, inline-object shorthand, leading-dot + S11.1 interaction, tab whitespace)
+  status: ✅ — fixed in #66; `parse_key` accepts space-concat continuations and merges into the LAST segment with literal space. Leading '.' after whitespace stays a path separator per S11.1.
 - **S10.9** `true`/`false` stringify to `"true"`/`"false"` in concat — §String value concatenation (L363)
   tests: tests/testdata/hocon/equiv01/unquoted.conf (fixture)
   status: ✅

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -218,7 +218,7 @@ same item descriptions verbatim.
   tests: tests/integration_test.rs:689 (s10_7_concat_does_not_span_newline)
   status: ✅
 - **S10.8** String concat allowed in field keys — §Value concatenation (L317)
-  tests: tests/integration_test.rs (s10_8_* it blocks: quoted, basic, three-token, dotted-prefix concat, dotted-tail concat, quoted+unquoted, inline-object shorthand, leading-dot + S11.1 interaction, tab whitespace)
+  tests: tests/integration_test.rs (s10_8_* tests: quoted, basic, three-token, dotted-prefix concat, dotted-tail concat, quoted+unquoted, inline-object shorthand, leading-dot + S11.1 interaction, tab whitespace)
   status: ✅ — fixed in #66; `parse_key` accepts space-concat continuations and merges into the LAST segment with literal space. Leading '.' after whitespace stays a path separator per S11.1.
 - **S10.9** `true`/`false` stringify to `"true"`/`"false"` in concat — §String value concatenation (L363)
   tests: tests/testdata/hocon/equiv01/unquoted.conf (fixture)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -305,13 +305,32 @@ impl<'a> Parser<'a> {
     fn parse_key(&mut self) -> Result<Vec<String>, ParseError> {
         let mut segments: Vec<String> = Vec::new();
         let mut trailing_dot;
+        // S10.8 (HOCON.md L317 + L553-560): "path expressions work like value
+        // concatenations" — when the next key token has whitespace before it
+        // (and is not a dot-continuation), it is a space-concat continuation
+        // that merges into the LAST existing segment with a literal space:
+        //   `a b = 1`     → key ['a b']
+        //   `a b c : 42`  → key ['a b c']        (spec L556 example)
+        //   `a.b c = 1`   → key ['a', 'b c']     (concat into last segment)
+        //   `"a" b = 1`   → key ['a b']          (quoted + unquoted)
+        //   `a .b = 1`    → key ['a', 'b']       (leading '.' stays a separator
+        //                                         per S11.1, not folded)
+        // Newlines break the chain (S10.7): the lexer emits a Newline token
+        // which falls through to the loop's else branch and exits.
+        let mut space_concat = false;
 
         loop {
             let kind = self.peek_kind();
             if kind == TokenKind::QuotedString {
                 let val = self.peek_value().to_string();
                 self.advance();
-                segments.push(val); // quoted: no dot split
+                if space_concat && !segments.is_empty() {
+                    let last_idx = segments.len() - 1;
+                    segments[last_idx].push(' ');
+                    segments[last_idx].push_str(&val);
+                } else {
+                    segments.push(val); // quoted: no dot split
+                }
                 trailing_dot = false;
             } else if kind == TokenKind::Unquoted {
                 let val = self.peek_value().to_string();
@@ -321,6 +340,7 @@ impl<'a> Parser<'a> {
                 // Split unquoted key at dots, tracking the char offset of each
                 // segment within the original raw token so S8.6 errors below
                 // can point at the offending segment, not the token start.
+                let mut new_segments: Vec<String> = Vec::new();
                 let mut seg_char_offset: usize = 0;
                 for part in val.split('.') {
                     if !part.is_empty() {
@@ -356,12 +376,36 @@ impl<'a> Parser<'a> {
                                 });
                             }
                         }
-                        segments.push(part.to_string());
+                        new_segments.push(part.to_string());
                     }
                     // Advance offset past this segment + its trailing '.' separator
                     // (the '.' is consumed by split; account for it by adding 1
                     // unless this is the last segment).
                     seg_char_offset += part.chars().count() + 1;
+                }
+                if space_concat && !new_segments.is_empty() && !segments.is_empty() {
+                    // S10.8 + S11.1 interaction: if the spaced-in token starts
+                    // with '.', the leading '.' is a path separator that
+                    // survives the space — not a literal char to fold into
+                    // the previous segment.
+                    //   `a .b = 1`     → ['a', 'b']
+                    //   `a .b.c = 1`   → ['a', 'b', 'c']
+                    //   `"a" .b = 1`   → ['a', 'b']
+                    // Otherwise the first piece merges into the last existing
+                    // segment; any remaining dot-split pieces become new
+                    // path segments.
+                    if val.starts_with('.') {
+                        segments.extend(new_segments);
+                    } else {
+                        let mut iter = new_segments.into_iter();
+                        let head = iter.next().expect("checked !is_empty above");
+                        let last_idx = segments.len() - 1;
+                        segments[last_idx].push(' ');
+                        segments[last_idx].push_str(&head);
+                        segments.extend(iter);
+                    }
+                } else {
+                    segments.extend(new_segments);
                 }
                 trailing_dot = val.ends_with('.');
             } else {
@@ -376,6 +420,8 @@ impl<'a> Parser<'a> {
                 }
                 break;
             }
+            // The continuation we just took has been consumed.
+            space_concat = false;
 
             if trailing_dot {
                 continue;
@@ -394,6 +440,17 @@ impl<'a> Parser<'a> {
                 }
                 // For ".d"-style tokens, fall through to the next loop iteration
                 // which will split ".d" on '.' → ["", "d"] and push "d".
+                continue;
+            }
+
+            // S10.8 space-concat continuation: an unquoted-or-quoted token
+            // separated from the previous key token by whitespace is part of
+            // the same key.
+            let next_kind = self.peek_kind();
+            if (next_kind == TokenKind::Unquoted || next_kind == TokenKind::QuotedString)
+                && self.peek_preceding_space()
+            {
+                space_concat = true;
                 continue;
             }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -744,7 +744,7 @@ fn s10_7_concat_does_not_span_newline() {
 // --- S10.8: string concat allowed in field keys (HOCON L317) -----------------
 // Spec L553-560: path expressions work like value concatenations, so
 // `a b c : 42` is a single-element path with key "a b c". Both quoted and
-// unquoted space-separated forms must be accepted (#66 fixed in v1.5.0).
+// unquoted space-separated forms must be accepted (#66).
 #[test]
 fn s10_8_quoted_key_with_space_allowed() {
     // A quoted string with spaces as a key is unambiguous and must be accepted.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -743,8 +743,8 @@ fn s10_7_concat_does_not_span_newline() {
 
 // --- S10.8: string concat allowed in field keys (HOCON L317) -----------------
 // Spec L553-560: path expressions work like value concatenations, so
-// `a b c : 42` is a single-element path with key "a b c". ✅ for quoted keys;
-// unquoted space-separated keys are ❌.
+// `a b c : 42` is a single-element path with key "a b c". Both quoted and
+// unquoted space-separated forms must be accepted (#66 fixed in v1.5.0).
 #[test]
 fn s10_8_quoted_key_with_space_allowed() {
     // A quoted string with spaces as a key is unambiguous and must be accepted.
@@ -757,26 +757,100 @@ fn s10_8_quoted_key_with_space_allowed() {
 }
 
 #[test]
-fn s10_8_unquoted_space_key_pin() {
-    // BUG: `a b c : 42` (spec example L556) should set key "a b c".
-    // Currently rs.hocon rejects this as a parse error.
-    assert!(
-        parse("foo bar = 42").is_err(),
-        "[pin] unquoted space-concat key currently rejected — update when fixed"
+fn s10_8_unquoted_space_key_basic() {
+    // Basic 2-token unquoted space-concat key.
+    let cfg = parse("foo bar = 1").expect("parse must succeed per HOCON L317/L556");
+    assert_eq!(
+        cfg.get_i64("foo bar")
+            .expect("key 'foo bar' must exist per HOCON L317/L556"),
+        1,
+        "unquoted space-concat key must produce key 'foo bar' per HOCON L556"
     );
 }
 
 #[test]
-#[ignore = "spec violation: unquoted space-concat key `a b c` must be accepted per HOCON L317/L556, see #66"]
-fn s10_8_unquoted_space_key_spec() {
-    // Spec example (L556): `a b c : 42` is equivalent to `"a b c" : 42`
-    let cfg = parse("foo bar = 42").expect("parse must succeed per HOCON L317/L556");
+fn s10_8_unquoted_space_key_spec_three_token() {
+    // Spec example (L556): `a b c : 42` is equivalent to `"a b c" : 42`.
+    let cfg = parse("a b c : 42").expect("parse must succeed per HOCON L317/L556");
     assert_eq!(
-        cfg.get_i64("foo bar")
-            .expect("key 'foo bar' must exist per HOCON L556"),
+        cfg.get_i64("a b c")
+            .expect("key 'a b c' must exist per HOCON L556"),
         42,
-        "unquoted space-concat key must produce key 'foo bar' per HOCON L556"
+        "three-token space-concat key must produce key 'a b c' per HOCON L556"
     );
+}
+
+#[test]
+fn s10_8_space_concat_after_dotted_path() {
+    // `a.b c = 1` → ['a', 'b c']: concat merges into the LAST path segment.
+    let cfg = parse("a.b c = 1").unwrap();
+    assert_eq!(cfg.get_i64("a.\"b c\"").unwrap(), 1);
+}
+
+#[test]
+fn s10_8_space_concat_dotted_tail() {
+    // `a b.c = 1` → ['a b', 'c']: head merges, tail pushes as new segment.
+    let cfg = parse("a b.c = 1").unwrap();
+    assert_eq!(cfg.get_i64("\"a b\".c").unwrap(), 1);
+}
+
+#[test]
+fn s10_8_quoted_then_unquoted_space_concat() {
+    // `"foo bar" baz = 1` → ['foo bar baz'].
+    let cfg = parse("\"foo bar\" baz = 1").unwrap();
+    assert_eq!(cfg.get_i64("foo bar baz").unwrap(), 1);
+}
+
+#[test]
+fn s10_8_inline_object_shorthand() {
+    // `a b { x = 1 }` → key ['a b'], value the inline object.
+    let cfg = parse("a b { x = 1 }").unwrap();
+    assert_eq!(cfg.get_i64("\"a b\".x").unwrap(), 1);
+}
+
+#[test]
+fn s10_8_leading_dot_after_whitespace_stays_separator() {
+    // `a .b = 1` → ['a', 'b'] (NOT ['a b']). The leading '.' survives the space
+    // as a path separator per S11.1, not folded into the previous segment.
+    let cfg = parse("a .b = 1").unwrap();
+    assert_eq!(cfg.get_i64("a.b").unwrap(), 1);
+}
+
+#[test]
+fn s10_8_leading_dot_after_whitespace_multi_segment_tail() {
+    // `a .b.c = 1` → ['a', 'b', 'c'].
+    let cfg = parse("a .b.c = 1").unwrap();
+    assert_eq!(cfg.get_i64("a.b.c").unwrap(), 1);
+}
+
+#[test]
+fn s10_8_leading_dot_after_quoted_then_whitespace() {
+    // `"a" .b = 1` → ['a', 'b'].
+    let cfg = parse("\"a\" .b = 1").unwrap();
+    assert_eq!(cfg.get_i64("a.b").unwrap(), 1);
+}
+
+#[test]
+fn s10_8_dotted_path_then_whitespace_then_dot() {
+    // `a.b .c = 1` → ['a', 'b', 'c'] (Copilot-flagged convergence case on ts).
+    let cfg = parse("a.b .c = 1").unwrap();
+    assert_eq!(cfg.get_i64("a.b.c").unwrap(), 1);
+}
+
+#[test]
+fn s10_8_quoted_dotted_path_then_whitespace_then_dot() {
+    // `"a.b" .c = 1` → ['a.b', 'c']: the literal 'a.b' segment is preserved
+    // (quoted keys do NOT path-split), and `.c` becomes a sibling segment.
+    let cfg = parse("\"a.b\" .c = 1").unwrap();
+    assert_eq!(cfg.get_i64("\"a.b\".c").unwrap(), 1);
+}
+
+#[test]
+fn s10_8_tab_between_key_tokens_is_space_concat() {
+    // `precedingSpace` covers any HOCON whitespace; the merge joiner is
+    // canonical U+0020 (per S10.6 whitespace normalisation).
+    let cfg = parse("a\tb = 1").unwrap();
+    assert_eq!(cfg.get_i64("\"a b\"").unwrap(), 1);
 }
 
 // --- S10.13: array/object in string concat → error (HOCON L373) --------------


### PR DESCRIPTION
## Summary

- Implements S10.8 (HOCON spec L317 + L553-560) — `foo bar = 1` now parses as key `"foo bar"` instead of erroring with `unexpected token after key: Unquoted`.
- `parse_key` gains a space-concat continuation branch via a `space_concat` flag: when the next key token has `preceding_space=true`, the first dot-split piece merges into the LAST existing segment with a literal space; any remaining pieces become new path segments.
- Leading '.' after whitespace stays a path separator per S11.1 (e.g. `a .b` → `["a", "b"]`, NOT `["a b"]`). This edge case was flagged on the ts.hocon companion PR by Claude + Codex + Copilot independent review (3-way convergence); the rs port preserves the same semantics.
- 12 regression tests pin: basic 2-token, 3-token spec L556 example, dotted-prefix + dotted-tail concat, quoted+unquoted concat, inline-object shorthand, all 4 leading-dot edge cases, and tab whitespace.

## Behaviour examples (all pinned by tests)

| Input | Key (post-fix) |
|---|---|
| `foo bar = 1` | `"foo bar"` |
| `a b c : 42` | `"a b c"` (spec L556) |
| `a.b c = 1` | `["a", "b c"]` |
| `a b.c = 1` | `["a b", "c"]` |
| `"foo bar" baz = 1` | `"foo bar baz"` |
| `a b { x = 1 }` | key `"a b"`, value the inline object |
| `a .b = 1` | `["a", "b"]` (leading dot stays separator per S11.1) |
| `a .b.c = 1` | `["a", "b", "c"]` |
| `"a" .b = 1` | `["a", "b"]` |
| `a.b .c = 1` | `["a", "b", "c"]` |
| `"a.b" .c = 1` | `["a.b", "c"]` |
| `a\tb = 1` | `"a b"` (tab counts as whitespace) |

## Cross-impl

- [x] ts.hocon [#128](https://github.com/o3co/ts.hocon/pull/128) — MERGED
- [ ] **this PR (rs.hocon #66)**
- [ ] go.hocon #65 — pending after this lands

xx.hocon compliance-matrix update will be a separate PR after all 3 impls ship.

Closes #66.

## Test plan

- [x] `cargo test --workspace` — all 38 test binaries pass (122 integration tests including 13 S10.8)
- [x] `cargo test --workspace --features serde` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] No regression on existing key tests (`a.b = 1`, `"a.b" = 1`, `a."b.c".d = 1`, `a. b` trailing-dot continuation)
- [x] Value-position concat (`x = foo bar`) unaffected — change is localised to `parse_key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)