### PR TITLE
release(v1.6.1): go.hocon#134 += include accumulation + Cargo.toml bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.6.1] - 2026-05-29
 
 Bugfix release: S13b.2 `+=` accumulation across includes ([go.hocon#134](https://github.com/o3co/go.hocon/issues/134)) — the follow-up deferred from v1.6.0. No public API changes; safe drop-in upgrade from v1.6.0. `Cargo.toml` is pre-bumped to `1.6.1` (the publish workflow's version-set step is idempotent).
@@ -205,7 +207,8 @@ Behaviour:
 
 - **CI: content-addressable testdata cache** (closes [#101](https://github.com/o3co/rs.hocon/issues/101)). `.github/workflows/test.yml` and `.github/workflows/publish.yml` previously used `actions/cache@v5` with `key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}`. The hash evaluated BEFORE the cache restore step ran, but `.xx-hocon-version` is gitignored and absent on fresh checkouts — so the key collapsed to a constant and cache entries shared the same slot. Split into `actions/cache/restore@v5` (matches via `restore-keys`) + `actions/cache/save@v5` (writes with the post-fetch hash, gated on `make testdata` success). No production code touched.
 
-[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/o3co/rs.hocon/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/o3co/rs.hocon/compare/v1.5.2...v1.6.0
 [1.5.2]: https://github.com/o3co/rs.hocon/compare/v1.5.0...v1.5.2
 [1.5.0]: https://github.com/o3co/rs.hocon/compare/v1.4.1...v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.6.1] - 2026-05-29
+
+Bugfix release: S13b.2 `+=` accumulation across includes ([go.hocon#134](https://github.com/o3co/go.hocon/issues/134)) — the follow-up deferred from v1.6.0. No public API changes; safe drop-in upgrade from v1.6.0. `Cargo.toml` is pre-bumped to `1.6.1` (the publish workflow's version-set step is idempotent).
 
 ### Fixed — S13b.2 `+=` accumulation across includes ([go.hocon#134](https://github.com/o3co/go.hocon/issues/134))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hocon-parser"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "criterion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hocon-parser"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 rust-version = "1.82"
 description = "Full Lightbend HOCON specification-compliant parser for Rust"


### PR DESCRIPTION
## Summary

Release-prep for **v1.6.1** (rs.hocon). Promotes the `[Unreleased]` CHANGELOG section to `## [1.6.1] - 2026-05-29` and pre-bumps `Cargo.toml` / `Cargo.lock` `1.6.0` → `1.6.1`.

Bugfix release, no public API changes — safe drop-in from v1.6.0:
- **go.hocon#134** — S13b.2 `+=` accumulation across includes (the follow-up deferred from v1.6.0).

## Release flow

After merge to develop, `v1.6.1` is tagged on the merged develop tip; `publish.yml` (push tag `v*`) runs `cargo set-version` from the tag (idempotent — skips when `Cargo.toml` already matches, which it now does) and publishes to crates.io.

## Test plan

- [x] CHANGELOG + version-bump only; `cargo update -p hocon-parser --precise 1.6.1` synced the lockfile; full suite already green on develop (#134 merged, 30cac55)

🤖 Generated with [Claude Code](https://claude.com/claude-code)