### PR TITLE
fix(resolver): fold nested self-refs in outer-merge priors and resolve descended value on cycle recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@ Two related defects in the cycle-recovery path:
    substitutions this returned the wrong subtree — typically an
    `Object` where the substitution targeted a leaf — which then
    surfaced as a downstream `S10` kind-mismatch in any concat that
-   consumed the result. The defect was masked by (1) on `develop`
-   because most multi-segment cycle paths bailed out via
-   `skip_due_to_self_ref` before the broken resolution call.
+   consumed the result. The defect was masked by (1) — most
+   multi-segment cycle paths bailed out via `skip_due_to_self_ref`
+   before the broken resolution call.
 
 `pyhocon`, Lightbend's reference impl, and `mockersf/hocon` all
 parse the same shapes correctly. No public API changes; safe drop-in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — false-positive `circular substitution` from cycle-recovery on chained self-refs nested below an outer-merge boundary
+
+Two related defects in the cycle-recovery path:
+
+1. **`utils::deep_merge_res_obj_into`** does not fold deeply-nested
+   self-refs inside the value it stores as an outer-level prior.
+   `fold_or_skip_prior` only matches `Subst` nodes whose path equals
+   the outer key, so a `Subst("<outer-key>.x.y.z")` nested inside
+   `prior` passes through unfolded — silently breaking the
+   "every saved prior is self-ref-free" invariant from
+   `fold_self_ref.rs`'s module comment. A later cycle-recovery descent
+   into the saved prior trips `contains_subst_by_path` on a
+   self-reference the leaf-level path already has a folded value for,
+   the `xx.hocon#27 sr12` short-circuit fires, and the resolver errors
+   `circular substitution` even though the leaf has a resolvable
+   prior chain. Fixed by adding a `fold_nested_self_refs` pass after
+   `fold_or_skip_prior` in `deep_merge_res_obj_into`'s Obj-Obj branch.
+
+2. **`substitution_resolver::resolve_subst`'s cycle-recovery call**
+   resolved `&prior` (the whole outer prior, often the entire
+   root-segment subtree) instead of `prior_for_check` (the value
+   already descended along `s.segments[1..]`). For multi-segment
+   substitutions this returned the wrong subtree — typically an
+   `Object` where the substitution targeted a leaf — which then
+   surfaced as a downstream `S10` kind-mismatch in any concat that
+   consumed the result. The defect was masked by (1) on `develop`
+   because most multi-segment cycle paths bailed out via
+   `skip_due_to_self_ref` before the broken resolution call.
+
+`pyhocon`, Lightbend's reference impl, and `mockersf/hocon` all
+parse the same shapes correctly. No public API changes; safe drop-in.
+
 ### Fixed
 
 - **CI: testdata fixtures are fetched fresh instead of partially cached**

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -240,12 +240,21 @@ impl<'a> SubstitutionResolver<'a> {
                     // For a multi-segment substitution `${a.b.c.d}`, `prior`
                     // is the entire `a` subtree; resolving it would return the
                     // whole Object instead of the leaf the substitution
-                    // targets. `prior_for_check` falls back to `&prior` when
-                    // the descent at `s.segments[1..]` could not match
-                    // (currently only when `prior` is not an Obj, but the
-                    // fallback keeps the recovery defensive against future
-                    // changes that could legitimately produce other paths
-                    // to `None`).
+                    // targets.
+                    //
+                    // `prior_for_check` is `None` in two cases (see its
+                    // construction above): (1) multi-segment and `prior` is not
+                    // an Obj, and (2) multi-segment, `prior` IS an Obj but
+                    // `lookup_path` cannot descend `s.segments[1..]` inside it
+                    // (the descended path is absent). In both the fallback
+                    // resolves the whole `&prior` — the pre-fix whole-subtree
+                    // behaviour. Case (2) is currently dormant:
+                    // `resolve_subst_inner` emits the "self-referential with no
+                    // prior value" error for an absent descended path before
+                    // this cycle branch is reached with such a prior, so the
+                    // fallback is not observed to leak a whole subtree today. It
+                    // is kept as the conservative default rather than asserting
+                    // unreachability via `expect`.
                     let prior_at_path = prior_for_check.as_ref().unwrap_or(&prior);
                     let result = self.resolve_val(prior_at_path, scope);
                     std::mem::swap(&mut self.resolving, &mut fresh_resolving);

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -238,12 +238,14 @@ impl<'a> SubstitutionResolver<'a> {
                     // Resolve the descended value at the substitution's exact
                     // path (`prior_for_check`), not the whole outer prior.
                     // For a multi-segment substitution `${a.b.c.d}`, `prior`
-                    // is the entire `a` subtree; resolving it returns the
+                    // is the entire `a` subtree; resolving it would return the
                     // whole Object instead of the leaf the substitution
-                    // targets. `prior_for_check` is `None` only on the
-                    // unreachable `_ => None` arm above (prior is not an
-                    // Obj); falling back to `&prior` preserves prior
-                    // behaviour on that path.
+                    // targets. `prior_for_check` falls back to `&prior` when
+                    // the descent at `s.segments[1..]` could not match
+                    // (currently only when `prior` is not an Obj, but the
+                    // fallback keeps the recovery defensive against future
+                    // changes that could legitimately produce other paths
+                    // to `None`).
                     let prior_at_path = prior_for_check.as_ref().unwrap_or(&prior);
                     let result = self.resolve_val(prior_at_path, scope);
                     std::mem::swap(&mut self.resolving, &mut fresh_resolving);

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -235,7 +235,17 @@ impl<'a> SubstitutionResolver<'a> {
                     let mut fresh_resolving = self.resolving.clone();
                     fresh_resolving.remove(&key);
                     std::mem::swap(&mut self.resolving, &mut fresh_resolving);
-                    let result = self.resolve_val(&prior, scope);
+                    // Resolve the descended value at the substitution's exact
+                    // path (`prior_for_check`), not the whole outer prior.
+                    // For a multi-segment substitution `${a.b.c.d}`, `prior`
+                    // is the entire `a` subtree; resolving it returns the
+                    // whole Object instead of the leaf the substitution
+                    // targets. `prior_for_check` is `None` only on the
+                    // unreachable `_ => None` arm above (prior is not an
+                    // Obj); falling back to `&prior` preserves prior
+                    // behaviour on that path.
+                    let prior_at_path = prior_for_check.as_ref().unwrap_or(&prior);
+                    let result = self.resolve_val(prior_at_path, scope);
                     std::mem::swap(&mut self.resolving, &mut fresh_resolving);
                     return result;
                 }

--- a/src/resolver/utils.rs
+++ b/src/resolver/utils.rs
@@ -121,6 +121,16 @@ pub(crate) fn deep_merge_res_obj_into(dst: &mut ResObj, src: ResObj, path_prefix
                     &full_key,
                     prior_existing.as_ref(),
                 ) {
+                    // fold_or_skip_prior only matches Subst nodes whose path
+                    // equals `full_key` (the outer key). It does not detect
+                    // self-refs nested at child paths inside `prior`, so
+                    // without a recursive fold the saved prior breaks the
+                    // "every saved prior is self-ref-free" invariant from
+                    // fold_self_ref.rs. A later cycle-recovery descent into
+                    // the prior would then trip contains_subst_by_path on a
+                    // self-ref the leaf-level path already has a folded
+                    // value for.
+                    let prior = super::fold_self_ref::fold_nested_self_refs(&prior, &child_prefix);
                     dst.prior_values.insert(k.clone(), prior);
                 }
             }

--- a/src/resolver/utils.rs
+++ b/src/resolver/utils.rs
@@ -130,8 +130,9 @@ pub(crate) fn deep_merge_res_obj_into(dst: &mut ResObj, src: ResObj, path_prefix
                     // the prior would then trip contains_subst_by_path on a
                     // self-ref the leaf-level path already has a folded
                     // value for.
-                    let prior = super::fold_self_ref::fold_nested_self_refs(&prior, &child_prefix);
-                    dst.prior_values.insert(k.clone(), prior);
+                    let prior_self_ref_free =
+                        super::fold_self_ref::fold_nested_self_refs(&prior, &child_prefix);
+                    dst.prior_values.insert(k.clone(), prior_self_ref_free);
                 }
             }
             deep_merge_res_obj_into(&mut dst_obj, src_obj, &child_prefix);

