### PR TITLE
release(v1.5.0): finalize CHANGELOG + bump Cargo to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-05-23
+
+Cross-impl spec-compliance + performance release with [go.hocon v1.5.0](https://github.com/o3co/go.hocon/releases/tag/v1.5.0) and [ts.hocon v1.5.0](https://github.com/o3co/ts.hocon/releases/tag/v1.5.0). One new feature ([#44](https://github.com/o3co/rs.hocon/issues/44), S14c.2 include-relativization fallback), two resolver perf wins ([#23](https://github.com/o3co/rs.hocon/issues/23), [#47](https://github.com/o3co/rs.hocon/issues/47)), three spec-compliance bugfixes ([#66](https://github.com/o3co/rs.hocon/issues/66), [#80](https://github.com/o3co/rs.hocon/issues/80), [#72](https://github.com/o3co/rs.hocon/issues/72)). No public API changes; safe drop-in upgrade from v1.4.1.
+
 ### Added — S14c.2 config path fallback for relativized substitutions
 
 - **Substitutions inside included files now fall back to the original (non-relativized) config path when the relativized path misses** ([#44](https://github.com/o3co/rs.hocon/issues/44)). Per the Lightbend reference implementation's "resolve against the fully merged tree" behaviour, an included file's `${y}` reference must see `y` defined at an ancestor scope even after relativization rewrites the substitution to `${prefix.y}`. Previously only env-var fallback honoured the original path; config-path lookup tried only the relativized form, so `${y}` inside an included file mounted at `bar { include "..." }` errored as "could not resolve substitution: ${bar.y}" when `y` only existed at root. The fix in `resolve_subst_inner` adds a `lookup_path(self.root, &s.segments[s.prefix_len..])` fallback after the relativized lookup misses and before env-var fallback — so the relativized path still wins when both exist, and env-vars still take precedence over a non-existent original path. Pinned by 4 new tests in `tests/include_test.rs` (`s14c_2_*`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hocon-parser"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "criterion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hocon-parser"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 rust-version = "1.82"
 description = "Full Lightbend HOCON specification-compliant parser for Rust"


### PR DESCRIPTION
## Summary

Cross-impl spec-compliance + performance release with go.hocon v1.5.0 and ts.hocon v1.5.0.

## Contents

- **Added** — S14c.2 config-path fallback for relativized substitutions ([#44](https://github.com/o3co/rs.hocon/issues/44))
- **Performance** — `deep_merge_hocon_objects` O(N²) → O(N) clone reduction ([#23](https://github.com/o3co/rs.hocon/issues/23)); `SubstitutionResolver::resolve` drops the unnecessary root clone ([#47](https://github.com/o3co/rs.hocon/issues/47))
- **Fixed** — S10.8 unquoted space-concat in field keys ([#66](https://github.com/o3co/rs.hocon/issues/66))
- **Fixed** — S17.6 `get_string()` on null errors ([#80](https://github.com/o3co/rs.hocon/issues/80))
- **Fixed** — S13b.2 `+=` on non-array prior errors ([#72](https://github.com/o3co/rs.hocon/issues/72))

## Diff

- `CHANGELOG.md` — `[Unreleased]` heading carved out, `## [1.5.0] - 2026-05-23` section with cross-impl preamble added above existing entries
- `Cargo.toml` — `version = "1.4.1"` → `"1.5.0"`

No public API changes; safe drop-in upgrade from v1.4.1.

## Test plan

- [x] CHANGELOG entries are the actual merged work since v1.4.1 (verified against `git log v1.4.1..HEAD --oneline`)
- [x] Cargo version bumped
- [x] No code changes — pure release prep

🤖 Generated with [Claude Code](https://claude.com/claude-code)