### PR TITLE
test(resolver): cross-impl regression for go.hocon#128 — include-child env-with-default

### DIFF
--- a/tests/issue128_include_env_fallback.rs
+++ b/tests/issue128_include_env_fallback.rs
@@ -90,9 +90,9 @@ fn issue128_include_file_env_unset_preserves_prior_default() {
     .unwrap();
     let input = format!("include \"{}/child.conf\"\n", dir_str);
     let cfg = hocon::parse(&input).expect("parse must succeed");
-    let got = cfg.get_string("registry.instance-id").expect(
-        "registry.instance-id missing — prior default must remain when ${?ENV} is unset",
-    );
+    let got = cfg
+        .get_string("registry.instance-id")
+        .expect("registry.instance-id missing — prior default must remain when ${?ENV} is unset");
     assert_eq!(got, "localhost");
 }
 
@@ -133,9 +133,9 @@ fn issue128_include_package_env_unset_preserves_prior_default() {
             r#"include package("github.com/o3co/rs.hocon/test/issue128-unset", "reference.conf")"#,
         )
         .expect("parse must succeed");
-    let got = cfg.get_string("registry.instance-id").expect(
-        "registry.instance-id missing — prior default must remain when ${?ENV} is unset",
-    );
+    let got = cfg
+        .get_string("registry.instance-id")
+        .expect("registry.instance-id missing — prior default must remain when ${?ENV} is unset");
     assert_eq!(got, "localhost");
 }
 
@@ -150,9 +150,7 @@ fn issue128_include_package_env_set_applies_env_value() {
         CHILD_DEFAULT_PLUS_OPTIONAL_PKG_SET,
     );
     let cfg = parser
