### PR TITLE
feat(parser): Parser::parse_with_options threading registry through deferred path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `Parser::parse_with_options` / `Parser::parse_file_with_options`
+
+- **New `Parser` entry points that accept `ParseOptions`**, mirroring the module-level [`parse_string_with_options`] / [`parse_file_with_options`] but threading the per-`Parser` package registry through phase 1. This closes an API gap where the deferred-resolve lifecycle (`ParseOptions::with_resolve_substitutions(false)`) was previously only available via the module-level functions, which do not carry a package registry — so deferred parsing of an `include package("identifier", "file")` source was structurally unreachable. The existing `Parser::parse` / `parse_file` / `parse_with_env` / `parse_file_with_env` are now thin delegates to the new methods (no behavioural change for those callers). Pinned by `tests/issue128_include_env_fallback.rs::issue128_include_package_deferred_env_unset_preserves_prior_default`, parity with the go.hocon `TestIncludePackage_OptionalEnvFallback_DeferredPath_PreservesPriorDefault` regression.
+
 ### Changed — E13 key-position parsing (xx.hocon [#42](https://github.com/o3co/xx.hocon/issues/42))
 
 - **S8.6 is no longer enforced on key path segments** — `foo -bar = 1`, `foo.-bar = 1`, `-foo bar = 1`, `foo -1bar = 1` etc. now parse verbatim per Lightbend 1.4.3. The HOCON.md L270-276 "begin with `-` requires digit" rule is a value-position lexer-disambiguation rule (governed by E8 in [xx.hocon extra-spec-conventions](https://github.com/o3co/xx.hocon/blob/main/docs/extra-spec-conventions.md)); key-position is governed by path-element parsing rules where Lightbend takes characters verbatim. Pinned by 8 new fixtures (`key-hyphen-position/kh01–kh08`) in xx.hocon main. Pure loosening — no previously-valid input is now rejected.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,19 +300,7 @@ impl Parser {
         input: &str,
         env: &HashMap<String, String>,
     ) -> Result<Config, HoconError> {
-        let tokens = lexer::tokenize(input)?;
-        assert_non_empty_document(&tokens)?;
-        let ast = parser::parse_tokens(&tokens)?;
-        let opts = self.into_resolve_opts(env.clone(), None);
-        let value = resolver::resolve(ast, &opts)?;
-        match value {
-            HoconValue::Object(fields) => Ok(Config::new(fields)),
-            _ => Err(HoconError::Parse(ParseError {
-                message: "root must be an object".into(),
-                line: 1,
-                col: 1,
-            })),
-        }
+        self.parse_with_options(input, ParseOptions::defaults().with_env(env.clone()))
     }
 
     /// Parse a HOCON file with a custom environment map and the registered registry.
@@ -321,22 +309,71 @@ impl Parser {
         path: impl AsRef<Path>,
         env: &HashMap<String, String>,
     ) -> Result<Config, HoconError> {
+        self.parse_file_with_options(path, ParseOptions::defaults().with_env(env.clone()))
+    }
+
+    /// Parse a HOCON string with explicit [`ParseOptions`] and the registered registry.
+    ///
+    /// Equivalent to the module-level [`parse_string_with_options`] but threads the
+    /// per-`Parser` package registry through phase 1, enabling
+    /// `include package("identifier", "file")` to resolve against `register_package`-supplied
+    /// content. Supports both fused (`resolve_substitutions = true`, default) and deferred
+    /// (`resolve_substitutions = false`) lifecycles. The latter returns an unresolved
+    /// `Config` whose `Config::resolve` call performs phase 2 — includes are already
+    /// inlined at phase 1 so the registry is not needed after this call returns.
+    pub fn parse_with_options(self, input: &str, opts: ParseOptions) -> Result<Config, HoconError> {
+        let tokens = lexer::tokenize(input)?;
+        assert_non_empty_document(&tokens)?;
+        let ast = parser::parse_tokens(&tokens)?;
+
+        let env: HashMap<String, String> = opts.env.clone().unwrap_or_else(|| {
+            if opts.resolve_substitutions {
+                std::env::vars().collect()
+            } else {
+                HashMap::new()
+            }
+        });
+
+        let internal_opts = self.into_resolve_opts(env, opts.base_dir.clone());
+
+        if opts.resolve_substitutions {
+            let value = resolver::resolve(ast, &internal_opts)?;
+            match value {
+                HoconValue::Object(fields) => {
+                    let mut cfg = Config::new(fields);
+                    cfg.parse_base_dir = opts.base_dir;
+                    cfg.origin_description = opts.origin_description;
+                    Ok(cfg)
+                }
+                _ => Err(HoconError::Parse(ParseError {
+                    message: "root must be an object".into(),
+                    line: 1,
+                    col: 1,
+                })),
+            }
+        } else {
+            let tree = resolver::build_tree(ast, &internal_opts)?;
+            Ok(Config::new_from_res_obj(
+                tree,
+                opts.base_dir,
+                opts.origin_description,
+            ))
+        }
+    }
+
+    /// Parse a HOCON file with explicit [`ParseOptions`] and the registered registry.
+    /// File's parent directory is used as base_dir (overrides `opts.base_dir`).
+    pub fn parse_file_with_options(
+        self,
+        path: impl AsRef<Path>,
+        opts: ParseOptions,
+    ) -> Result<Config, HoconError> {
         let path = path.as_ref();
         let content = std::fs::read_to_string(path)
             .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {}", path.display(), e)))?;
-        let tokens = lexer::tokenize(&content)?;
-        assert_non_empty_document(&tokens)?;
-        let ast = parser::parse_tokens(&tokens)?;
-        let opts = self.into_resolve_opts(env.clone(), path.parent().map(|p| p.to_path_buf()));
-        let value = resolver::resolve(ast, &opts)?;
-        match value {
-            HoconValue::Object(fields) => Ok(Config::new(fields)),
-            _ => Err(HoconError::Parse(ParseError {
-                message: "root must be an object".into(),
-                line: 1,
-                col: 1,
-            })),
-        }
+        let base_dir = path.parent().map(|p| p.to_path_buf());
+        let opts = ParseOptions { base_dir, ..opts };
+        self.parse_with_options(&content, opts)
     }
 
     /// Convert this `Parser` into `ResolveOptions`, threading the registry in.
@@ -364,6 +401,9 @@ pub fn parse(input: &str) -> Result<Config, HoconError> {
 /// `opts.resolve_substitutions = true` (default): fused parse + resolve, same
 /// as [`parse`]. `opts.resolve_substitutions = false`: phase 1 only; returned
 /// `Config` may have `is_resolved() = false`. Use [`Config::resolve`] later.
+///
+/// This module-level function does **not** thread a package registry — for that,
+/// use [`Parser::parse_with_options`] (feature `include-package`).
 pub fn parse_string_with_options(input: &str, opts: ParseOptions) -> Result<Config, HoconError> {
     let tokens = lexer::tokenize(input)?;
     assert_non_empty_document(&tokens)?;

--- a/tests/issue128_include_env_fallback.rs
+++ b/tests/issue128_include_env_fallback.rs
@@ -28,9 +28,11 @@
 //!
 //! Hermeticity: env is injected via `hocon::parse_with_env` (string
 //! entry point, for the include "file" tests that build their input as
-//! a string referencing a tempdir path) and `Parser::parse_with_env`
-//! (for the include package(...) tests that need a registry). `std::env`
-//! is never read or mutated. Matches the cross-impl convention used by
+//! a string referencing a tempdir path), `Parser::parse_with_env` (for
+//! the include package(...) tests that need a registry), and
+//! `Parser::parse_with_options` (for the deferred-resolve path
+//! exercised against an include package(...) source). `std::env` is
+//! never read or mutated. Matches the cross-impl convention used by
 //! `ts.hocon` (`parse(input, { env })`). As a result these tests are
 //! safe to run in parallel — no shared mutable process state.
 //!
@@ -38,7 +40,7 @@
 
 #![cfg(feature = "include-package")]
 
-use hocon::Parser;
+use hocon::{ParseOptions, Parser, ResolveOptions};
 use std::collections::HashMap;
 use tempfile::tempdir;
 
@@ -70,15 +72,21 @@ registry {
 }
 "#;
 
-// Note on deferred-resolve coverage: rs.hocon's `Parser` (the
-// package-registry entry point) does not currently expose a
-// deferred-resolve variant — `Parser::parse_with_env` always runs both
-// phases. The module-level `parse_string_with_options(... with_resolve_substitutions(false))`
-// supports deferred resolution but does not thread a package registry.
-// Pinning the deferred path through `include package(...)` therefore
-// awaits a Parser API addition; the immediate-resolve coverage below
-// is sufficient to pin the priorValues-through-merge invariant exercised
-// by go.hocon#128.
+const CHILD_DEFAULT_PLUS_OPTIONAL_PKG_DEFERRED: &str = r#"
+registry {
+  instance-id = "localhost"
+  instance-id = ${?GH128_RS_PKG_DEFERRED}
+}
+"#;
+
+// Deferred-resolve coverage uses `Parser::parse_with_options(...
+// ParseOptions::defaults().with_resolve_substitutions(false).with_env(...))`,
+// which threads the per-Parser package registry through phase 1 and
+// returns an unresolved `Config`. Includes are already inlined at phase 1
+// so the registry is no longer needed when `Config::resolve` runs phase 2.
+// This pins go.hocon#128 (parity with the go.hocon
+// TestIncludePackage_OptionalEnvFallback_DeferredPath_PreservesPriorDefault
+// regression).
 
 #[test]
 fn issue128_include_file_env_unset_preserves_prior_default() {
@@ -156,4 +164,30 @@ fn issue128_include_package_env_set_applies_env_value() {
         .get_string("registry.instance-id")
         .expect("registry.instance-id missing");
     assert_eq!(got, "from-pkg-env");
+}
+
+#[test]
+fn issue128_include_package_deferred_env_unset_preserves_prior_default() {
+    let parser = Parser::new().register_package(
+        "github.com/o3co/rs.hocon/test/issue128-deferred",
+        "reference.conf",
+        CHILD_DEFAULT_PLUS_OPTIONAL_PKG_DEFERRED,
+    );
+    let env: HashMap<String, String> = HashMap::new();
+    let opts = ParseOptions::defaults()
+        .with_resolve_substitutions(false)
+        .with_env(env);
+    let unresolved = parser
+        .parse_with_options(
+            r#"include package("github.com/o3co/rs.hocon/test/issue128-deferred", "reference.conf")"#,
+            opts,
+        )
+        .expect("parse must succeed");
+    let resolved = unresolved
+        .resolve(ResolveOptions::defaults().with_use_system_environment(false))
+        .expect("Resolve must succeed");
+    let got = resolved
+        .get_string("registry.instance-id")
+        .expect("registry.instance-id missing — prior default must remain when ${?ENV} is unset");
+    assert_eq!(got, "localhost");
 }


### PR DESCRIPTION
## Summary

- Add \`Parser::parse_with_options(self, &str, ParseOptions) -> Result<Config, HoconError>\` and \`Parser::parse_file_with_options(self, path, ParseOptions) -> Result<Config, HoconError>\`.
- Both mirror the module-level \`parse_string_with_options\` / \`parse_file_with_options\` but thread the per-\`Parser\` package registry through phase 1.
- Closes the API gap where the deferred-resolve lifecycle (\`with_resolve_substitutions(false)\` → \`Config::resolve\`) was unreachable for \`include package(\"identifier\", \"file\")\` sources.
- Existing \`Parser::parse\` / \`parse_file\` / \`parse_with_env\` / \`parse_file_with_env\` become thin delegates (no behavioural change).

## Why now

Cross-impl follow-up to go.hocon#128. The issue128 regression file's header
previously documented this API gap as a deferred coverage TODO; with the new
methods in place we can pin the deferred path through \`include package(...)\`
the same way go.hocon already does
(\`TestIncludePackage_OptionalEnvFallback_DeferredPath_PreservesPriorDefault\`).

Internally, includes are already inlined at phase 1, so the registry is not
needed once \`Config::resolve\` runs phase 2 — the existing \`Config::resolve\`
path needs no change.

## What's pinned

New regression test:

- \`tests/issue128_include_env_fallback.rs::issue128_include_package_deferred_env_unset_preserves_prior_default\` — parses an \`include package(...)\` source deferred, then resolves with \`use_system_environment=false\`, and asserts the prior default \"localhost\" survives the \`\${?ENV}\` fallback being undefined. This is the deferred-half of the go.hocon#128 cluster.

## Test plan

- [x] \`cargo test --features include-package\` — all green (the new test passes; existing 4 issue128 tests + everything else unchanged)
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy -- -D warnings\` + \`cargo clippy --features serde -- -D warnings\` clean (matches CI scope)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)