### PR TITLE
release(v1.5.2): relabel v1.5.1 → v1.5.2 to align with go.hocon v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.5.1] - 2026-05-23
+## [1.5.2] - 2026-05-23
 
-Cross-impl chained-self-referential-substitution fix coordinated with [go.hocon v1.5.2](https://github.com/o3co/go.hocon/releases/tag/v1.5.2). No public API changes; safe drop-in upgrade from v1.5.0.
+Cross-impl chained / value-interior self-referential substitution fix — version aligned with [go.hocon v1.5.2](https://github.com/o3co/go.hocon/releases/tag/v1.5.2) (which covers the same two bug classes: #118 + #120). No public API changes; safe drop-in upgrade from v1.5.0. (v1.5.1 was skipped to match the go.hocon version where the same fix scope landed.)
 
 ### Fixed — chained / value-interior self-referential substitution
 
@@ -138,8 +138,8 @@ Behaviour:
 
 - **CI: content-addressable testdata cache** (closes [#101](https://github.com/o3co/rs.hocon/issues/101)). `.github/workflows/test.yml` and `.github/workflows/publish.yml` previously used `actions/cache@v5` with `key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}`. The hash evaluated BEFORE the cache restore step ran, but `.xx-hocon-version` is gitignored and absent on fresh checkouts — so the key collapsed to a constant and cache entries shared the same slot. Split into `actions/cache/restore@v5` (matches via `restore-keys`) + `actions/cache/save@v5` (writes with the post-fetch hash, gated on `make testdata` success). No production code touched.
 
-[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.5.1...HEAD
-[1.5.1]: https://github.com/o3co/rs.hocon/compare/v1.5.0...v1.5.1
+[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.5.2...HEAD
+[1.5.2]: https://github.com/o3co/rs.hocon/compare/v1.5.0...v1.5.2
 [1.5.0]: https://github.com/o3co/rs.hocon/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/o3co/rs.hocon/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/o3co/rs.hocon/compare/v1.3.0...v1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.2] - 2026-05-23
 
-Cross-impl chained / value-interior self-referential substitution fix — version aligned with [go.hocon v1.5.2](https://github.com/o3co/go.hocon/releases/tag/v1.5.2) (which covers the same two bug classes: #118 + #120). No public API changes; safe drop-in upgrade from v1.5.0. (v1.5.1 was skipped to match the go.hocon version where the same fix scope landed.)
+Cross-impl chained / value-interior self-referential substitution fix — version aligned with [go.hocon v1.5.2](https://github.com/o3co/go.hocon/releases/tag/v1.5.2) (which covers the same two bug classes: [go.hocon#118](https://github.com/o3co/go.hocon/issues/118) + [go.hocon#120](https://github.com/o3co/go.hocon/issues/120)). No public API changes; safe drop-in upgrade from v1.5.0. (v1.5.1 was skipped to match the go.hocon version where the same fix scope landed.)
 
 ### Fixed — chained / value-interior self-referential substitution
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hocon-parser"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "criterion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hocon-parser"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 rust-version = "1.82"
 description = "Full Lightbend HOCON specification-compliant parser for Rust"


### PR DESCRIPTION
## Summary

Relabels the unreleased v1.5.1 prep as v1.5.2 to align with go.hocon's version. Since rs.hocon's #119 fix covered both bug classes (#118-equivalent chain + #120-equivalent value-interior) in a single PR, the appropriate cross-impl version is v1.5.2 (matching go.hocon, where v1.5.2 is the version that includes both fixes).

- CHANGELOG: `[1.5.1] - 2026-05-23` → `[1.5.2] - 2026-05-23` + link defs
- Cargo.toml: `1.5.1` → `1.5.2`
- Cargo.lock: regenerated

v1.5.1 was never tagged on GitHub, so this is a clean rename (no public release exists for v1.5.1).

## Test plan

- [x] cargo build clean at 1.5.2
- [ ] Merge → push tag v1.5.2 → GitHub Release workflow auto-publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)