### PR TITLE
fix(resolver): cluster 3h sr12-16 follow-ups (xx.hocon#27)

### DIFF
--- a/src/resolver/fold_self_ref.rs
+++ b/src/resolver/fold_self_ref.rs
@@ -35,7 +35,7 @@ use crate::lexer::Segment;
 /// wrapping shapes covered by the #118/#120 union).
 pub(crate) fn contains_self_ref(v: &ResolverValue, full_key: &str) -> bool {
     match v {
-        ResolverValue::Subst(sp) => subst_full_key(sp) == full_key,
+        ResolverValue::Subst(sp) => !sp.known_absent && subst_full_key(sp) == full_key,
         ResolverValue::Concat(c) => c.nodes.iter().any(|n| contains_self_ref(n, full_key)),
         ResolverValue::UnresolvedArray(elems) => {
             elems.iter().any(|e| contains_self_ref(e, full_key))
@@ -93,12 +93,12 @@ pub(crate) fn fold_self_ref(
 ///
 ///   * `prior` has no self-ref to `full_key`         → save as-is        → `Some(prior.clone())`
 ///   * `prior` has self-ref AND `old` is `Some(_)`   → fold against old  → `Some(folded)`
-///   * `prior` has self-ref AND `old` is `None`      → skip save         → `None`
+///   * optional self-ref AND `old` is `None`         → fold to absent    → `Some(folded)`
+///   * required self-ref AND `old` is `None`         → skip save         → `None`
 ///
-/// The skip case (no old prior to fold against) preserves the existing
-/// "self-referential substitution with no prior value" error path in
-/// `resolve_subst`. Callers must not write to `prior_values` when this
-/// returns `None`.
+/// The no-prior optional case preserves S13a.13's "optional self-ref with no
+/// prior resolves to undefined" rule while still saving the literal parts of
+/// a concat for the next overwrite (sr15: `${?a}1; ${?a}2` → `12`).
 pub(crate) fn fold_or_skip_prior(
     prior: &ResolverValue,
     full_key: &str,
@@ -107,7 +107,53 @@ pub(crate) fn fold_or_skip_prior(
     if !contains_self_ref(prior, full_key) {
         return Some(prior.clone());
     }
-    old.map(|o| fold_self_ref(prior, full_key, o))
+    if let Some(o) = old {
+        return Some(fold_self_ref(prior, full_key, o));
+    }
+    fold_optional_self_ref_absent(prior, full_key)
+}
+
+fn fold_optional_self_ref_absent(v: &ResolverValue, full_key: &str) -> Option<ResolverValue> {
+    match v {
+        ResolverValue::Subst(sp) if subst_full_key(sp) == full_key => {
+            if !sp.optional {
+                return None;
+            }
+            let mut absent = sp.clone();
+            absent.known_absent = true;
+            Some(ResolverValue::Subst(absent))
+        }
+        ResolverValue::Concat(c) => {
+            let mut nodes = Vec::with_capacity(c.nodes.len());
+            for n in &c.nodes {
+                nodes.push(fold_optional_self_ref_absent(n, full_key)?);
+            }
+            Some(ResolverValue::Concat(ConcatPlaceholder {
+                nodes,
+                separator_flags: c.separator_flags.clone(),
+                line: c.line,
+                col: c.col,
+            }))
+        }
+        ResolverValue::UnresolvedArray(elems) => {
+            let mut folded = Vec::with_capacity(elems.len());
+            for e in elems {
+                folded.push(fold_optional_self_ref_absent(e, full_key)?);
+            }
+            Some(ResolverValue::UnresolvedArray(folded))
+        }
+        ResolverValue::Obj(o) => {
+            let mut new_fields = indexmap::IndexMap::new();
+            for (k, val) in &o.fields {
+                new_fields.insert(k.clone(), fold_optional_self_ref_absent(val, full_key)?);
+            }
+            Some(ResolverValue::Obj(ResObj {
+                fields: new_fields,
+                prior_values: o.prior_values.clone(),
+            }))
+        }
+        _ => Some(v.clone()),
+    }
 }
 
 /// Dotted-path key of a substitution placeholder's segments. Segments are
@@ -118,26 +164,10 @@ pub(crate) fn subst_full_key(sp: &SubstPlaceholder) -> String {
 }
 
 /// Recursively folds nested self-references inside a value tree using each
-/// enclosing `ResObj`'s `prior_values` as the substitution target. For
-/// every `Obj` encountered, each field `k` is examined: if the field's
-/// value contains a `Subst` pointing at `path_prefix + k` (the field's
-/// own full dotted path) AND the `Obj` has a `prior_values[k]` entry,
-/// the substitution is folded against the prior.
-///
-/// Why this exists in rs.hocon but not go.hocon: go.hocon's setPath fix
-/// writes `r.priorValues[fullKey]` keyed by the full dotted path, so
-/// `resolveSubst`'s lookup finds the saved prior directly without
-/// navigating into an intermediate `ResObj`. rs.hocon's
-/// `resolve_subst` navigates `prior_root.fields` per segment, so a
-/// chain-3 multi-segment pattern (`r.x = ${r.x} [...]` × N) saves a
-/// `${r.x}`-containing concat at the leaf which then loops when
-/// re-encountered during prior-resolution. Pre-folding the nested
-/// self-references at save time breaks the loop.
-///
-/// Cross-impl note: covers the multi-segment chain (#118-class) and
-/// multi-segment object-merge (#120-class) on rs.hocon. Called from
-/// `structure_builder::apply_field` before saving an `Obj`-typed
-/// existing as the parent's prior.
+/// enclosing `ResObj`'s `prior_values` as the substitution target. This remains
+/// necessary when an object assignment overwrites existing child keys, but sr13
+/// avoids using it for pure additions so an already-folded prior is not saved
+/// and folded again on a later field.
 pub(crate) fn fold_nested_self_refs(v: &ResolverValue, path_prefix: &[String]) -> ResolverValue {
     if let ResolverValue::Obj(o) = v {
         let mut new_fields = indexmap::IndexMap::new();
@@ -146,8 +176,6 @@ pub(crate) fn fold_nested_self_refs(v: &ResolverValue, path_prefix: &[String]) -
             child_path.push(k.clone());
             let full_key =
                 super::utils::string_segments_to_key(child_path.iter().map(String::as_str));
-            // Recurse first (depth-first) so deeper folds happen before
-            // we examine the current level.
             let folded_field = fold_nested_self_refs(field_val, &child_path);
             let final_val = if contains_self_ref(&folded_field, &full_key) {
                 if let Some(leaf_prior) = o.prior_values.get(k) {
@@ -181,7 +209,9 @@ pub(crate) fn fold_nested_self_refs(v: &ResolverValue, path_prefix: &[String]) -
 /// `Obj`.
 pub(crate) fn contains_subst_by_path(v: &ResolverValue, target: &[Segment]) -> bool {
     match v {
-        ResolverValue::Subst(sp) => super::utils::segments_text_equal(&sp.segments, target),
+        ResolverValue::Subst(sp) => {
+            !sp.known_absent && super::utils::segments_text_equal(&sp.segments, target)
+        }
         ResolverValue::Concat(c) => c.nodes.iter().any(|n| contains_subst_by_path(n, target)),
         ResolverValue::UnresolvedArray(elems) => {
             elems.iter().any(|e| contains_subst_by_path(e, target))

--- a/src/resolver/fold_self_ref.rs
+++ b/src/resolver/fold_self_ref.rs
@@ -192,6 +192,265 @@ pub(crate) fn subst_full_key(sp: &SubstPlaceholder) -> String {
     segments_to_key(&sp.segments)
 }
 
+#[cfg(test)]
+mod tests {
+    //! Unit tests for `fold_optional_self_ref_absent` branch coverage.
+    //!
+    //! `fold_optional_self_ref_absent` is private; exercised via the
+    //! `fold_or_skip_prior(prior, key, None)` path, which calls
+    //! `fold_optional_self_ref_absent` when `contains_self_ref` is true.
+    //!
+    //! For the fallback branch (`_ => Some(v.clone())`), we call
+    //! `fold_optional_self_ref_absent` directly since it is in the same module.
+    //!
+    //! Covers: UnresolvedArray, Obj, and fallback branches that have no
+    //! fixture coverage from sr01–sr21 (sr15 only exercises Subst + Concat).
+
+    use super::*;
+    use crate::lexer::Segment;
+    use crate::value::{HoconValue, ScalarValue};
+    use indexmap::IndexMap;
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    fn seg(text: &str) -> Segment {
+        Segment {
+            text: text.to_string(),
+            line: 1,
+            col: 1,
+        }
+    }
+
+    fn make_subst(key: &str, optional: bool) -> ResolverValue {
+        ResolverValue::Subst(SubstPlaceholder {
+            segments: vec![seg(key)],
+            optional,
+            known_absent: false,
+            list_suffix: false,
+            line: 1,
+            col: 1,
+            prefix_len: 0,
+        })
+    }
+
+    fn subst_known_absent(v: &ResolverValue) -> bool {
+        match v {
+            ResolverValue::Subst(sp) => sp.known_absent,
+            _ => panic!("expected Subst, got {:?}", v),
+        }
+    }
+
+    // ── UnresolvedArray branch ───────────────────────────────────────────────
+
+    /// UnresolvedArray containing an optional self-ref item → item folded to
+    /// known_absent=true. Tests the `ResolverValue::UnresolvedArray` arm of
+    /// `fold_optional_self_ref_absent`.
+    #[test]
+    fn unresolved_array_optional_self_ref_folded() {
+        let array = ResolverValue::UnresolvedArray(vec![make_subst("a", true)]);
+        let result = fold_or_skip_prior(&array, "a", None);
+        assert!(result.is_some(), "expected Some for optional self-ref array");
+        match result.unwrap() {
+            ResolverValue::UnresolvedArray(elems) => {
+                assert_eq!(elems.len(), 1);
+                assert!(
+                    subst_known_absent(&elems[0]),
+                    "array item should be known_absent after fold"
+                );
+            }
+            other => panic!("expected UnresolvedArray, got {:?}", other),
+        }
+    }
+
+    /// UnresolvedArray containing a required self-ref item → returns None
+    /// (short-circuit: save is skipped).
+    #[test]
+    fn unresolved_array_required_self_ref_returns_none() {
+        let array = ResolverValue::UnresolvedArray(vec![make_subst("a", false)]);
+        let result = fold_or_skip_prior(&array, "a", None);
+        assert!(
+            result.is_none(),
+            "expected None for required self-ref in array"
+        );
+    }
+
+    /// UnresolvedArray with no self-ref to key "a" → cloned and returned as-is.
+    #[test]
+    fn unresolved_array_no_self_ref_passes_through() {
+        // contains_self_ref("a") is false for ${?b} → fold_or_skip_prior
+        // takes the `Some(prior.clone())` fast path. Tests the no-self-ref
+        // clone path through the array.
+        let array = ResolverValue::UnresolvedArray(vec![make_subst("b", true)]);
+        let result = fold_or_skip_prior(&array, "a", None);
+        assert!(result.is_some());
+        match result.unwrap() {
+            ResolverValue::UnresolvedArray(elems) => {
+                assert_eq!(elems.len(), 1);
+                // "b" is not "a" so known_absent must remain false
+                assert!(!subst_known_absent(&elems[0]));
+            }
+            other => panic!("expected UnresolvedArray, got {:?}", other),
+        }
+    }
+
+    /// UnresolvedArray with mixed items: optional self-ref + non-self-ref.
+    /// Self-ref item folded; other item preserved unchanged.
+    #[test]
+    fn unresolved_array_mixed_items_only_self_ref_folded() {
+        let array = ResolverValue::UnresolvedArray(vec![
+            make_subst("a", true), // self-ref → fold
+            make_subst("b", true), // not self-ref → preserve
+        ]);
+        let result = fold_or_skip_prior(&array, "a", None);
+        assert!(result.is_some());
+        match result.unwrap() {
+            ResolverValue::UnresolvedArray(elems) => {
+                assert_eq!(elems.len(), 2);
+                assert!(subst_known_absent(&elems[0]), "first item should be known_absent");
+                assert!(!subst_known_absent(&elems[1]), "second item should not be known_absent");
+            }
+            other => panic!("expected UnresolvedArray, got {:?}", other),
+        }
+    }
+
+    // ── Obj branch ───────────────────────────────────────────────────────────
+
+    /// ResObj with a field containing an optional self-ref → field folded to
+    /// known_absent=true. Tests the `ResolverValue::Obj` arm of
+    /// `fold_optional_self_ref_absent`.
+    #[test]
+    fn obj_optional_self_ref_field_folded() {
+        let mut fields = IndexMap::new();
+        fields.insert("history".to_string(), make_subst("a", true));
+        let obj = ResolverValue::Obj(ResObj {
+            fields,
+            prior_values: IndexMap::new(),
+        });
+        let result = fold_or_skip_prior(&obj, "a", None);
+        assert!(result.is_some(), "expected Some for optional self-ref in obj field");
+        match result.unwrap() {
+            ResolverValue::Obj(o) => {
+                let field = o.fields.get("history").expect("history field missing");
+                assert!(
+                    subst_known_absent(field),
+                    "obj field should be known_absent after fold"
+                );
+            }
+            other => panic!("expected Obj, got {:?}", other),
+        }
+    }
+
+    /// ResObj with a field containing a required self-ref → returns None.
+    #[test]
+    fn obj_required_self_ref_field_returns_none() {
+        let mut fields = IndexMap::new();
+        fields.insert("history".to_string(), make_subst("a", false));
+        let obj = ResolverValue::Obj(ResObj {
+            fields,
+            prior_values: IndexMap::new(),
+        });
+        let result = fold_or_skip_prior(&obj, "a", None);
+        assert!(
+            result.is_none(),
+            "expected None for required self-ref in obj field"
+        );
+    }
+
+    /// ResObj with multiple fields: only the self-ref field is folded.
+    #[test]
+    fn obj_multiple_fields_only_self_ref_folded() {
+        let mut fields = IndexMap::new();
+        fields.insert("history".to_string(), make_subst("a", true));
+        fields.insert("other".to_string(), make_subst("b", true));
+        let obj = ResolverValue::Obj(ResObj {
+            fields,
+            prior_values: IndexMap::new(),
+        });
+        let result = fold_or_skip_prior(&obj, "a", None);
+        assert!(result.is_some());
+        match result.unwrap() {
+            ResolverValue::Obj(o) => {
+                let history = o.fields.get("history").expect("history missing");
+                let other = o.fields.get("other").expect("other missing");
+                assert!(subst_known_absent(history), "history should be known_absent");
+                assert!(!subst_known_absent(other), "other should not be known_absent");
+            }
+            other => panic!("expected Obj, got {:?}", other),
+        }
+    }
+
+    // ── Fallback branch (`_ => Some(v.clone())`) ─────────────────────────────
+
+    /// Resolved scalar value has no self-ref → `fold_optional_self_ref_absent`
+    /// takes the `_` fallback arm, returning `Some(v.clone())`.
+    ///
+    /// We call `fold_optional_self_ref_absent` directly because
+    /// `contains_self_ref` on a Resolved value returns false, so
+    /// `fold_or_skip_prior` would return `Some(prior.clone())` before ever
+    /// calling `fold_optional_self_ref_absent`.  The fallback arm is only
+    /// reachable from within a recursive call where a parent node (e.g.
+    /// UnresolvedArray or Obj) contains a self-ref but one of its children is
+    /// a non-self-ref Resolved value.
+    #[test]
+    fn fallback_resolved_scalar_passthrough() {
+        let scalar = ResolverValue::Resolved(HoconValue::Scalar(ScalarValue::string(
+            "hello".to_string(),
+        )));
+        // Direct call to exercise the `_` arm.
+        let result = fold_optional_self_ref_absent(&scalar, "a");
+        assert!(result.is_some());
+        match result.unwrap() {
+            ResolverValue::Resolved(HoconValue::Scalar(sv)) => {
+                assert_eq!(sv.raw, "hello");
+            }
+            other => panic!("expected Resolved(Scalar), got {:?}", other),
+        }
+    }
+
+    /// Resolved number scalar passes through the fallback arm unchanged.
+    #[test]
+    fn fallback_resolved_number_passthrough() {
+        let num = ResolverValue::Resolved(HoconValue::Scalar(ScalarValue::number(
+            "42".to_string(),
+        )));
+        let result = fold_optional_self_ref_absent(&num, "a");
+        assert!(result.is_some());
+        match result.unwrap() {
+            ResolverValue::Resolved(HoconValue::Scalar(sv)) => {
+                assert_eq!(sv.raw, "42");
+            }
+            other => panic!("expected Resolved(Scalar), got {:?}", other),
+        }
+    }
+
+    /// UnresolvedArray with Resolved scalar + optional self-ref: verifies that
+    /// the Resolved item hits the `_` fallback arm during recursive traversal.
+    #[test]
+    fn unresolved_array_resolved_item_hits_fallback() {
+        let array = ResolverValue::UnresolvedArray(vec![
+            ResolverValue::Resolved(HoconValue::Scalar(ScalarValue::string("x".to_string()))),
+            make_subst("a", true),
+        ]);
+        let result = fold_or_skip_prior(&array, "a", None);
+        assert!(result.is_some());
+        match result.unwrap() {
+            ResolverValue::UnresolvedArray(elems) => {
+                assert_eq!(elems.len(), 2);
+                // First item is Resolved scalar → passes through fallback
+                match &elems[0] {
+                    ResolverValue::Resolved(HoconValue::Scalar(sv)) => {
+                        assert_eq!(sv.raw, "x");
+                    }
+                    other => panic!("expected Resolved(Scalar) at [0], got {:?}", other),
+                }
+                // Second item is the self-ref → folded to known_absent
+                assert!(subst_known_absent(&elems[1]));
+            }
+            other => panic!("expected UnresolvedArray, got {:?}", other),
+        }
+    }
+}
+
 /// Recursively folds nested self-references inside a value tree using each
 /// enclosing `ResObj`'s `prior_values` as the substitution target. This remains
 /// necessary when an object assignment overwrites existing child keys, but sr13

--- a/src/resolver/fold_self_ref.rs
+++ b/src/resolver/fold_self_ref.rs
@@ -113,6 +113,35 @@ pub(crate) fn fold_or_skip_prior(
     fold_optional_self_ref_absent(prior, full_key)
 }
 
+/// Mixed-concat contract (review #124 item a):
+///
+/// This function walks a value tree and decides, node by node, whether a node
+/// containing a self-reference can be included in the saved prior when there is
+/// no previously-assigned value for the key (`old == None`).
+///
+/// The `?`-propagation rule applies ONLY to nodes that are the self-referencing
+/// substitution itself:
+///
+///   * Node IS the self-ref AND optional  → mark known_absent → `Some(...)`.
+///     At resolve time the concat-omission rule (Phase 6 §3b) drops it.
+///   * Node IS the self-ref AND required  → return `None` → `?` short-circuits
+///     the entire enclosing `Concat` → save is skipped entirely → at resolve
+///     time the required-self-ref-no-prior error fires (sr05-like).
+///   * Node is NOT the self-ref (e.g. a literal, `${b}`, or a different key's
+///     substitution) → `_ => Some(v.clone())` → preserved in the saved prior
+///     → evaluated normally at resolve time.
+///
+/// Consequence: mixed concats like `a = ${?a}foo${b}` or `a = ${?a}foo${?b}`
+/// are handled correctly without special-casing:
+///   - `${b}` (required, external) is saved and errors at resolve time if b
+///     has no definition.
+///   - `${?b}` (optional, external) is saved and drops silently at resolve
+///     time if b is absent.
+///   - `a = ${?a}foo${a}` (required self-ref in concat) short-circuits → save
+///     skipped → required-self-ref error at resolve time.
+///
+/// Tests: sr17 (pure-optional), sr18 (required external), sr19 (required
+/// self-ref mixed) in tests/self_ref_lookback_test.rs.
 fn fold_optional_self_ref_absent(v: &ResolverValue, full_key: &str) -> Option<ResolverValue> {
     match v {
         ResolverValue::Subst(sp) if subst_full_key(sp) == full_key => {

--- a/src/resolver/fold_self_ref.rs
+++ b/src/resolver/fold_self_ref.rs
@@ -249,7 +249,10 @@ mod tests {
     fn unresolved_array_optional_self_ref_folded() {
         let array = ResolverValue::UnresolvedArray(vec![make_subst("a", true)]);
         let result = fold_or_skip_prior(&array, "a", None);
-        assert!(result.is_some(), "expected Some for optional self-ref array");
+        assert!(
+            result.is_some(),
+            "expected Some for optional self-ref array"
+        );
         match result.unwrap() {
             ResolverValue::UnresolvedArray(elems) => {
                 assert_eq!(elems.len(), 1);
@@ -306,8 +309,14 @@ mod tests {
         match result.unwrap() {
             ResolverValue::UnresolvedArray(elems) => {
                 assert_eq!(elems.len(), 2);
-                assert!(subst_known_absent(&elems[0]), "first item should be known_absent");
-                assert!(!subst_known_absent(&elems[1]), "second item should not be known_absent");
+                assert!(
+                    subst_known_absent(&elems[0]),
+                    "first item should be known_absent"
+                );
+                assert!(
+                    !subst_known_absent(&elems[1]),
+                    "second item should not be known_absent"
+                );
             }
             other => panic!("expected UnresolvedArray, got {:?}", other),
         }
@@ -327,7 +336,10 @@ mod tests {
             prior_values: IndexMap::new(),
         });
         let result = fold_or_skip_prior(&obj, "a", None);
-        assert!(result.is_some(), "expected Some for optional self-ref in obj field");
+        assert!(
+            result.is_some(),
+            "expected Some for optional self-ref in obj field"
+        );
         match result.unwrap() {
             ResolverValue::Obj(o) => {
                 let field = o.fields.get("history").expect("history field missing");
@@ -372,8 +384,14 @@ mod tests {
             ResolverValue::Obj(o) => {
                 let history = o.fields.get("history").expect("history missing");
                 let other = o.fields.get("other").expect("other missing");
-                assert!(subst_known_absent(history), "history should be known_absent");
-                assert!(!subst_known_absent(other), "other should not be known_absent");
+                assert!(
+                    subst_known_absent(history),
+                    "history should be known_absent"
+                );
+                assert!(
+                    !subst_known_absent(other),
+                    "other should not be known_absent"
+                );
             }
             other => panic!("expected Obj, got {:?}", other),
         }
@@ -393,9 +411,8 @@ mod tests {
     /// a non-self-ref Resolved value.
     #[test]
     fn fallback_resolved_scalar_passthrough() {
-        let scalar = ResolverValue::Resolved(HoconValue::Scalar(ScalarValue::string(
-            "hello".to_string(),
-        )));
+        let scalar =
+            ResolverValue::Resolved(HoconValue::Scalar(ScalarValue::string("hello".to_string())));
         // Direct call to exercise the `_` arm.
         let result = fold_optional_self_ref_absent(&scalar, "a");
         assert!(result.is_some());
@@ -410,9 +427,8 @@ mod tests {
     /// Resolved number scalar passes through the fallback arm unchanged.
     #[test]
     fn fallback_resolved_number_passthrough() {
-        let num = ResolverValue::Resolved(HoconValue::Scalar(ScalarValue::number(
-            "42".to_string(),
-        )));
+        let num =
+            ResolverValue::Resolved(HoconValue::Scalar(ScalarValue::number("42".to_string())));
         let result = fold_optional_self_ref_absent(&num, "a");
         assert!(result.is_some());
         match result.unwrap() {

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -242,6 +242,7 @@ fn hocon_value_to_resolver(v: &crate::value::HoconValue) -> types::ResolverValue
             ResolverValue::Subst(SubstPlaceholder {
                 segments,
                 optional: pv.optional,
+                known_absent: false,
                 list_suffix: false,
                 line: 0,
                 col: 0,

--- a/src/resolver/structure_builder.rs
+++ b/src/resolver/structure_builder.rs
@@ -184,7 +184,10 @@ impl<'a> StructureBuilder<'a> {
                     if let ResolverValue::Obj(existing_obj) = ex {
                         // Fold only when new keys are a subset of existing keys (same-key
                         // or strict-subset Obj-Obj).  Adding new keys → skip (sr13 guard).
-                        new_obj.fields.keys().all(|k| existing_obj.fields.contains_key(k))
+                        new_obj
+                            .fields
+                            .keys()
+                            .all(|k| existing_obj.fields.contains_key(k))
                     } else {
                         false
                     }

--- a/src/resolver/structure_builder.rs
+++ b/src/resolver/structure_builder.rs
@@ -166,17 +166,20 @@ impl<'a> StructureBuilder<'a> {
             let full_key = string_segments_to_key(child_prefix.iter().map(String::as_str));
             let old_prior = obj.prior_values.get(&head).cloned();
             let prior_source;
-            let should_fold_nested =
-                if let (ResolverValue::Obj(existing_obj), ResolverValue::Obj(new_obj)) =
-                    (ex, &new_val)
-                {
-                    new_obj
-                        .fields
-                        .keys()
-                        .all(|key| existing_obj.fields.contains_key(key))
-                } else {
-                    false
-                };
+            // xx.hocon#27 review #124 Issue 3 (cross-impl with ts.hocon Codex P1 + Claude #1):
+            // fold nested self-refs in `existing` when `existing` is an Obj and `new_val`
+            // is NOT an Obj (e.g. `o = ${?o}` overwriting `{a:Concat[...]}` with a Subst).
+            // In this case the prior for `o` must capture the pre-overwrite state with
+            // sub-field references resolved, so that `${?o}` at resolve time returns
+            // `{a:"xbar"}` not `{a:"bar"}`.  The original gate (`both Obj + same keys`)
+            // is preserved for Obj-overwrites-Obj cases to prevent the sr13 double-fold:
+            // when `new_val` is an Obj adding new keys, the sub-field resolve is handled
+            // at resolve time via the leaf-prior fallback in resolve_subst_inner.
+            let should_fold_nested = if matches!(ex, ResolverValue::Obj(_)) {
+                !matches!(new_val, ResolverValue::Obj(_))
+            } else {
+                false
+            };
             let prior_input = if should_fold_nested {
                 prior_source = fold_nested_self_refs(ex, &child_prefix);
                 &prior_source

--- a/src/resolver/structure_builder.rs
+++ b/src/resolver/structure_builder.rs
@@ -167,18 +167,30 @@ impl<'a> StructureBuilder<'a> {
             let old_prior = obj.prior_values.get(&head).cloned();
             let prior_source;
             // xx.hocon#27 review #124 Issue 3 (cross-impl with ts.hocon Codex P1 + Claude #1):
-            // fold nested self-refs in `existing` when `existing` is an Obj and `new_val`
-            // is NOT an Obj (e.g. `o = ${?o}` overwriting `{a:Concat[...]}` with a Subst).
-            // In this case the prior for `o` must capture the pre-overwrite state with
-            // sub-field references resolved, so that `${?o}` at resolve time returns
-            // `{a:"xbar"}` not `{a:"bar"}`.  The original gate (`both Obj + same keys`)
-            // is preserved for Obj-overwrites-Obj cases to prevent the sr13 double-fold:
-            // when `new_val` is an Obj adding new keys, the sub-field resolve is handled
-            // at resolve time via the leaf-prior fallback in resolve_subst_inner.
-            let should_fold_nested = if matches!(ex, ResolverValue::Obj(_)) {
-                !matches!(new_val, ResolverValue::Obj(_))
-            } else {
-                false
+            // fold nested self-refs in `existing` when `existing` is an Obj and either:
+            //   (a) `new_val` is NOT an Obj (e.g. `o = ${?o}` overwriting `{a:Concat[...]}`)
+            //       — prior must capture pre-overwrite state with sub-fields resolved so
+            //       `${?o}` at resolve time returns `{a:"xbar"}` not `{a:"bar"}`; or
+            //   (b) `new_val` IS an Obj whose keys are a subset of `existing`'s keys
+            //       (same-key Obj-Obj overwrite, e.g. `o = {a=1, prev=${?o}}` after
+            //       `o.a = "xbar"`) — same sub-field resolution requirement applies.
+            //
+            // Do NOT fold for the sr13 case: Obj-Obj adding new keys.  When `new_val`
+            // has keys not in `existing`, the leaf-prior fallback in resolve_subst_inner
+            // handles sub-field resolution; folding here would double-fold on the 3rd
+            // write producing the "xbarbar" regression.
+            let should_fold_nested = match (ex, &new_val) {
+                (ResolverValue::Obj(_), ResolverValue::Obj(new_obj)) => {
+                    if let ResolverValue::Obj(existing_obj) = ex {
+                        // Fold only when new keys are a subset of existing keys (same-key
+                        // or strict-subset Obj-Obj).  Adding new keys → skip (sr13 guard).
+                        new_obj.fields.keys().all(|k| existing_obj.fields.contains_key(k))
+                    } else {
+                        false
+                    }
+                }
+                (ResolverValue::Obj(_), _) => true, // Obj overwritten by non-Obj
+                _ => false,
             };
             let prior_input = if should_fold_nested {
                 prior_source = fold_nested_self_refs(ex, &child_prefix);

--- a/src/resolver/structure_builder.rs
+++ b/src/resolver/structure_builder.rs
@@ -158,25 +158,32 @@ impl<'a> StructureBuilder<'a> {
         let new_val = self.ast_to_resolver_value(field.value, &child_prefix)?;
 
         // #118 + #120: save existing with fold-or-skip (chain-class fix).
-        // Cross-impl with go.hocon PR #121 / #123. Applies regardless of
-        // whether new_val will deep-merge with existing — the previous
-        // unconditional save still worked for #118-chain crashes because
-        // ResolverValue::Obj couldn't contain a self-ref placeholder visible
-        // to the prior-save layer (only the merged sub-object's interior
-        // could, see #120). With fold + walker extension covering Obj /
-        // UnresolvedArray interiors, the saved prior is self-ref-free.
         //
-        // fold_nested_self_refs pre-pass handles the multi-segment chain
-        // (`r.x = ${r.x} [...]` × N): rs.hocon's resolve_subst navigates
-        // prior_root.fields per segment, so a leaf-level concat containing
-        // ${r.x} retained in the nested ResObj would loop during prior
-        // resolution. The pre-pass folds those nested ${X.Y} refs against
-        // each enclosing ResObj's prior_values before the outer save.
+        // xx.hocon#27 cluster 3h sr13: save the previous value before any
+        // nested fold. If this stores a post-fold object, the next overwrite
+        // can fold that already-expanded value again (`xbarbar`).
         if let Some(ref ex) = existing {
             let full_key = string_segments_to_key(child_prefix.iter().map(String::as_str));
-            let ex_folded = fold_nested_self_refs(ex, &child_prefix);
             let old_prior = obj.prior_values.get(&head).cloned();
-            if let Some(prior) = fold_or_skip_prior(&ex_folded, &full_key, old_prior.as_ref()) {
+            let prior_source;
+            let should_fold_nested =
+                if let (ResolverValue::Obj(existing_obj), ResolverValue::Obj(new_obj)) =
+                    (ex, &new_val)
+                {
+                    new_obj
+                        .fields
+                        .keys()
+                        .all(|key| existing_obj.fields.contains_key(key))
+                } else {
+                    false
+                };
+            let prior_input = if should_fold_nested {
+                prior_source = fold_nested_self_refs(ex, &child_prefix);
+                &prior_source
+            } else {
+                ex
+            };
+            if let Some(prior) = fold_or_skip_prior(prior_input, &full_key, old_prior.as_ref()) {
                 obj.prior_values.insert(head.clone(), prior);
             }
         }
@@ -234,6 +241,7 @@ impl<'a> StructureBuilder<'a> {
             } => Ok(ResolverValue::Subst(SubstPlaceholder {
                 segments,
                 optional,
+                known_absent: false,
                 list_suffix,
                 line: pos.line,
                 col: pos.col,

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -157,11 +157,33 @@ impl<'a> SubstitutionResolver<'a> {
                 .or_else(|| self.root.prior_values.get(root_seg));
             if let Some(prior) = prior {
                 let prior = prior.clone();
-                let mut fresh_resolving = self.resolving.clone();
-                std::mem::swap(&mut self.resolving, &mut fresh_resolving);
-                let result = self.resolve_val(&prior, scope);
-                std::mem::swap(&mut self.resolving, &mut fresh_resolving);
-                return result;
+                // xx.hocon#27 cluster 3h sr12: if the prior itself contains a
+                // self-ref to the same key (e.g. `foo.a = ${?foo.a}bar; foo.b
+                // = ${foo.a}` saves Obj({a:Concat[${?foo.a},bar]}) as foo's
+                // prior), resolving it would re-discover the same self-ref
+                // and recurse infinitely. Treat as no-prior — fall through
+                // to the optional/required short-circuit below.
+                let prior_for_check = match s.segments.len() {
+                    1 => Some(prior.clone()),
+                    _ => match prior {
+                        ResolverValue::Obj(ref po) => lookup_path(po, &s.segments[1..]).cloned(),
+                        _ => None,
+                    },
+                };
+                let skip_due_to_self_ref = prior_for_check.as_ref().is_some_and(|p| {
+                    super::fold_self_ref::contains_subst_by_path(p, &s.segments)
+                });
+                if !skip_due_to_self_ref {
+                    // Surgical: only remove the current cycling key from the
+                    // swapped-in set; other in-flight resolutions stay guarded.
+                    let mut fresh_resolving = self.resolving.clone();
+                    fresh_resolving.remove(&key);
+                    std::mem::swap(&mut self.resolving, &mut fresh_resolving);
+                    let result = self.resolve_val(&prior, scope);
+                    std::mem::swap(&mut self.resolving, &mut fresh_resolving);
+                    return result;
+                }
+                // Fall through to optional/required short-circuit below.
             }
             if s.optional {
                 return Ok(None);
@@ -254,14 +276,25 @@ impl<'a> SubstitutionResolver<'a> {
                             Some(prior_root)
                         };
                         if let Some(prior) = prior {
-                            let result = self.resolve_val(&prior, scope)?;
-                            if let Some(ref r) = result {
-                                self.cache.insert(key.to_string(), r.clone());
+                            // xx.hocon#27 cluster 3h sr12: when the saved prior
+                            // itself contains a self-ref to the same key (e.g.
+                            // `foo.a = ${?foo.a}bar; foo.b = ${foo.a}` saves the
+                            // unfolded Concat[${?foo.a},bar] as foo's prior),
+                            // resolving the prior would re-discover the same
+                            // self-ref and recurse infinitely. Treat as no-prior
+                            // and fall through to the optional/required
+                            // short-circuit below — semantically there is no
+                            // "previous resolved value" to look back to.
+                            if !super::fold_self_ref::contains_subst_by_path(&prior, &s.segments) {
+                                let result = self.resolve_val(&prior, scope)?;
+                                if let Some(ref r) = result {
+                                    self.cache.insert(key.to_string(), r.clone());
+                                }
+                                return Ok(result);
                             }
-                            return Ok(result);
                         }
-                        // Prior root exists but nested path not found — fall through to
-                        // no-prior short-circuit below.
+                        // Prior root exists but nested path not found OR prior
+                        // contains the same self-ref — fall through.
                     }
                     // Object-literal form fallback: when `foo { a = "x"; a = ${?foo.a}bar }`
                     // is used, the prior for the leaf key `a` is stored directly in the

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -79,26 +79,22 @@ impl<'a> SubstitutionResolver<'a> {
             match resolved_result? {
                 Some(resolved) => {
                     // Delayed merge: if both current and prior resolve to objects, deep merge
-                    let final_value =
-                        if let HoconValue::Object(ref current_fields) = resolved {
-                            if let Some(prior) = obj.prior_values.get(key) {
-                                self.resolving_field_path.push(key.clone());
-                                let prior_result = self.resolve_val(prior, obj);
-                                self.resolving_field_path.pop();
-                                if let Some(HoconValue::Object(prior_fields)) = prior_result? {
-                                    deep_merge_hocon_objects(
-                                        prior_fields,
-                                        current_fields.clone(),
-                                    )
-                                } else {
-                                    resolved
-                                }
+                    let final_value = if let HoconValue::Object(ref current_fields) = resolved {
+                        if let Some(prior) = obj.prior_values.get(key) {
+                            self.resolving_field_path.push(key.clone());
+                            let prior_result = self.resolve_val(prior, obj);
+                            self.resolving_field_path.pop();
+                            if let Some(HoconValue::Object(prior_fields)) = prior_result? {
+                                deep_merge_hocon_objects(prior_fields, current_fields.clone())
                             } else {
                                 resolved
                             }
                         } else {
                             resolved
-                        };
+                        }
+                    } else {
+                        resolved
+                    };
                     // xx.hocon#27 cluster 3h sr14+sr16: write the field's final
                     // resolved value to the substitution cache under its full
                     // dotted path. Without this, the self-ref code path's
@@ -111,7 +107,9 @@ impl<'a> SubstitutionResolver<'a> {
                     // reads back `b`'s preview of `a`). The post-loop write
                     // here is always authoritative for fields the resolver
                     // commits into `result`.
-                    self.cache.insert(full_cache_key, final_value.clone());
+                    self.cache
+                        .insert(full_cache_key.clone(), final_value.clone());
+                    self.cache_descendants(&full_cache_key, &final_value);
                     result.insert(key.clone(), final_value);
                 }
                 None => {
@@ -121,7 +119,9 @@ impl<'a> SubstitutionResolver<'a> {
                         let prior_result = self.resolve_val(prior, obj);
                         self.resolving_field_path.pop();
                         if let Some(prior_resolved) = prior_result? {
-                            self.cache.insert(full_cache_key, prior_resolved.clone());
+                            self.cache
+                                .insert(full_cache_key.clone(), prior_resolved.clone());
+                            self.cache_descendants(&full_cache_key, &prior_resolved);
                             result.insert(key.clone(), prior_resolved);
                         }
                     }
@@ -129,6 +129,16 @@ impl<'a> SubstitutionResolver<'a> {
             }
         }
         Ok(HoconValue::Object(result))
+    }
+
+    fn cache_descendants(&mut self, prefix: &str, value: &HoconValue) {
+        if let HoconValue::Object(fields) = value {
+            for (key, child) in fields {
+                let child_key = format!("{prefix}.{key}");
+                self.cache.insert(child_key.clone(), child.clone());
+                self.cache_descendants(&child_key, child);
+            }
+        }
     }
 
     fn resolve_val(
@@ -162,6 +172,10 @@ impl<'a> SubstitutionResolver<'a> {
         s: &SubstPlaceholder,
         scope: &ResObj,
     ) -> Result<Option<HoconValue>, ResolveError> {
+        if s.known_absent {
+            return Ok(None);
+        }
+
         // Cache key includes list_suffix to prevent `${X}` and `${X[]}` collisions:
         // both resolve via different code paths (scalar fallback vs resolve_env_list)
         // and can produce different values, so they must occupy distinct cache slots.
@@ -200,9 +214,9 @@ impl<'a> SubstitutionResolver<'a> {
                         _ => None,
                     },
                 };
-                let skip_due_to_self_ref = prior_for_check.as_ref().is_some_and(|p| {
-                    super::fold_self_ref::contains_subst_by_path(p, &s.segments)
-                });
+                let skip_due_to_self_ref = prior_for_check
+                    .as_ref()
+                    .is_some_and(|p| super::fold_self_ref::contains_subst_by_path(p, &s.segments));
                 if !skip_due_to_self_ref {
                     // Surgical: only remove the current cycling key from the
                     // swapped-in set; other in-flight resolutions stay guarded.

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -5,7 +5,9 @@ use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 
 use super::types::{AppendPlaceholder, ResObj, ResolverValue, SubstPlaceholder};
-use super::utils::{deep_merge_hocon_objects, lookup_path, segments_to_key, string_segments_to_key};
+use super::utils::{
+    deep_merge_hocon_objects, lookup_path, segments_to_key, string_segments_to_key,
+};
 
 pub(crate) struct SubstitutionResolver<'a> {
     root: &'a ResObj,
@@ -337,7 +339,10 @@ impl<'a> SubstitutionResolver<'a> {
                             // sr12 guard: if the leaf prior itself contains a
                             // self-ref to the same key, treat as no-prior to
                             // avoid infinite recursion.
-                            if !super::fold_self_ref::contains_subst_by_path(&leaf_prior, &s.segments) {
+                            if !super::fold_self_ref::contains_subst_by_path(
+                                &leaf_prior,
+                                &s.segments,
+                            ) {
                                 let result = self.resolve_val(&leaf_prior, scope)?;
                                 if let Some(ref r) = result {
                                     self.cache.insert(key.to_string(), r.clone());

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 
 use super::types::{AppendPlaceholder, ResObj, ResolverValue, SubstPlaceholder};
-use super::utils::{deep_merge_hocon_objects, lookup_path, segments_to_key};
+use super::utils::{deep_merge_hocon_objects, lookup_path, segments_to_key, string_segments_to_key};
 
 pub(crate) struct SubstitutionResolver<'a> {
     root: &'a ResObj,
@@ -65,7 +65,14 @@ impl<'a> SubstitutionResolver<'a> {
         let mut result = IndexMap::new();
         for (key, val) in &obj.fields {
             self.resolving_field_path.push(key.clone());
-            let full_cache_key = self.resolving_field_path.join(".");
+            // Use the same escaping as segments_to_key / string_segments_to_key so
+            // that a quoted key like `"a.b"` produces cache key `"a.b"` (quoted),
+            // not `a.b` (unescaped). Without this, a top-level `"a.b" = "literal"`
+            // field and a nested `a { b = "nested" }` path produce the same raw
+            // dot-join `a.b`, causing a cache collision that makes `${a.b}` return
+            // "literal" instead of "nested". (Review #124 Issue 1.)
+            let full_cache_key =
+                string_segments_to_key(self.resolving_field_path.iter().map(String::as_str));
             // xx.hocon#27 cluster 3h sr16: invalidate any cached entry for
             // this field's key BEFORE resolving it. The cache may hold a
             // stale "preview" value written when an earlier field (e.g.
@@ -134,7 +141,11 @@ impl<'a> SubstitutionResolver<'a> {
     fn cache_descendants(&mut self, prefix: &str, value: &HoconValue) {
         if let HoconValue::Object(fields) = value {
             for (key, child) in fields {
-                let child_key = format!("{prefix}.{key}");
+                // Use the same quoting rule as string_segments_to_key so that
+                // a field key containing a dot (e.g. `"a.b"`) is stored as
+                // `prefix."a.b"` (quoted), not `prefix.a.b` (ambiguous).
+                let escaped_key = string_segments_to_key(std::iter::once(key.as_str()));
+                let child_key = format!("{prefix}.{escaped_key}");
                 self.cache.insert(child_key.clone(), child.clone());
                 self.cache_descendants(&child_key, child);
             }

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -65,25 +65,54 @@ impl<'a> SubstitutionResolver<'a> {
         let mut result = IndexMap::new();
         for (key, val) in &obj.fields {
             self.resolving_field_path.push(key.clone());
+            let full_cache_key = self.resolving_field_path.join(".");
+            // xx.hocon#27 cluster 3h sr16: invalidate any cached entry for
+            // this field's key BEFORE resolving it. The cache may hold a
+            // stale "preview" value written when an earlier field (e.g.
+            // `b = ${a}` declared before `a = ${?a}foo`) resolved a's concat
+            // and cached the cycle-short-circuited result `"foo"`. Without
+            // the invalidation, `a`'s own concat reads back `"foo"` from
+            // cache and produces `"foofoo"`.
+            self.cache.remove(&full_cache_key);
             let resolved_result = self.resolve_val(val, obj);
             self.resolving_field_path.pop();
             match resolved_result? {
                 Some(resolved) => {
                     // Delayed merge: if both current and prior resolve to objects, deep merge
-                    if let HoconValue::Object(ref current_fields) = resolved {
-                        if let Some(prior) = obj.prior_values.get(key) {
-                            self.resolving_field_path.push(key.clone());
-                            let prior_result = self.resolve_val(prior, obj);
-                            self.resolving_field_path.pop();
-                            if let Some(HoconValue::Object(prior_fields)) = prior_result? {
-                                let merged =
-                                    deep_merge_hocon_objects(prior_fields, current_fields.clone());
-                                result.insert(key.clone(), merged);
-                                continue;
+                    let final_value =
+                        if let HoconValue::Object(ref current_fields) = resolved {
+                            if let Some(prior) = obj.prior_values.get(key) {
+                                self.resolving_field_path.push(key.clone());
+                                let prior_result = self.resolve_val(prior, obj);
+                                self.resolving_field_path.pop();
+                                if let Some(HoconValue::Object(prior_fields)) = prior_result? {
+                                    deep_merge_hocon_objects(
+                                        prior_fields,
+                                        current_fields.clone(),
+                                    )
+                                } else {
+                                    resolved
+                                }
+                            } else {
+                                resolved
                             }
-                        }
-                    }
-                    result.insert(key.clone(), resolved);
+                        } else {
+                            resolved
+                        };
+                    // xx.hocon#27 cluster 3h sr14+sr16: write the field's final
+                    // resolved value to the substitution cache under its full
+                    // dotted path. Without this, the self-ref code path's
+                    // intermediate cache writes (prior values from is_self_ref
+                    // branch at L290; cycle-handler results; external-caller
+                    // preview values) survive as stale entries — external
+                    // lookups like `b = ${a}` then read the prior instead of
+                    // the post-concat final value (sr14: `b="x"` instead of
+                    // `"xfoo"`; sr16: `a="foofoo"` because `a`'s own concat
+                    // reads back `b`'s preview of `a`). The post-loop write
+                    // here is always authoritative for fields the resolver
+                    // commits into `result`.
+                    self.cache.insert(full_cache_key, final_value.clone());
+                    result.insert(key.clone(), final_value);
                 }
                 None => {
                     // Unresolved optional: fall back to prior value
@@ -92,6 +121,7 @@ impl<'a> SubstitutionResolver<'a> {
                         let prior_result = self.resolve_val(prior, obj);
                         self.resolving_field_path.pop();
                         if let Some(prior_resolved) = prior_result? {
+                            self.cache.insert(full_cache_key, prior_resolved.clone());
                             result.insert(key.clone(), prior_resolved);
                         }
                     }

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -312,6 +312,40 @@ impl<'a> SubstitutionResolver<'a> {
                 let is_self_ref =
                     is_owner && super::fold_self_ref::contains_subst_by_path(&found, &s.segments);
                 if is_self_ref {
+                    // xx.hocon#27 round-3 review #124 (Codex P2): for multi-segment
+                    // self-refs (`${?o.a}` while resolving `o.a`), prefer the LEAF
+                    // prior in the current scope (`scope.prior_values[a] = "x"`)
+                    // over navigating into the outer prior root (`root.prior[o].a`
+                    // which may be the post-fold form `"xbar"` when a partial
+                    // overwrite saved a folded snapshot at the parent level).
+                    //
+                    // The leaf prior is the spec-correct "previous value of this
+                    // specific field" — the outer-prior navigation can yield a
+                    // post-fold value when an Obj-Obj overwrite folded existing
+                    // nested self-refs to seed `${?o}` (whole-object) references
+                    // in the new value. For `${?o.a}` self-ref, the unfolded leaf
+                    // prior is what spec says to consult.
+                    //
+                    // sr21 repro: `o.a="x"; o.b=0; o.a=${?o.a}bar; o={b=1}` — the
+                    // strict-subset overwrite folds outer prior to `{a:"xbar",b:0}`,
+                    // but the live `${?o.a}` Concat must read inner leaf prior
+                    // `a="x"` to produce `"xbar"`, not the folded `"xbar"` which
+                    // double-folds to `"xbarbar"`.
+                    if s.segments.len() > 1 {
+                        let leaf_seg = s.segments.last().map(|seg| seg.text.as_str()).unwrap_or("");
+                        if let Some(leaf_prior) = scope.prior_values.get(leaf_seg).cloned() {
+                            // sr12 guard: if the leaf prior itself contains a
+                            // self-ref to the same key, treat as no-prior to
+                            // avoid infinite recursion.
+                            if !super::fold_self_ref::contains_subst_by_path(&leaf_prior, &s.segments) {
+                                let result = self.resolve_val(&leaf_prior, scope)?;
+                                if let Some(ref r) = result {
+                                    self.cache.insert(key.to_string(), r.clone());
+                                }
+                                return Ok(result);
+                            }
+                        }
+                    }
                     let root_seg = s.segments.first().map(|s| s.text.as_str()).unwrap_or("");
                     let prior_root = scope
                         .prior_values
@@ -350,26 +384,6 @@ impl<'a> SubstitutionResolver<'a> {
                         }
                         // Prior root exists but nested path not found OR prior
                         // contains the same self-ref — fall through.
-                    }
-                    // Object-literal form fallback: when `foo { a = "x"; a = ${?foo.a}bar }`
-                    // is used, the prior for the leaf key `a` is stored directly in the
-                    // current scope (inner_obj.prior_values["a"]), not in the root scope
-                    // under the parent key "foo".  The root-segment lookup above only
-                    // finds the parent object's prior (used for dotted-path reassignments
-                    // at root level), so it finds nothing here.
-                    //
-                    // Guard: only fire this fallback when the substitution is multi-segment
-                    // (len > 1) — single-segment priors are already handled above — and the
-                    // leaf segment's prior lives directly in `scope`.
-                    if s.segments.len() > 1 {
-                        let leaf_seg = s.segments.last().map(|seg| seg.text.as_str()).unwrap_or("");
-                        if let Some(leaf_prior) = scope.prior_values.get(leaf_seg).cloned() {
-                            let result = self.resolve_val(&leaf_prior, scope)?;
-                            if let Some(ref r) = result {
-                                self.cache.insert(key.to_string(), r.clone());
-                            }
-                            return Ok(result);
-                        }
                     }
                     // Spec L841: no prior + self-ref → optional yields undefined; required errors.
                     if s.optional {

--- a/src/resolver/types.rs
+++ b/src/resolver/types.rs
@@ -107,7 +107,10 @@ pub struct SubstPlaceholder {
     pub optional: bool,
     /// Internal sentinel used when folding an optional self-reference with no
     /// prior value. It resolves to undefined without performing a lookup.
-    pub known_absent: bool,
+    /// `pub(crate)` because `SubstPlaceholder` is an internal resolver type not
+    /// re-exported through `lib.rs`; downstream consumers cannot reach this
+    /// field via the public API. (Review #124 Issue 2.)
+    pub(crate) known_absent: bool,
     /// Propagated from `AstNode::Substitution::list_suffix`; true for `${X[]}` / `${?X[]}`.
     pub list_suffix: bool,
     pub line: usize,

--- a/src/resolver/types.rs
+++ b/src/resolver/types.rs
@@ -105,6 +105,9 @@ pub enum ResolverValue {
 pub struct SubstPlaceholder {
     pub segments: Vec<Segment>,
     pub optional: bool,
+    /// Internal sentinel used when folding an optional self-reference with no
+    /// prior value. It resolves to undefined without performing a lookup.
+    pub known_absent: bool,
     /// Propagated from `AstNode::Substitution::list_suffix`; true for `${X[]}` / `${?X[]}`.
     pub list_suffix: bool,
     pub line: usize,

--- a/src/resolver/types.rs
+++ b/src/resolver/types.rs
@@ -101,15 +101,25 @@ pub enum ResolverValue {
     UnresolvedArray(Vec<ResolverValue>),
 }
 
+/// Substitution placeholder in the resolver's pre-resolve tree.
+///
+/// `#[non_exhaustive]`: the resolver module is `pub` but `#[doc(hidden)]`
+/// (see lib.rs:130-136) for integration-test access. External consumers
+/// that reach this type via `hocon::resolver::types` do so outside the
+/// stable API contract; `#[non_exhaustive]` formally signals that
+/// additional fields may be added without a major version bump.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct SubstPlaceholder {
     pub segments: Vec<Segment>,
     pub optional: bool,
     /// Internal sentinel used when folding an optional self-reference with no
     /// prior value. It resolves to undefined without performing a lookup.
-    /// `pub(crate)` because `SubstPlaceholder` is an internal resolver type not
-    /// re-exported through `lib.rs`; downstream consumers cannot reach this
-    /// field via the public API. (Review #124 Issue 2.)
+    /// `pub(crate)` because this is purely an internal fold-time marker —
+    /// callers outside the resolver crate have no reason to set it. The
+    /// surrounding `#[non_exhaustive]` keeps that semantic forward-compatible
+    /// (downstream cannot construct the struct via pattern literal anyway).
+    /// (Review #124 Issue 2.)
     pub(crate) known_absent: bool,
     /// Propagated from `AstNode::Substitution::list_suffix`; true for `${X[]}` / `${?X[]}`.
     pub list_suffix: bool,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1701,3 +1701,32 @@ c = ${a.b}
         "c = ${{a.b}} must return \"nested\" (no cache collision with \"a.b\" quoted key)"
     );
 }
+
+// --- Review #124 Issue 3: should_fold_nested gate for non-Obj overwrite --------
+/// Regression: when an object field that contains nested self-refs is then
+/// overwritten by a non-object value (e.g. `o = ${?o}`), the prior saved for
+/// `o` must capture the sub-field state with self-refs folded.
+///
+/// Pre-fix: `should_fold_nested` required `new_val` to be an `Obj` with
+/// overlapping keys, so for `new_val = Subst(${?o})` the gate was false.
+/// The existing value `{a:Concat[${?o.a},bar]}` was saved as-is. At resolve
+/// time the prior's `${?o.a}` looked up `o.a` in root where `o = ${?o}` (a
+/// Subst, not an Obj), returning None → `o.a = "bar"` instead of `"xbar"`.
+///
+/// Fix: fold when `existing` is an Obj AND `new_val` is NOT an Obj (review
+/// #124 Issue 3, cross-impl with ts.hocon Codex P1 + Claude #1).
+#[test]
+fn should_fold_nested_gate_non_obj_overwrite() {
+    // o.a = "x"         → prior for "o" = Obj({a:Resolved("x")}) after step 2
+    // o.a = ${?o.a}bar  → o.a becomes "xbar"; prior should reflect that
+    // o = ${?o}         → new_val is Subst; existing prior must be folded so
+    //                     resolve(${?o}) returns {a:"xbar"} not {a:"bar"}
+    let input = "o.a = \"x\"\no.a = ${?o.a}bar\no = ${?o}";
+    let cfg = hocon::parse_with_env(input, &std::collections::HashMap::new())
+        .expect("parse failed");
+    assert_eq!(
+        cfg.get_string("o.a").unwrap(),
+        "xbar",
+        "o.a must be \"xbar\" (non-Obj overwrite must fold nested self-refs in prior)"
+    );
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1686,8 +1686,8 @@ fn dotted_quoted_key_no_cache_collision_with_nested_path() {
 "a.b" = "literal"
 c = ${a.b}
 "#;
-    let cfg = hocon::parse_with_env(input, &std::collections::HashMap::new())
-        .expect("parse failed");
+    let cfg =
+        hocon::parse_with_env(input, &std::collections::HashMap::new()).expect("parse failed");
     // The two-segment path resolves correctly.
     assert_eq!(
         cfg.get_string("a.b").unwrap(),
@@ -1722,8 +1722,8 @@ fn should_fold_nested_gate_non_obj_overwrite() {
     // o = ${?o}         → new_val is Subst; existing prior must be folded so
     //                     resolve(${?o}) returns {a:"xbar"} not {a:"bar"}
     let input = "o.a = \"x\"\no.a = ${?o.a}bar\no = ${?o}";
-    let cfg = hocon::parse_with_env(input, &std::collections::HashMap::new())
-        .expect("parse failed");
+    let cfg =
+        hocon::parse_with_env(input, &std::collections::HashMap::new()).expect("parse failed");
     assert_eq!(
         cfg.get_string("o.a").unwrap(),
         "xbar",

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1665,3 +1665,39 @@ fn s13a_13_external_reference_to_self_ref_field() {
     assert_eq!(cfg.get_string("a").unwrap(), "foo");
     assert_eq!(cfg.get_string("b").unwrap(), "foo");
 }
+
+// --- Review #124 Issue 1: dotted-key cache collision fix ----------------------
+/// Regression: a quoted key containing a dot (`"a.b" = "literal"`) and a
+/// nested path with the same segments (`a { b = "nested" }`) must NOT
+/// collide in the substitution cache.  Before the fix, both were stored
+/// under the raw key `a.b`; the literal field's write then overwrote the
+/// nested field's entry, so `${a.b}` returned `"literal"` instead of
+/// `"nested"`.  The resolver now uses `string_segments_to_key` (which
+/// quotes keys containing dots) for the `full_cache_key` in `resolve_res_obj`
+/// and in `cache_descendants`.
+#[test]
+fn dotted_quoted_key_no_cache_collision_with_nested_path() {
+    // `a { b = "nested" }` stores `a.b = "nested"` (two-segment path).
+    // `"a.b" = "literal"` is a top-level key whose *text* contains a literal
+    // dot — it is a single segment `a.b`, stored as `"a.b"` (quoted) in the cache.
+    // `c = ${a.b}` resolves via segments [a, b] → cache key `a.b` (unquoted)
+    // → must find "nested", not "literal".
+    let input = r#"a { b = "nested" }
+"a.b" = "literal"
+c = ${a.b}
+"#;
+    let cfg = hocon::parse_with_env(input, &std::collections::HashMap::new())
+        .expect("parse failed");
+    // The two-segment path resolves correctly.
+    assert_eq!(
+        cfg.get_string("a.b").unwrap(),
+        "nested",
+        "two-segment path a.b must resolve to \"nested\""
+    );
+    // The substitution ${a.b} must NOT be poisoned by the quoted-key entry.
+    assert_eq!(
+        cfg.get_string("c").unwrap(),
+        "nested",
+        "c = ${{a.b}} must return \"nested\" (no cache collision with \"a.b\" quoted key)"
+    );
+}

--- a/tests/self_ref_lookback_test.rs
+++ b/tests/self_ref_lookback_test.rs
@@ -418,6 +418,50 @@ fn sr19_required_self_ref_mixed_no_prior() {
     );
 }
 
+// ── sr21: Codex round-3 review #124 regression guard ──────────────────────
+
+/// sr21: Strict-subset Obj-Obj overwrite where existing has unresolved self-ref.
+///
+/// Codex P2 finding from round-3 review of rs.hocon #124: the fix in commit
+/// 6c0e3f3 (combined gate: same-key OR strict-subset OR Obj-non-Obj) folds
+/// every nested self-reference in existing and saves the folded object as the
+/// outer prior for `o`. But when the strict-subset overwrite leaves the
+/// existing self-ref field LIVE (not overwritten by new), the live ${?o.a}
+/// substitution then reads the outer folded prior (`o.a = "xbar"`) instead
+/// of the inner leaf prior (`o.a = "x"`), producing `o.a = "xbarbar"`.
+///
+/// Input:
+/// ```
+/// o.a = "x"
+/// o.b = 0
+/// o.a = ${?o.a}bar
+/// o = {b = 1}
+/// ```
+/// `o = {b = 1}` is a strict-subset deep-merge; after merge `o.a` is still
+/// the live Concat[${?o.a}, "bar"]. ${?o.a} should resolve via the inner
+/// leaf prior `a = "x"` (the spec-correct previous value of o.a) → "xbar".
+///
+/// Expected: `o.a = "xbar"`, `o.b = 1` (after merge).
+/// Regression: `o.a = "xbarbar"`.
+#[test]
+fn sr21_strict_subset_obj_overwrite_keeps_live_self_ref() {
+    let env = std::collections::HashMap::new();
+    let input = "o.a = \"x\"\no.b = 0\no.a = ${?o.a}bar\no = {b = 1}";
+    let cfg = hocon::parse_with_env(input, &env)
+        .unwrap_or_else(|e| panic!("sr21: unexpected parse error: {:?}", e));
+    assert_eq!(
+        cfg.get_string("o.a").unwrap(),
+        "xbar",
+        "sr21: o.a should be \"xbar\" (Concat resolves via inner leaf prior o.a=\"x\"); \
+         got wrong value — folded outer prior incorrectly preempted leaf prior"
+    );
+    assert_eq!(
+        cfg.get_string("o.b").unwrap(),
+        "1",
+        "sr21: o.b should be \"1\" (deep merge of new value)"
+    );
+}
+
 // ── sr20: Codex round-2 review #124 regression guard ────────────────────────
 
 /// sr20: Same-key Obj-Obj overwrite with nested self-ref.

--- a/tests/self_ref_lookback_test.rs
+++ b/tests/self_ref_lookback_test.rs
@@ -310,3 +310,110 @@ fn sr15_double_self_ref() {
 fn sr16_external_before_self_ref() {
     run_fixture("sr16-external-before-self-ref");
 }
+
+// ── sr17–sr19: mixed-concat semantics (review #124 item a) ──────────────────
+//
+// These tests pin the contract of `fold_optional_self_ref_absent` for concats
+// that mix optional self-refs with other substitutions or literals.
+//
+// Contract (S13a):
+//   - fold_optional_self_ref_absent walks a Concat node-by-node.
+//   - A node that IS the self-ref AND is required → returns None → `?` short-
+//     circuits the whole concat → save is skipped → required-self-ref error
+//     fires at resolve time (sr05-like behaviour).
+//   - A node that IS the self-ref AND is optional → returns Some(known_absent)
+//     → resolve_subst returns Ok(None) → the operand is simply dropped from
+//     the concat fold (omission rule, Phase 6 #3b).
+//   - A node that is NOT the self-ref (e.g. ${b}, a literal, or ${a}
+//     referencing a different key) → falls through to `_ => Some(v.clone())`
+//     → saved as-is in the prior → evaluated at resolve time where it either
+//     resolves normally or errors per its own required/optional status.
+//
+// Consequence: `fold_optional_self_ref_absent` is NOT broken for mixed concats.
+// The `?`-propagation only fires on the exact self-ref node; all other nodes
+// are preserved in the saved prior and deferred to resolve time.
+
+/// sr17: Pure-optional concat `a = ${?a}foo${?b}` no prior.
+/// Both optional refs drop at resolve time; literal "foo" remains → a = "foo".
+/// Pins: non-self-ref optional ${?b} is preserved in saved prior and drops at
+/// resolve time (not incorrectly skipped during fold).
+#[test]
+fn sr17_pure_optional_concat_no_prior() {
+    let env = std::collections::HashMap::new();
+    // a = ${?a}foo${?b}: no prior for a, b not defined anywhere.
+    // fold_or_skip_prior: contains_self_ref=true (${?a}), old=None →
+    //   fold_optional_self_ref_absent called.
+    //   ${?a} node → known_absent Subst (optional self-ref, no prior).
+    //   "foo" literal → Some(literal).
+    //   ${?b} node → NOT self-ref of a → _ arm → Some(${?b} Subst).
+    //   → prior saved as Concat([known_absent_a, "foo", ${?b}]).
+    // At resolve time: known_absent_a → None (dropped); "foo" → "foo";
+    //   ${?b} → None (b undefined, optional) → dropped.
+    //   concat operands: ["foo"] → a = "foo".
+    let result = hocon::parse_with_env("a = ${?a}foo${?b}", &env);
+    assert!(
+        result.is_ok(),
+        "expected Ok but got error: {:?}",
+        result.err()
+    );
+    assert_eq!(
+        result.unwrap().get_string("a").unwrap(),
+        "foo",
+        "a = ${{?a}}foo${{?b}} no prior should resolve to \"foo\""
+    );
+}
+
+/// sr18: Required external ref `a = ${?a}foo${b}` no prior for either.
+/// ${b} is required and has no definition → resolve-time error.
+/// Pins: `fold_optional_self_ref_absent` does NOT fold required non-self-ref
+/// ${b} to absent; it preserves ${b} in the saved prior so the required-missing
+/// error fires correctly at resolve time (not silently swallowed at fold time).
+#[test]
+fn sr18_required_external_no_def_errors() {
+    let env = std::collections::HashMap::new();
+    // a = ${?a}foo${b}: no prior for a, b not defined.
+    // fold_or_skip_prior: contains_self_ref=true (${?a}), old=None →
+    //   fold_optional_self_ref_absent called.
+    //   ${?a} → known_absent.  "foo" → literal.  ${b} → _ arm → Some(${b}).
+    //   → prior saved as Concat([known_absent_a, "foo", ${b}]).
+    // At resolve time: known_absent_a drops; "foo" stays; ${b} required+missing
+    //   → Err("could not resolve substitution: ${b}").
+    let result = hocon::parse_with_env("a = ${?a}foo${b}", &env);
+    assert!(
+        result.is_err(),
+        "expected resolve error for required missing ${{b}}, got Ok"
+    );
+    let err_msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        err_msg.contains("could not resolve substitution") || err_msg.contains("b"),
+        "error message should mention unresolved substitution b, got: {err_msg}"
+    );
+}
+
+/// sr19: Required self-ref `a = ${?a}foo${a}` no prior.
+/// The required ${a} is a self-ref with no prior → resolve error (sr05-like).
+/// Pins: `fold_optional_self_ref_absent` returns None for the required self-ref
+/// node, which short-circuits the entire Concat via `?` → save is skipped →
+/// at resolve time the original value fires the required-self-ref error path.
+#[test]
+fn sr19_required_self_ref_mixed_no_prior() {
+    let env = std::collections::HashMap::new();
+    // a = ${?a}foo${a}: no prior; ${a} is required self-ref.
+    // fold_or_skip_prior: contains_self_ref=true, old=None →
+    //   fold_optional_self_ref_absent called.
+    //   ${?a} → Some(known_absent).  "foo" → Some(literal).
+    //   ${a} (required self-ref) → None → Concat short-circuits → outer None.
+    //   → fold_or_skip_prior returns None → save skipped.
+    // At resolve time: no prior, original value = Concat([${?a},"foo",${a}]).
+    //   is_self_ref fires on ${a} (required, no prior) → Err(self-referential).
+    let result = hocon::parse_with_env("a = ${?a}foo${a}", &env);
+    assert!(
+        result.is_err(),
+        "expected resolve error for required self-ref ${{a}} with no prior, got Ok"
+    );
+    let err_msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        err_msg.contains("self-referential") || err_msg.contains("no prior"),
+        "error message should mention self-referential substitution, got: {err_msg}"
+    );
+}

--- a/tests/self_ref_lookback_test.rs
+++ b/tests/self_ref_lookback_test.rs
@@ -244,12 +244,12 @@ fn sr11_mutual_ref_forward() {
     run_fixture("sr11-mutual-ref-forward");
 }
 
-/// sr12: object-literal form `foo { a = "x"\n a = ${?foo.a}bar }` → `foo.a = "xbar"`
-/// Regression guard: AST normalization must unify object-literal and dotted-path forms
-/// for self-ref look-back (Copilot rs-T1 verification).
-/// Note: HOCON field separator is LF (0x0A); semicolons are not newline equivalents
-/// in this parser, so the multi-field form requires a literal newline inside the
-/// object-literal block.
+/// (cluster 3f, NOT the cluster 3h sr12): object-literal form
+/// `foo { a = "x"\n a = ${?foo.a}bar }` → `foo.a = "xbar"`. Regression guard
+/// for AST normalization unifying object-literal and dotted-path forms.
+/// Note: HOCON field separator is LF (0x0A); semicolons are not newline
+/// equivalents in this parser, so the multi-field form requires a literal
+/// newline inside the object-literal block.
 #[test]
 fn s13a_13_nested_self_ref_object_literal_form() {
     let cfg = hocon::parse_with_env(
@@ -258,4 +258,55 @@ fn s13a_13_nested_self_ref_object_literal_form() {
     )
     .expect("parse failed");
     assert_eq!(cfg.get_string("foo.a").unwrap(), "xbar");
+}
+
+// ── sr12–sr16 (xx.hocon#27 cluster 3h follow-ups) ────────────────────────────
+//
+// 4 cross-impl resolver bugs surfaced by Round-2 multi-agent-review of the
+// S13a.13 cluster 3f PRs. See xx.hocon E14 for the convention. Pre-fix rs.hocon
+// status:
+//   sr12 FAIL-CRASH (stack overflow) — cycle handler clones the resolving set
+//   sr13 FAIL-WRONG (foo.a="xbarbar"; expected "xbar") — fold_nested_self_refs
+//        overwrites prior with already-folded form on the 3rd field write
+//   sr14 FAIL-WRONG (b="x" vs "xfoo") — cache pollution: is_self_ref branch
+//        writes prior to cache, external lookup reads stale entry
+//   sr15 FAIL-WRONG (a="2" vs "12") — fold_or_skip_prior skips when prior
+//        contains self-ref AND no old prior (universal failure cross-impl)
+//   sr16 FAIL-WRONG (a="foofoo" vs "foo") — cache pollution: external caller
+//        traverses self-ref field's concat, caches preview value, then
+//        self-ref field reads stale cache
+
+/// sr12: `foo.a = ${?foo.a}bar; foo.b = ${foo.a}` → `{foo:{a:"bar",b:"bar"}}`
+/// Pre-fix: stack overflow (cycle handler bug in resolve_subst_inner).
+#[test]
+fn sr12_nested_external_ref_no_prior() {
+    run_fixture("sr12-nested-external-ref-no-prior");
+}
+
+/// sr13: `foo.a = "x"; foo.a = ${?foo.a}bar; foo.b = ${foo.a}` → both `"xbar"`.
+/// Pre-fix: `foo.a="xbarbar", foo.b="xbar"` — prior-overwrite-with-folded.
+#[test]
+fn sr13_nested_external_ref_with_prior() {
+    run_fixture("sr13-nested-external-ref-with-prior");
+}
+
+/// sr14: `a = "x"; a = ${?a}foo; b = ${a}` → both `"xfoo"`.
+/// Pre-fix: `a="xfoo", b="x"` — cache pollution from is_self_ref branch.
+#[test]
+fn sr14_cache_prior_external() {
+    run_fixture("sr14-cache-prior-external");
+}
+
+/// sr15: `a = ${?a}1; a = ${?a}2` → `"12"`.
+/// Pre-fix: `"2"` — fold_or_skip_prior drops first concat (universal cross-impl bug).
+#[test]
+fn sr15_double_self_ref() {
+    run_fixture("sr15-double-self-ref");
+}
+
+/// sr16: `b = ${a}; a = ${?a}foo` → `a="foo", b="foo"` (order-independent).
+/// Pre-fix: `a="foofoo", b="foo"` — cache pollution from external preview.
+#[test]
+fn sr16_external_before_self_ref() {
+    run_fixture("sr16-external-before-self-ref");
 }

--- a/tests/self_ref_lookback_test.rs
+++ b/tests/self_ref_lookback_test.rs
@@ -417,3 +417,45 @@ fn sr19_required_self_ref_mixed_no_prior() {
         "error message should mention self-referential substitution, got: {err_msg}"
     );
 }
+
+// ── sr20: Codex round-2 review #124 regression guard ────────────────────────
+
+/// sr20: Same-key Obj-Obj overwrite with nested self-ref.
+///
+/// Codex P2 finding from round-2 review of rs.hocon #124: the fix in commit
+/// 30ce495 dropped the original same-key Obj-Obj fold case, causing ${?o}
+/// inside `o = {a=1, prev=${?o}}` to see the unfolded state of `o` (where
+/// `o.a` is already 1) instead of the prior folded state (where `o.a = "xbar"`).
+///
+/// Input:
+/// ```
+/// o.a = "x"
+/// o.prev = 0
+/// o.a = ${?o.a}bar
+/// o = {a = 1, prev = ${?o}}
+/// ```
+/// `${?o}` on the last line should preview the prior `o` which had `a = "xbar"`.
+/// Expected: `o.prev.a = "xbar"`.
+/// Regression (pre-fix #124 round-2): `o.prev.a = "1bar"`.
+#[test]
+fn sr20_obj_overwrite_same_keys_with_self_ref() {
+    let env = std::collections::HashMap::new();
+    let input = "o.a = \"x\"\no.prev = 0\no.a = ${?o.a}bar\no = {a = 1, prev = ${?o}}";
+    let cfg = hocon::parse_with_env(input, &env)
+        .unwrap_or_else(|e| panic!("sr20: unexpected parse error: {:?}", e));
+    // o.prev is the prior `o` object at the point of the final `o = {...}` overwrite.
+    // At that point o had: a="xbar", prev=0 (from the two dotted assignments).
+    // So o.prev.a should be "xbar".
+    assert_eq!(
+        cfg.get_string("o.prev.a").unwrap(),
+        "xbar",
+        "sr20: o.prev.a should be \"xbar\" (prior o.a = ${{?o.a}}bar resolved to \"xbar\"); \
+         got wrong value — same-key Obj-Obj fold regression"
+    );
+    // Also verify the final o.a = 1 (the last assignment wins).
+    assert_eq!(
+        cfg.get_string("o.a").unwrap(),
+        "1",
+        "sr20: o.a should be \"1\" (last assignment wins)"
+    );
+}


### PR DESCRIPTION
## Summary

Fix 4 cross-impl resolver bugs surfaced by Round-2 multi-agent-review of S13a.13 cluster 3f (xx.hocon#27, E14):

- **sr12** (stack overflow → green): cycle handler + is_self_ref branch detect when saved prior contains self-ref to same key
- **sr13** (post-fold overwrite): save prior BEFORE \`fold_nested_self_refs\`
- **sr14 + sr16** (cache pollution): \`resolve_res_obj\` invalidates cache before resolving each field, writes authoritative value after, recursively caches descendants
- **sr15** (universal "drop first concat" bug): introduce \`SubstPlaceholder.known_absent\` sentinel; \`fold_or_skip_prior\` folds optional no-prior self-refs to sentinel rather than skipping the save

## Pre-fix vs post-fix

| Fixture | Pre-fix | Post-fix |
|---------|---------|----------|
| sr12 | stack overflow | \`{foo:{a:"bar",b:"bar"}}\` |
| sr13 | \`xbarbar\` | \`xbar\` ✅ |
| sr14 | \`b="x"\` | \`b="xfoo"\` ✅ |
| sr15 | \`"2"\` | \`"12"\` ✅ |
| sr16 | \`a="foofoo"\` | \`a="foo"\` ✅ |

## Test evidence

- 17/17 \`tests/self_ref_lookback_test.rs\` pass (sr01-sr16 + object-literal form)
- \`cargo test\`, \`cargo test --features serde\`, \`cargo clippy -- -D warnings\` all green
- No regressions on sr01-sr11 chain self-ref tests

## Spec reference

- E14 (cross-impl detection mechanism variants): xx.hocon#45 MERGED
- S13a.13: HOCON.md L837-L854

## Review status

DRAFT — awaiting human review. multi-agent-review pending.

Co-Authored-By: Codex <noreply@openai.com>