-        .parse(
-            r#"include package("github.com/o3co/rs.hocon/test/issue128-set", "reference.conf")"#,
-        )
+        .parse(r#"include package("github.com/o3co/rs.hocon/test/issue128-set", "reference.conf")"#)
         .expect("parse must succeed");
     let got = cfg
         .get_string("registry.instance-id")
@@ -161,4 +159,3 @@ fn issue128_include_package_env_set_applies_env_value() {
     std::env::remove_var("GH128_RS_PKG_SET");
     assert_eq!(got, "from-pkg-env");
 }
-

--- a/tests/issue128_include_env_fallback.rs
+++ b/tests/issue128_include_env_fallback.rs
@@ -1,0 +1,164 @@
+//! Cross-impl regression tests for go.hocon#128 — include-child
+//! `${?ENV_VAR}` env-with-default pattern silently erases the prior
+//! duplicate-key assignment when the env var is unset.
+//!
+//! Pattern under test (canonical Lightbend reference.conf idiom):
+//!
+//! ```hocon
+//! registry {
+//!   instance-id = "localhost"
+//!   instance-id = ${?REGISTRY_INSTANCE_ID}
+//! }
+//! ```
+//!
+//! Spec basis: S7.1 (later non-object overrides earlier) +
+//! S13.2/S13.11 (optional substitution undefined → field not created,
+//! i.e. the second assignment "disappears", leaving the prior) +
+//! S14b.2 (included keys merge per duplicate-key rules — include
+//! boundary is invisible to the merge semantics).
+//!
+//! go.hocon v1.4.1–v1.5.2 lost the include-child's `priorValues` across
+//! a separate lenient-resolve pass; rs.hocon merges include content
+//! into the parent's tree at structure-build time
+//! (`deep_merge_res_obj_into` preserves both fields and `prior_values`,
+//! see `src/resolver/utils.rs`), so a single substitution-resolve pass
+//! over the merged tree never strips the prior. These tests pin that
+//! behaviour so a future refactor to a multi-pass shape can't silently
+//! regress.
+//!
+//! Run: `cargo test --features include-package --test issue128_include_env_fallback`
+
+#![cfg(feature = "include-package")]
+
+use hocon::Parser;
+use std::sync::Mutex;
+use tempfile::tempdir;
+
+// Rust tests run in parallel by default; serialise the ones that touch
+// process env so they don't see one another's writes.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+const CHILD_DEFAULT_PLUS_OPTIONAL_FILE_UNSET: &str = r#"
+registry {
+  instance-id = "localhost"
+  instance-id = ${?GH128_RS_FILE_UNSET}
+}
+"#;
+
+const CHILD_DEFAULT_PLUS_OPTIONAL_FILE_SET: &str = r#"
+registry {
+  instance-id = "localhost"
+  instance-id = ${?GH128_RS_FILE_SET}
+}
+"#;
+
+const CHILD_DEFAULT_PLUS_OPTIONAL_PKG_UNSET: &str = r#"
+registry {
+  instance-id = "localhost"
+  instance-id = ${?GH128_RS_PKG_UNSET}
+}
+"#;
+
+const CHILD_DEFAULT_PLUS_OPTIONAL_PKG_SET: &str = r#"
+registry {
+  instance-id = "localhost"
+  instance-id = ${?GH128_RS_PKG_SET}
+}
+"#;
+
+// Note on deferred-resolve coverage: rs.hocon's `Parser` (the
+// package-registry entry point) does not currently expose a
+// deferred-resolve variant — `Parser::parse` always runs both phases.
+// The module-level `parse_string_with_options(... with_resolve_substitutions(false))`
+// supports deferred resolution but does not thread a package registry.
+// Pinning the deferred path through `include package(...)` therefore
+// awaits a Parser API addition; the immediate-resolve coverage below
+// is sufficient to pin the priorValues-through-merge invariant exercised
+// by go.hocon#128.
+
+#[test]
+fn issue128_include_file_env_unset_preserves_prior_default() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    std::env::remove_var("GH128_RS_FILE_UNSET");
+
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(
+        dir.path().join("child.conf"),
+        CHILD_DEFAULT_PLUS_OPTIONAL_FILE_UNSET,
+    )
+    .unwrap();
+    let input = format!("include \"{}/child.conf\"\n", dir_str);
+    let cfg = hocon::parse(&input).expect("parse must succeed");
+    let got = cfg.get_string("registry.instance-id").expect(
+        "registry.instance-id missing — prior default must remain when ${?ENV} is unset",
+    );
+    assert_eq!(got, "localhost");
+}
+
+#[test]
+fn issue128_include_file_env_set_applies_env_value() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    std::env::set_var("GH128_RS_FILE_SET", "from-env");
+
+    let dir = tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(
+        dir.path().join("child.conf"),
+        CHILD_DEFAULT_PLUS_OPTIONAL_FILE_SET,
+    )
+    .unwrap();
+    let input = format!("include \"{}/child.conf\"\n", dir_str);
+    let cfg = hocon::parse(&input).expect("parse must succeed");
+    let got = cfg
+        .get_string("registry.instance-id")
+        .expect("registry.instance-id missing");
+
+    std::env::remove_var("GH128_RS_FILE_SET");
+    assert_eq!(got, "from-env");
+}
+
+#[test]
+fn issue128_include_package_env_unset_preserves_prior_default() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    std::env::remove_var("GH128_RS_PKG_UNSET");
+
+    let parser = Parser::new().register_package(
+        "github.com/o3co/rs.hocon/test/issue128-unset",
+        "reference.conf",
+        CHILD_DEFAULT_PLUS_OPTIONAL_PKG_UNSET,
+    );
+    let cfg = parser
+        .parse(
+            r#"include package("github.com/o3co/rs.hocon/test/issue128-unset", "reference.conf")"#,
+        )
+        .expect("parse must succeed");
+    let got = cfg.get_string("registry.instance-id").expect(
+        "registry.instance-id missing — prior default must remain when ${?ENV} is unset",
+    );
+    assert_eq!(got, "localhost");
+}
+
+#[test]
+fn issue128_include_package_env_set_applies_env_value() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    std::env::set_var("GH128_RS_PKG_SET", "from-pkg-env");
+
+    let parser = Parser::new().register_package(
+        "github.com/o3co/rs.hocon/test/issue128-set",
+        "reference.conf",
+        CHILD_DEFAULT_PLUS_OPTIONAL_PKG_SET,
+    );
+    let cfg = parser
+        .parse(
+            r#"include package("github.com/o3co/rs.hocon/test/issue128-set", "reference.conf")"#,
+        )
+        .expect("parse must succeed");
+    let got = cfg
+        .get_string("registry.instance-id")
+        .expect("registry.instance-id missing");
+
+    std::env::remove_var("GH128_RS_PKG_SET");
+    assert_eq!(got, "from-pkg-env");
+}
+


