### PR TITLE
fix(parser): S10.5 + S10.11 cross-impl spec fixes (go.hocon#132/#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.6.0] - 2026-05-27
 
-Minor-version bump because of the new public-surface addition to `Parser`
-(see "Added" below). Functional content (the fixes) matches [go.hocon
-v1.5.3](https://github.com/o3co/go.hocon/releases/tag/v1.5.3) and
-[ts.hocon v1.5.3](https://github.com/o3co/ts.hocon/releases/tag/v1.5.3),
-so the 3-impl release line has intentionally diverged at this point:
-rs.hocon ships the same fixes plus a backwards-compatible API addition.
-SemVer mandates minor for purely additive changes; the version skip
-(v1.5.2 → v1.6.0) keeps that invariant honest. Safe drop-in upgrade
-from v1.5.2.
+Cross-impl release coordinated to land at v1.6.0 across go.hocon /
+ts.hocon / rs.hocon. Minor-version bump (skipping v1.5.3 for rs.hocon)
+because of the new public-surface addition to `Parser` (see "Added") and
+the two S10 string-concat spec fixes below. Carries the spec-compliance
+content already shipped in [go.hocon
+v1.5.3](https://github.com/o3co/go.hocon/releases/tag/v1.5.3)
+(xx.hocon#22 / #27 / #42, go.hocon#128 pins) plus two cross-impl fixes
+from the go.hocon#131–#135 audit that apply to rs.hocon: S10.5 (#132)
+and S10.11 (#133). (go.hocon#134 — `+=` accumulation across includes —
+also applies to rs.hocon but is deferred to a follow-up: the correct fix
+is a resolver-chain change that needs the multi-agent-review treatment
+the chained-self-ref machinery already required.) Safe drop-in upgrade
+from v1.5.2; the only one-time source-visible change is `Token` becoming
+`#[non_exhaustive]` (E13, documented below).
 
 ### Added — `Parser::parse_with_options` / `Parser::parse_file_with_options`
 
 - **New `Parser` entry points that accept `ParseOptions`**, mirroring the module-level `parse_string_with_options` / `parse_file_with_options` but threading the per-`Parser` package registry through phase 1. This closes an API gap where the deferred-resolve lifecycle (`ParseOptions::with_resolve_substitutions(false)`) was previously only available via the module-level functions, which do not carry a package registry — so deferred parsing of an `include package("identifier", "file")` source was structurally unreachable. The existing `Parser::parse` / `parse_file` / `parse_with_env` / `parse_file_with_env` are now thin delegates to the new methods (no behavioural change for those callers). Pinned by `tests/issue128_include_env_fallback.rs::issue128_include_package_deferred_env_unset_preserves_prior_default`, parity with the go.hocon `TestIncludePackage_OptionalEnvFallback_DeferredPath_PreservesPriorDefault` regression.
+
+### Fixed — S10.5 inner whitespace in value concatenation ([go.hocon#132](https://github.com/o3co/go.hocon/issues/132))
+
+- **Literal whitespace runs between simple values in a string concatenation are now preserved verbatim** (HOCON.md §String value concatenation L332). `parse_value` inserted a single hardcoded `" "` separator between concat pieces, collapsing every multi-space run to one space (`foo   bar` → `"foo bar"`, and `"left"  ${?UNSET}  "right"` → `"left  right"` instead of Lightbend's `"left    right"`). The fix threads `peek_preceding_whitespace()` (the lexer field E13 already added for key-position whitespace) into the value-position separator. Single-space concatenations are unchanged, so no existing behaviour shifts. Pinned by 6 tests in `tests/s10_5_concat_whitespace.rs`.
+
+### Fixed — S10.11 numeric lexeme preserved for stringification ([go.hocon#133](https://github.com/o3co/go.hocon/issues/133))
+
+- **Numbers now stringify "as written in the source file" when used as the target of a substitution inside a string concatenation** (HOCON.md L366). `parse_scalar_value` canonicalized integer lexemes via `n.to_string()` (`05` → `"5"`, `01` → `"1"`), so `version = ${major}.${minor}` with `minor = 05` produced `"26.5"` instead of `"26.05"`. The `Number` scalar now retains the raw source lexeme; the numeric accessors (`get_i64`, serde `ScalarType::Number`) already re-parse `raw`, so the standalone value is unchanged (`01` still reads as 1 and serializes as `1`). This refines the earlier E8/F3 decision that over-canonicalized the `raw` field — the two affected E8 unit tests are updated to assert lexeme preservation plus a semantic-accessor check; the us13 JSON fixture (`{"a":1}`) is unaffected. Pinned by 6 tests in `tests/s10_11_numeric_lexeme.rs`.
 
 ### Changed — E13 key-position parsing (xx.hocon [#42](https://github.com/o3co/xx.hocon/issues/42))
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -837,6 +837,14 @@ impl<'a> Parser<'a> {
             }
 
             let had_space = self.peek_preceding_space() && !parts.is_empty();
+            // S10.5: inner whitespace between simple values is preserved verbatim,
+            // so capture the literal run (not a collapsed single space) before the
+            // node match advances past the token.
+            let preceding_ws = if had_space {
+                self.peek_preceding_whitespace().to_string()
+            } else {
+                String::new()
+            };
             let t_line = self.peek_line();
             let t_col = self.peek_col();
 
@@ -892,8 +900,17 @@ impl<'a> Parser<'a> {
             };
 
             if had_space {
+                // Preserve the literal whitespace run (S10.5). Defensive fallback to
+                // a single space if the lexer reported preceding_space but captured no
+                // chars (should not happen for value-position whitespace, which is
+                // pure HOCON_WS with no comments).
+                let sep = if preceding_ws.is_empty() {
+                    " ".to_string()
+                } else {
+                    preceding_ws
+                };
                 parts.push(AstNode::Scalar {
-                    value: ScalarValue::string(" ".into()),
+                    value: ScalarValue::string(sep),
                     pos: Pos {
                         line: t_line,
                         col: t_col,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1055,11 +1055,17 @@ fn parse_scalar_value(raw: &str) -> ScalarValue {
     let starts_like_number = matches!(raw.as_bytes(), [b'0'..=b'9', ..] | [b'-', b'0'..=b'9', ..]);
 
     if starts_like_number {
-        // i64 first for canonical-form normalization: `01` → "1", `-0` → "0",
-        // matching Lightbend's parseLong (which silently drops leading zeros
-        // and the negative-zero sign). This is the F3 BREAKING surface.
-        if let Ok(n) = raw.parse::<i64>() {
-            return ScalarValue::number(n.to_string());
+        // S10.11 (go.hocon#133): a numeric value stringifies "as written in the
+        // source file" when it is the target of a substitution inside a string
+        // concatenation. Lightbend keeps the original lexeme ("05" → "26.05")
+        // for stringification while still rendering the standalone value
+        // semantically (getInt / serde re-parse the lexeme, dropping leading
+        // zeros and the negative-zero sign). So preserve the raw token text here
+        // rather than canonicalizing via `n.to_string()`; the numeric accessors
+        // (`get_i64`, serde `ScalarType::Number`) already parse `raw`, so the
+        // standalone semantic value is unchanged (`01` still reads as 1).
+        if raw.parse::<i64>().is_ok() {
+            return ScalarValue::number(raw.to_string());
         }
         // f64 fallback for fractional / scientific forms — preserve the
         // original input text rather than f64-round-tripping (Lightbend

--- a/tests/s10_11_numeric_lexeme.rs
+++ b/tests/s10_11_numeric_lexeme.rs
@@ -21,10 +21,7 @@
 
 #[test]
 fn s10_11_leading_zero_preserved_in_concat() {
-    let cfg = hocon::parse(
-        "major = 26\nminor = 05\nversion = ${major}.${minor}\n",
-    )
-    .expect("parse");
+    let cfg = hocon::parse("major = 26\nminor = 05\nversion = ${major}.${minor}\n").expect("parse");
     assert_eq!(cfg.get_string("version").unwrap(), "26.05");
 }
 

--- a/tests/s10_11_numeric_lexeme.rs
+++ b/tests/s10_11_numeric_lexeme.rs
@@ -1,0 +1,67 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+//! S10.11 — numbers stringify "as written in the source file" (HOCON.md
+//! §String value concatenation, L366). Cross-impl regression for
+//! go.hocon#133.
+//!
+//! Pre-fix, `parse_scalar_value` canonicalized integer lexemes via
+//! `n.to_string()` (`05` → `"5"`, `01` → `"1"`), so a `${minor}`
+//! substitution into a string concat lost the leading zero
+//! (`version = ${major}.${minor}` → `"26.5"` instead of `"26.05"`).
+//! Lightbend keeps the source lexeme for stringification while still
+//! reading the standalone value semantically (`getInt` / serde re-parse,
+//! dropping leading zeros). The fix stores the raw token text in the
+//! `Number` scalar's `raw` field; numeric accessors already parse it.
+
+#[test]
+fn s10_11_leading_zero_preserved_in_concat() {
+    let cfg = hocon::parse(
+        "major = 26\nminor = 05\nversion = ${major}.${minor}\n",
+    )
+    .expect("parse");
+    assert_eq!(cfg.get_string("version").unwrap(), "26.05");
+}
+
+#[test]
+fn s10_11_standalone_numeric_still_canonical() {
+    // The standalone value reads/serializes semantically: 05 → 5.
+    let cfg = hocon::parse("minor = 05\n").expect("parse");
+    assert_eq!(cfg.get_i64("minor").unwrap(), 5);
+}
+
+#[test]
+fn s10_11_leading_zero_string_getter_returns_lexeme() {
+    // Lenient get_string on a numeric scalar returns the source lexeme
+    // (Lightbend's getString throws WrongType; rs.hocon is lenient and
+    // must echo the preserved lexeme, not a canonicalized form).
+    let cfg = hocon::parse("minor = 05\n").expect("parse");
+    assert_eq!(cfg.get_string("minor").unwrap(), "05");
+}
+
+#[test]
+fn s10_11_negative_zero_lexeme_in_concat() {
+    let cfg = hocon::parse("z = -0\ns = v${z}\n").expect("parse");
+    assert_eq!(cfg.get_string("s").unwrap(), "v-0");
+    assert_eq!(cfg.get_i64("z").unwrap(), 0);
+}
+
+#[test]
+fn s10_11_unquoted_numeric_prefix_name_unaffected() {
+    // `00_example` is not a pure number (parse::<i64> fails), so it stays a
+    // string verbatim — this path was already correct, pinned as a guard.
+    let cfg = hocon::parse("name = 00_example\n").expect("parse");
+    assert_eq!(cfg.get_string("name").unwrap(), "00_example");
+}
+
+#[test]
+fn s10_11_fractional_lexeme_preserved() {
+    // Fractional forms were already preserved (f64 path kept raw); guard it.
+    let cfg = hocon::parse("pi = 3.140\ns = v${pi}\n").expect("parse");
+    assert_eq!(cfg.get_string("s").unwrap(), "v3.140");
+}

--- a/tests/s10_5_concat_whitespace.rs
+++ b/tests/s10_5_concat_whitespace.rs
@@ -1,0 +1,66 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+//! S10.5 — inner whitespace between simple values in a string value
+//! concatenation is preserved verbatim (HOCON.md §String value
+//! concatenation, L332). Cross-impl regression for go.hocon#132.
+//!
+//! Pre-fix, rs.hocon's `parse_value` inserted a single hardcoded `" "`
+//! separator between concat pieces regardless of how many whitespace
+//! characters the source had, collapsing every multi-space run to one
+//! space. Lightbend keeps the literal run. The fix threads
+//! `peek_preceding_whitespace()` (the same lexer field E13 added for
+//! key-position whitespace) into the value-position separator.
+//!
+//! The undefined-optional case (`"left"  ${?UNSET}  "right"`) is the
+//! shape reported in go.hocon#132: both surrounding whitespace runs must
+//! survive even though the substitution between them resolves to nothing,
+//! yielding `"left    right"` (2 + 2 = 4 spaces).
+
+use std::collections::HashMap;
+
+#[test]
+fn s10_5_unquoted_multi_space_preserved() {
+    let cfg = hocon::parse("a = foo   bar\n").expect("parse");
+    assert_eq!(cfg.get_string("a").unwrap(), "foo   bar");
+}
+
+#[test]
+fn s10_5_quoted_multi_space_preserved() {
+    let cfg = hocon::parse("a = \"foo\"   \"bar\"\n").expect("parse");
+    assert_eq!(cfg.get_string("a").unwrap(), "foo   bar");
+}
+
+#[test]
+fn s10_5_single_space_unchanged() {
+    let cfg = hocon::parse("a = foo bar\n").expect("parse");
+    assert_eq!(cfg.get_string("a").unwrap(), "foo bar");
+}
+
+#[test]
+fn s10_5_defined_subst_multi_space_preserved() {
+    let cfg = hocon::parse("x = mid\na = \"left\"  ${x}  \"right\"\n").expect("parse");
+    assert_eq!(cfg.get_string("a").unwrap(), "left  mid  right");
+}
+
+#[test]
+fn s10_5_undefined_optional_keeps_both_runs() {
+    // go.hocon#132 canonical repro: env unset → substitution contributes
+    // nothing, but the 2 + 2 whitespace runs around it must remain.
+    let env: HashMap<String, String> = HashMap::new();
+    let cfg = hocon::parse_with_env("a = \"left\"  ${?GO132_UNSET}  \"right\"\n", &env)
+        .expect("parse");
+    assert_eq!(cfg.get_string("a").unwrap(), "left    right");
+}
+
+#[test]
+fn s10_5_tab_run_preserved() {
+    // HOCON_WS includes tab; the literal run (space + tab + space) is kept.
+    let cfg = hocon::parse("a = foo \t bar\n").expect("parse");
+    assert_eq!(cfg.get_string("a").unwrap(), "foo \t bar");
+}

--- a/tests/s10_5_concat_whitespace.rs
+++ b/tests/s10_5_concat_whitespace.rs
@@ -53,8 +53,8 @@ fn s10_5_undefined_optional_keeps_both_runs() {
     // go.hocon#132 canonical repro: env unset → substitution contributes
     // nothing, but the 2 + 2 whitespace runs around it must remain.
     let env: HashMap<String, String> = HashMap::new();
-    let cfg = hocon::parse_with_env("a = \"left\"  ${?GO132_UNSET}  \"right\"\n", &env)
-        .expect("parse");
+    let cfg =
+        hocon::parse_with_env("a = \"left\"  ${?GO132_UNSET}  \"right\"\n", &env).expect("parse");
     assert_eq!(cfg.get_string("a").unwrap(), "left    right");
 }
 

--- a/tests/s8_unquoted_starts.rs
+++ b/tests/s8_unquoted_starts.rs
@@ -271,34 +271,34 @@ fn e8_value_start_hyphen_alone_lexes_as_unquoted() {
 }
 
 #[test]
-fn e8_value_start_leading_zero_normalizes_to_number_one() {
-    // F3 BREAKING (vs all prior rs.hocon behavior): `a = 01` is a digit-
-    // leading run that the E8 amendment specifies should be coerced via the
-    // greedy numeric path with i64-first parsing. `parse_scalar_value` now
-    // normalizes leading zeros: `"01".parse::<i64>()` returns 1, so the
-    // stored `raw` becomes `"1"`. Lightbend produces the same `{"a":1}`
-    // JSON via its parseLong fallback.
+fn e8_value_start_leading_zero_preserves_lexeme_but_reads_as_number() {
+    // `a = 01` is a digit-leading run coerced via the E8 greedy numeric path
+    // (value_type = Number). S10.11 (go.hocon#133) refines the earlier F3
+    // decision: a numeric value stringifies "as written in the source file",
+    // so the stored `raw` must KEEP the original lexeme `"01"` for string
+    // concatenation, while the typed/semantic accessors re-parse it. Lightbend
+    // does the same — `${a}` in a string concat yields "01", but the standalone
+    // value reads as 1 and renders as `1` in JSON.
     //
-    // BREAKING surface: `get_string("a")` now returns `"1"` (was `"01"`);
-    // typed `get_i64("a")` returns 1 (unchanged); JSON serialization
-    // produces `1` (unchanged).
+    // (Earlier this asserted `raw == "1"`; that over-canonicalized the lexeme
+    // and was the go.hocon#133 bug — corrected here cross-impl.)
     let cfg = parse("a = 01");
     let sv = get_scalar(&cfg, "a");
     assert_eq!(sv.value_type, hocon::ScalarType::Number);
-    assert_eq!(
-        sv.raw, "1",
-        "leading zero must be normalized to canonical i64 form"
-    );
+    assert_eq!(sv.raw, "01", "S10.11: numeric lexeme preserved as written");
+    // Semantic value still canonical:
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
 }
 
 #[test]
-fn e8_value_start_negative_zero_normalizes_to_zero() {
-    // `-0` parses as i64 = 0; the canonical form drops the sign (no negative
-    // zero in integer arithmetic). Lightbend's parseLong does the same.
+fn e8_value_start_negative_zero_preserves_lexeme_but_reads_as_zero() {
+    // `-0` reads as i64 = 0 (no negative zero in integer arithmetic), but its
+    // source lexeme `"-0"` is preserved in `raw` for S10.11 stringification.
     let cfg = parse("a = -0");
     let sv = get_scalar(&cfg, "a");
     assert_eq!(sv.value_type, hocon::ScalarType::Number);
-    assert_eq!(sv.raw, "0");
+    assert_eq!(sv.raw, "-0", "S10.11: numeric lexeme preserved as written");
+    assert_eq!(cfg.get_i64("a").unwrap(), 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two cross-impl spec fixes from the go.hocon#131–#135 audit that apply to rs.hocon, for the coordinated v1.6.0 release:

- **#132 (S10.5)** — preserve literal whitespace runs in value concatenation. `parse_value` collapsed every multi-space run to a single `" "` separator; now threads `peek_preceding_whitespace()` (the E13 lexer field) into the value-position separator. `"left"  ${?UNSET}  "right"` → `"left    right"` (was `"left  right"`).
- **#133 (S10.11)** — numbers stringify "as written in the source file". `parse_scalar_value` canonicalized integer lexemes (`05` → `"5"`); the `Number` scalar now keeps the raw lexeme so `version = ${major}.${minor}` (`minor = 05`) → `"26.05"`. Standalone value semantics unchanged (`get_i64`/serde re-parse). Refines the earlier E8/F3 over-canonicalization; 2 E8 unit tests updated.

## #134 split out

go.hocon#134 (`+=` accumulation across includes) also applies to rs.hocon but is **deferred to a dedicated follow-up cluster**. The initial fix (a merge-time `src.prior_values.contains_key` discriminator) was flagged by Copilot as ambiguous: a within-file `+=` chain inside an included file also creates a source prior, so it conflates "accumulate" with "reset" and drops a preceding include's elements. Verified empirically. The correct fix needs origin-tracking or prior-chain composition — the multi-agent-review treatment the chained-self-ref machinery (#118/#119/sr15) already required. WIP preserved on branch `wip/issue134-plus-equals-cluster`.

## Test plan

- [x] 12 new regression tests (`tests/s10_5_concat_whitespace.rs` ×6, `tests/s10_11_numeric_lexeme.rs` ×6)
- [x] full suite passes / 0 failed
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -- -D warnings` + `--features serde` clean (CI scope)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)