--- a/src/resolver/utils.rs
+++ b/src/resolver/utils.rs
@@ -130,6 +130,19 @@ pub(crate) fn deep_merge_res_obj_into(dst: &mut ResObj, src: ResObj, path_prefix
                     // the prior would then trip contains_subst_by_path on a
                     // self-ref the leaf-level path already has a folded
                     // value for.
+                    //
+                    // Unlike structure_builder.rs's sr13 site, this fold needs
+                    // no `should_fold_nested` guard. The two folds here target
+                    // disjoint key sets: fold_or_skip_prior folds only the
+                    // outer-key self-ref `${full_key}`, while fold_nested_self_refs
+                    // folds only deeper nested-path self-refs against each
+                    // sub-object's own prior_values — no node is folded twice.
+                    // fold_nested_self_refs is also self-guarded by
+                    // contains_self_ref per leaf, so applying it to an
+                    // already-self-ref-free prior (e.g. on a subsequent merge
+                    // into the same key) is a no-op. That idempotence is what
+                    // sr13's guard exists to enforce structurally there; here it
+                    // holds for free, so the unconditional fold is safe.
                     let prior_self_ref_free =
                         super::fold_self_ref::fold_nested_self_refs(&prior, &child_prefix);
                     dst.prior_values.insert(k.clone(), prior_self_ref_free);


### PR DESCRIPTION
## Summary

Two related defects in the cycle-recovery path that surface together when two files are merged at the top level and the destination subtree contains a chained self-reference (`field = ${parent.field} ${self.field}`) nested several levels below the merge boundary.

No public API changes; safe drop-in.

## Related issue

- https://github.com/o3co/rs.hocon/issues/135

## Changes

`utils::deep_merge_res_obj_into` was not folding deeply-nested self-refs inside the value it stored as an outer-level prior. `fold_or_skip_prior` only matches `Subst` nodes whose path equals the outer key, so a `Subst("<outer-key>.x.y.z")` nested inside `prior` passed through unfolded — silently breaking the "every saved prior is self-ref-free" invariant from `fold_self_ref.rs`'s module comment. The leaf-level path in `structure_builder.rs` honours the invariant via `fold_or_skip_prior` keyed on the full leaf path; the Obj-Obj deep-merge path didn't.

A later cycle-recovery descent into the saved prior found the unfolded self-ref via `contains_subst_by_path`, the `xx.hocon#27 sr12` short-circuit fired, and the resolver errored `circular substitution` even though the leaf had a resolvable prior chain (an `include` above the self-ref site already set the value the chain folds against). Fixed by adding a `fold_nested_self_refs` pass after `fold_or_skip_prior` in the Obj-Obj branch.

The same code path also had a separate defect in
`substitution_resolver::resolve_subst`'s cycle-recovery call: `prior_for_check` was descended to the substitution's exact path along `s.segments[1..]` for the `skip_due_to_self_ref` check, then the following `resolve_val` call resolved `&prior` (the whole outer prior, often the entire root-segment subtree) instead of `prior_for_check`. For multi-segment substitutions this returned the wrong subtree — typically an `Object` where the substitution targeted a leaf — which surfaced as a downstream `S10` kind-mismatch in any concat that consumed the result. This defect was masked on `develop` because most multi-segment cycle paths bailed out via `skip_due_to_self_ref` before the broken resolution call; it is reachable once the first defect is patched, on sibling chained-self-refs.

`pyhocon`, Lightbend's reference impl, and `mockersf/hocon` all parse the same shapes correctly.

Both fixes are localized and verified to not regress upstream tests (`make testdata && cargo test --release` and
`cargo test --release --features serde`: 45 binaries, 0 failures, 0 regressions). I have a deterministic failing case in a private codebase but was unable to reduce it to a self-contained synthetic input that fails on `develop` — minimization attempts kept resolving correctly even when instrumentation confirmed they stored the same broken outer prior, suggesting the cycle handler entry sequence depends on additional state in the larger real-file context that I could not isolate. Happy to share the failing conf privately or run further diagnostics if useful for test-case construction.

## Test plan

I'm not able to faithfully reproduce the issue outside of my work repository's repo which makes heavy use of hocon, and where I found/fixed this bug. I issue reports the "shape" of the problem, but I can't find a minimal example to fully reproduce.


- [ ] `cargo test` passes
- [ ] `cargo test --features serde` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] New tests added for changes 