### PR TITLE
feat(resolver): S14c.2 config-path fallback for relativized substitutions (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — S14c.2 config path fallback for relativized substitutions
+
+- **Substitutions inside included files now fall back to the original (non-relativized) config path when the relativized path misses** ([#44](https://github.com/o3co/rs.hocon/issues/44)). Per the Lightbend reference implementation's "resolve against the fully merged tree" behaviour, an included file's `${y}` reference must see `y` defined at an ancestor scope even after relativization rewrites the substitution to `${prefix.y}`. Previously only env-var fallback honoured the original path; config-path lookup tried only the relativized form, so `${y}` inside an included file mounted at `bar { include "..." }` errored as "could not resolve substitution: ${bar.y}" when `y` only existed at root. The fix in `resolve_subst_inner` adds a `lookup_path(self.root, &s.segments[s.prefix_len..])` fallback after the relativized lookup misses and before env-var fallback — so the relativized path still wins when both exist, and env-vars still take precedence over a non-existent original path. Pinned by 4 new tests in `tests/include_test.rs` (`s14c_2_*`).
+
 ### Performance — resolver clone reduction
 
 - **`deep_merge_hocon_objects` no longer clones the existing subtree or the overlay's `new_fields` on each recursive call** ([#23](https://github.com/o3co/rs.hocon/issues/23)). The pre-fix `(merged.get(&k).cloned(), &v)` shape produced O(N²) work for an N-deep nested object merge because every level deep-cloned the subtree below it. The refactor peeks at types by reference (`matches!`), then takes ownership of the existing inner `IndexMap` via `mem::take` and consumes `v` directly — both clones eliminated. Observable behaviour (overlay-wins on scalars/arrays, deep-merge on object/object, IndexMap position preserved on existing-key updates) is unchanged and pinned by 6 new unit tests in `src/resolver/utils.rs`.

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -503,8 +503,8 @@ same item descriptions verbatim.
   tests: tests/include_test.rs:74 (include_relativize_quoted_key_with_dots); tests/integration_test.rs:510 (nested_include_resolves_substitutions_in_scope); tests/lightbend_test.rs:316 (lightbend_test10_nested_include)
   status: ✅
 - **S14c.2** Original (non-relativized) path also tried as fallback — §Include semantics: substitution (L1048)
-  tests: tests/lightbend_test.rs:221 (lightbend_test03_includes_with_substitution_fallback)
-  status: ❌ ([#44](https://github.com/o3co/rs.hocon/issues/44)) — non-relativized fallback is not implemented; the cited test is written to accept either success or a substitution error, so passing the test does not prove correctness
+  tests: tests/lightbend_test.rs:221 (lightbend_test03_includes_with_substitution_fallback); tests/include_test.rs (s14c_2_ancestor_scope_var_fallback_after_relativization, s14c_2_relativized_path_still_wins_when_both_exist, s14c_2_optional_substitution_falls_back_to_original, s14c_2_neither_path_resolves_still_errors)
+  status: ✅ — fixed in [#44](https://github.com/o3co/rs.hocon/issues/44); `resolve_subst_inner` falls back to `lookup_path(self.root, &s.segments[s.prefix_len..])` after the relativized lookup misses and before env-var fallback.
 
 ### S14d. Include semantics: missing / required
 

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -331,10 +331,39 @@ impl<'a> SubstitutionResolver<'a> {
         // still wins when both exist. Tried BEFORE env-var fallback so config
         // values take precedence over env vars (matching the primary-lookup
         // ordering).
+        //
+        // Delayed-merge mirror: when the fallback resolves to an `Object` AND the
+        // original path is single-segment AND the root has a prior value for that
+        // segment, deep-merge prior + current — same rule the primary lookup
+        // applies (see lines 295-313 above). Without this, a config like
+        // `y = { a = 1 }; y = ${z}; z = { b = 2 }; bar { include "..." }` where
+        // the included file does `ref = ${y}` would yield `bar.ref = { b = 2 }`
+        // via the fallback while `y` at root would yield `{ a = 1, b = 2 }` —
+        // a silent divergence. See Codex review on PR #117 for the reproducer.
         if s.prefix_len > 0 && s.segments.len() > s.prefix_len {
             let original_segments = &s.segments[s.prefix_len..];
             if let Some(fallback_found) = lookup_path(self.root, original_segments).cloned() {
-                let result = self.resolve_val(&fallback_found, scope)?;
+                let mut result = self.resolve_val(&fallback_found, scope)?;
+
+                if original_segments.len() == 1 {
+                    if let Some(HoconValue::Object(ref current_fields)) = result {
+                        let root_seg = original_segments
+                            .first()
+                            .map(|s| s.text.as_str())
+                            .unwrap_or("");
+                        let prior = self.root.prior_values.get(root_seg).cloned();
+                        if let Some(prior) = prior {
+                            if let Some(HoconValue::Object(prior_fields)) =
+                                self.resolve_val(&prior, scope)?
+                            {
+                                let merged =
+                                    deep_merge_hocon_objects(prior_fields, current_fields.clone());
+                                result = Some(merged);
+                            }
+                        }
+                    }
+                }
+
                 if let Some(ref r) = result {
                     self.cache.insert(key.to_string(), r.clone());
                 }

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -319,6 +319,29 @@ impl<'a> SubstitutionResolver<'a> {
             return Ok(result);
         }
 
+        // S14c.2 (rs.hocon#44): config-path fallback for relativized substitutions.
+        //
+        // When a substitution inside an included file references an ancestor-scope
+        // variable that doesn't exist at the relativized path, try the ORIGINAL
+        // (non-relativized) path against the merged root. This matches Lightbend's
+        // "resolve against the fully merged tree" behaviour — included files see
+        // ancestor variables that don't exist at the include's prefix scope.
+        //
+        // Tried only after the relativized lookup misses, so the relativized path
+        // still wins when both exist. Tried BEFORE env-var fallback so config
+        // values take precedence over env vars (matching the primary-lookup
+        // ordering).
+        if s.prefix_len > 0 && s.segments.len() > s.prefix_len {
+            let original_segments = &s.segments[s.prefix_len..];
+            if let Some(fallback_found) = lookup_path(self.root, original_segments).cloned() {
+                let result = self.resolve_val(&fallback_found, scope)?;
+                if let Some(ref r) = result {
+                    self.cache.insert(key.to_string(), r.clone());
+                }
+                return Ok(result);
+            }
+        }
+
         // S13c: env-var list expansion — `${X[]}` / `${?X[]}`.
         // When list_suffix=true and config lookup missed, delegate entirely to
         // resolve_env_list. The scalar env fallback below is SUPPRESSED (S13c.5).

--- a/tests/include_test.rs
+++ b/tests/include_test.rs
@@ -228,6 +228,64 @@ bar {{ include "{}/ref.conf" }}
 }
 
 #[test]
+fn s14c_2_delayed_merge_preserved_via_fallback() {
+    // Regression for the Codex-flagged correctness bug on the original PR:
+    // when the fallback resolves to a single-segment root value that has a
+    // prior value (via reassignment-with-substitution), the delayed merge
+    // must still apply — otherwise included `${y}` would yield only the
+    // last reassignment and silently differ from a normal root `${y}` lookup.
+    //
+    // Setup:
+    //   y = { a = 1 }
+    //   y = ${z}          ← reassigns; primary lookup uses delayed merge
+    //   z = { b = 2 }
+    //   bar { include ref.conf }   # ref.conf: ref = ${y}
+    //
+    // Expected: bar.ref = { a = 1, b = 2 } (same as normal `y` would yield).
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("ref.conf"), "ref = ${y}\n").unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    let input = format!(
+        r#"y = {{ a = 1 }}
+y = ${{z}}
+z = {{ b = 2 }}
+bar {{ include "{}/ref.conf" }}
+"#,
+        dir_str
+    );
+    let config = hocon::parse(&input).unwrap();
+    // Baseline: normal y lookup carries the delayed merge.
+    assert_eq!(config.get_i64("y.a").unwrap(), 1);
+    assert_eq!(config.get_i64("y.b").unwrap(), 2);
+    // Fallback must yield the same merged shape.
+    assert_eq!(config.get_i64("bar.ref.a").unwrap(), 1);
+    assert_eq!(config.get_i64("bar.ref.b").unwrap(), 2);
+}
+
+#[test]
+fn s14c_2_multi_level_include_relativization_chain() {
+    // Pin the prefix_len accumulation in `relativize_subst_paths`:
+    // an include inside an include should still find an ancestor-scope
+    // variable via the fallback (the inner include's prefix is `outer.inner`).
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("inner.conf"), "ref = ${y}\n").unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(
+        dir.path().join("outer.conf"),
+        format!("inner {{ include \"{}/inner.conf\" }}\n", dir_str),
+    )
+    .unwrap();
+    let input = format!(
+        r#"y = "from-root"
+outer {{ include "{}/outer.conf" }}
+"#,
+        dir_str
+    );
+    let config = hocon::parse(&input).unwrap();
+    assert_eq!(config.get_string("outer.inner.ref").unwrap(), "from-root");
+}
+
+#[test]
 fn s14c_2_neither_path_resolves_still_errors() {
     let dir = tempdir().unwrap();
     // Neither relativized (bar.y) nor original (y) exists — must still error

--- a/tests/include_test.rs
+++ b/tests/include_test.rs
@@ -160,3 +160,86 @@ fn file_include_resolves_from_cwd_not_including_dir() {
     assert!(config.get_bool("bare_ok").unwrap());
     // file() with absolute path also found the child (child_key still 1)
 }
+
+// S14c.2 (rs.hocon#44): config-path fallback for relativized substitutions.
+//
+// When a substitution inside an included file references an ancestor-scope
+// variable that doesn't exist at the relativized path, resolution must fall
+// back to the original (non-relativized) path against the merged root —
+// matching Lightbend's "resolve against the fully merged tree" behaviour.
+//
+// Pre-fix: only env var fallback honoured the original path; config-path
+// fallback was missing, so `${y}` inside an included file relativized to
+// `${bar.y}` would fail when `y` only existed at root.
+
+#[test]
+fn s14c_2_ancestor_scope_var_fallback_after_relativization() {
+    let dir = tempdir().unwrap();
+    // child.conf references `y` which lives at the ROOT scope, not under the
+    // include's `bar` prefix. After relativization, `${y}` becomes `${bar.y}`,
+    // which doesn't exist — the fallback must try the original `${y}` path.
+    std::fs::write(dir.path().join("ref.conf"), "ref = ${y}\n").unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    let input = format!(
+        r#"y = "root-y"
+bar {{ include "{}/ref.conf" }}
+"#,
+        dir_str
+    );
+    let config = hocon::parse(&input).unwrap();
+    // bar.ref should resolve to "root-y" via the original-path fallback.
+    assert_eq!(config.get_string("bar.ref").unwrap(), "root-y");
+}
+
+#[test]
+fn s14c_2_relativized_path_still_wins_when_both_exist() {
+    let dir = tempdir().unwrap();
+    // Both `y` (root) and `bar.y` (relativized) exist. The relativized path
+    // takes precedence — this pins that the fallback does NOT shadow the
+    // primary lookup.
+    std::fs::write(dir.path().join("ref.conf"), "y = \"local-y\"\nref = ${y}\n").unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    let input = format!(
+        r#"y = "root-y"
+bar {{ include "{}/ref.conf" }}
+"#,
+        dir_str
+    );
+    let config = hocon::parse(&input).unwrap();
+    // bar.ref should see the relativized bar.y ("local-y"), not the root y.
+    assert_eq!(config.get_string("bar.ref").unwrap(), "local-y");
+    assert_eq!(config.get_string("y").unwrap(), "root-y");
+}
+
+#[test]
+fn s14c_2_optional_substitution_falls_back_to_original() {
+    let dir = tempdir().unwrap();
+    // Optional substitution form: `${?y}` — same fallback rule applies.
+    std::fs::write(dir.path().join("ref.conf"), "ref = ${?y}\n").unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    let input = format!(
+        r#"y = "from-root"
+bar {{ include "{}/ref.conf" }}
+"#,
+        dir_str
+    );
+    let config = hocon::parse(&input).unwrap();
+    assert_eq!(config.get_string("bar.ref").unwrap(), "from-root");
+}
+
+#[test]
+fn s14c_2_neither_path_resolves_still_errors() {
+    let dir = tempdir().unwrap();
+    // Neither relativized (bar.y) nor original (y) exists — must still error
+    // (mandatory substitution). This pins that the fallback doesn't mask
+    // legitimate "key not found" errors.
+    std::fs::write(dir.path().join("ref.conf"), "ref = ${y}\n").unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    let input = format!(r#"bar {{ include "{}/ref.conf" }}"#, dir_str);
+    let err = hocon::parse(&input).expect_err("expected resolve error");
+    assert!(
+        err.to_string().contains("y") || err.to_string().contains("resolve"),
+        "error should mention the missing key 'y' or resolution failure, got: {}",
+        err
+    );
+}

--- a/tests/lightbend_test.rs
+++ b/tests/lightbend_test.rs
@@ -220,30 +220,26 @@ fn lightbend_test02_empty_keys_and_quoted_paths() {
 
 #[test]
 fn lightbend_test03_includes_with_substitution_fallback() {
-    // test03.conf includes test01.conf inside a nested key, plus test03-included.conf.
-    // test01.conf contains ${ints.fortyTwo} which requires resolving within the
-    // include scope — this is a known limitation when included into a nested key.
+    // test03.conf includes test03-included.conf at root AND at `subtree`.
+    // The included file has `b = ${bar}` where `bar` is defined in the
+    // PARENT (test03.conf) at root level. Both inclusion points must
+    // resolve `b` to the same string via the S14c.2 original-path fallback
+    // (rs.hocon#44): at root no relativization is needed; at `subtree`
+    // the substitution gets rewritten to `${subtree.bar}` and the fallback
+    // strips the prefix to resolve against root `${bar}`.
     let path = testdata_dir().join("test03.conf");
-    let result = hocon::parse_file(&path);
-
-    match result {
-        Ok(config) => {
-            assert_eq!(config.get_i64("test01.booleans").unwrap(), 42);
-            assert_eq!(
-                config.get_string("b").unwrap(),
-                "This is in the including file"
-            );
-        }
-        Err(e) => {
-            let msg = e.to_string().to_lowercase();
-            assert!(
-                msg.contains("substitution"),
-                "unexpected parse error for {}: {}",
-                path.display(),
-                e
-            );
-        }
-    }
+    let config = hocon::parse_file(&path).unwrap();
+    assert_eq!(config.get_i64("test01.booleans").unwrap(), 42);
+    assert_eq!(
+        config.get_string("b").unwrap(),
+        "This is in the including file",
+        "root b = ${{bar}} uses parent's bar (root-level include — no relativization)"
+    );
+    assert_eq!(
+        config.get_string("subtree.b").unwrap(),
+        "This is in the including file",
+        "subtree.b = ${{bar}} relativized to ${{subtree.bar}} then fallback strips prefix to root ${{bar}} (S14c.2 / rs.hocon#44)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes [#44](https://github.com/o3co/rs.hocon/issues/44) — S14c.2 spec compliance gap.

Substitutions inside included files now fall back to the original (non-relativized) config path when the relativized lookup misses, matching Lightbend's "resolve against the fully merged tree" behaviour.

### Reproducer

```
y = \"root-y\"
bar { include \"ref.conf\" }
# ref.conf: ref = \${y}
```

| | Before | After |
|---|---|---|
| `bar.ref` | error: \"could not resolve substitution: \${bar.y}\" | `\"root-y\"` |

### Implementation

In `resolve_subst_inner` (`src/resolver/substitution_resolver.rs`), after the relativized lookup misses and before env-var fallback, try `lookup_path(self.root, &s.segments[s.prefix_len..])` — the prefix-stripped original path. Resolve and cache identically to the primary path.

### Ordering invariants preserved

- Relativized path still wins when both relativized and original exist
- Env-var fallback still applies when neither config path resolves
- Mandatory substitution still errors when neither path exists
- Optional substitution \`\${?y}\` honours the fallback

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — full suite passes
- [x] 4 new tests in `tests/include_test.rs` (`s14c_2_*`) — RED-then-GREEN verified
- [x] `docs/spec-compliance.md` S14c.2 row flipped ❌ → ✅
- [x] CHANGELOG entry under \`[Unreleased]\` → \`### Added — S14c.2 config path fallback\`

## Cross-impl

ts.hocon and go.hocon would benefit from a parity audit on S14c.2 — to be filed as a separate xx.hocon issue if the compliance-matrix doesn't already show their status. (rs.hocon's matrix row was the only ❌ on S14c.2.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)