### PR DESCRIPTION
## Summary

Cross-impl regression suite pinning rs.hocon's correct handling of the canonical Lightbend reference.conf idiom

```hocon
key = "default"
key = ${?ENV_VAR}
```

when reached through `include "file"` or `include package(...)`. Mirrors the cross-impl pattern used for [go.hocon#105](https://github.com/o3co/rs.hocon/blob/develop/tests/issue105_empty_include.rs) and [go.hocon#106](https://github.com/o3co/rs.hocon/blob/develop/tests/issue106_include_ordering.rs).

## Why this lands now

[go.hocon#128](https://github.com/o3co/go.hocon/issues/128) (PR [#129](https://github.com/o3co/go.hocon/pull/129)) fixed a resolver bug where the include-child's `priorValues` were stripped across a separate lenient-resolve pass — env unset through `include package(...)` silently erased the prior default. The go.hocon PR description flagged ts.hocon and rs.hocon as cross-impl follow-up candidates.

Empirical result (this branch): **rs.hocon does NOT exhibit the bug**. The architecture differs: rs.hocon merges include content into the parent's tree at structure-build time via [`deep_merge_res_obj_into`](https://github.com/o3co/rs.hocon/blob/develop/src/resolver/utils.rs#L144-L147) (which preserves both `fields` and `prior_values`), then runs a **single** substitution-resolve pass over the merged tree. The "include-child does its own lenient resolveSubstitutions pass that strips prior_values" failure mode is structurally absent.

This PR pins that behaviour so a future refactor to a multi-pass shape cannot silently regress.

## Spec basis

- **S7.1** Later non-object key overrides earlier (`docs/spec-checklist.md`)
- **S13.2** + **S13.11** Optional substitution undefined → field not created (so the second assignment "disappears", leaving the prior)
- **S14b.2** Included keys merge per duplicate-key rules — include boundary is invisible to the merge semantics
- Lightbend [`equiv04/missing-substitutions.conf`](https://github.com/o3co/hocon2/blob/main/testdata/lightbend/equiv04/missing-substitutions.conf): `a = ${?NOT_DEFINED}` alone → `{}` (S13.11 fires only when there's no prior)

## Coverage (4 tests)

| Test | Path | Env state |
|---|---|---|
| 1 | `include "file"` | unset → prior retained |
| 2 | `include "file"` | set → env value applied |
| 3 | `include package(...)` | unset → prior retained |
| 4 | `include package(...)` | set → env value applied |

Deferred-resolve through `include package(...)` is not pinned — `Parser` does not currently expose a deferred variant (`Parser::parse` always runs both phases); `parse_string_with_options(... with_resolve_substitutions(false))` supports deferred resolution but does not thread a package registry. Noted in the test file header as a Parser API gap; the immediate-resolve coverage above is sufficient to pin the prior_values-through-merge invariant exercised by go.hocon#128.

## Implementation notes

- Gated on the `include-package` feature (matches existing `tests/include_package_test.rs` convention)
- Uses `static ENV_LOCK: Mutex<()>` to serialise process-env mutations across rustc's parallel test threads

## Test plan

- [x] `cargo test --features include-package --test issue128_include_env_fallback` → **4 PASS**
- [x] `cargo test --features include-package` (full suite) → **801 PASS / 0 FAIL** (no regressions vs. develop)

## Cross-impl pin status

| impl | bug? | regression test |
|---|---|---|
| go.hocon | YES (v1.4.1–v1.5.2) | go.hocon PR [#129](https://github.com/o3co/go.hocon/pull/129) |
| ts.hocon | NO | sibling PR [#138](https://github.com/o3co/ts.hocon/pull/138) |
| rs.hocon | NO | this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)