### PR TITLE
ci(testdata): fetch fixtures fresh by exact SHA (drop the partial cache)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           path: |
             tests/testdata/expected
+            tests/testdata/hocon
             .xx-hocon-version
           key: xx-hocon-expected-pending
           restore-keys: xx-hocon-expected-
@@ -62,6 +63,7 @@ jobs:
         with:
           path: |
             tests/testdata/expected
+            tests/testdata/hocon
             .xx-hocon-version
           key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,46 +26,14 @@ jobs:
             cargo set-version "$TAG_VERSION"
           fi
 
-      # Cache is split into restore+save so the save key is content-addressable
-      # via the post-fetch hash of `.xx-hocon-version`. On a fresh checkout,
-      # `.xx-hocon-version` is gitignored and absent at restore time, so the
-      # restore step relies on `restore-keys` to match the most recent entry.
-      # Mirrors the test.yml pattern so the publish job doesn't re-fetch on
-      # every tag push (avoids GitHub API rate-limit + transient network
-      # failures during release). (closes #101)
-      - name: Restore expected JSON cache
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            tests/testdata/expected
-            tests/testdata/hocon
-            .xx-hocon-version
-          key: xx-hocon-expected-pending
-          restore-keys: xx-hocon-expected-
-
-      - name: Fetch expected JSON sidecars from xx.hocon
-        # tests/concat_errors_test.rs, tests/s8_unquoted_starts.rs, and
-        # other sidecar-driven conformance tests need `tests/testdata/expected/`
-        # populated. That dir is gitignored (repo convention — sidecars are
-        # fetched, not vendored), so without this step the publish-time
-        # `cargo test` fails with "no expected sidecar" panics on ce01-ce15
-        # / us02-us30 etc. Mirrors ts.hocon release.yml fix from v1.2.0
-        # publish regression. The Makefile's early-exit on matching pin SHA
-        # makes this a no-op when the cache hit above is fresh.
+      # No cache: fetch the conformance fixtures fresh (see test.yml rationale).
+      # tests/concat_errors_test.rs, tests/s8_unquoted_starts.rs, and other
+      # sidecar-driven conformance tests need tests/testdata/{hocon,expected}/
+      # populated. Those dirs are gitignored (sidecars are fetched, not
+      # vendored), so without this step the publish-time `cargo test` fails with
+      # "no expected sidecar" panics on ce01-ce15 / us02-us30 etc.
+      - name: Fetch testdata fixtures
         run: make testdata
-
-      # Default `if: success()` — skip the save if `make testdata` failed so
-      # we don't write a partial/missing-pin cache under the empty-hash key
-      # (which would collapse to the constant `xx-hocon-expected-` and
-      # recreate the bug this PR is fixing). Copilot review thread.
-      - name: Save expected JSON cache
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            tests/testdata/expected
-            tests/testdata/hocon
-            .xx-hocon-version
-          key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}
 
       - run: cargo test
       - run: cargo test --features serde

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           path: |
             tests/testdata/expected
+            tests/testdata/hocon
             .xx-hocon-version
           key: xx-hocon-expected-pending
           restore-keys: xx-hocon-expected-
@@ -46,6 +47,7 @@ jobs:
         with:
           path: |
             tests/testdata/expected
+            tests/testdata/hocon
             .xx-hocon-version
           key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}
       - run: cargo test
@@ -77,6 +79,7 @@ jobs:
         with:
           path: |
             tests/testdata/expected
+            tests/testdata/hocon
             .xx-hocon-version
           key: xx-hocon-expected-pending
           restore-keys: xx-hocon-expected-
@@ -91,6 +94,7 @@ jobs:
         with:
           path: |
             tests/testdata/expected
+            tests/testdata/hocon
             .xx-hocon-version
           key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}
       - uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,34 +22,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      # Cache is split into restore+save so the save key is content-addressable
-      # via the post-fetch hash of `.xx-hocon-version`. On a fresh checkout,
-      # `.xx-hocon-version` is gitignored and absent at restore time, so the
-      # restore step relies on `restore-keys` to match the most recent entry.
-      # (closes #101)
-      - name: Restore expected JSON cache
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            tests/testdata/expected
-            tests/testdata/hocon
-            .xx-hocon-version
-          key: xx-hocon-expected-pending
-          restore-keys: xx-hocon-expected-
-      - name: Fetch expected JSON
+      # No cache: `make testdata` fetches the fixtures fresh each run (a small
+      # tarball). Caching only part of the fixture tree previously left the
+      # fetched-only `.conf` files absent on warm-cache jobs (#101 resurfaced),
+      # and caching the whole tree would clobber git-tracked fixtures with stale
+      # cached copies. Fetching is ~1-2s and always correct.
+      - name: Fetch testdata fixtures
         run: make testdata
-      # Default `if: success()` — skip the save if `make testdata` failed so
-      # we don't write a partial/missing-pin cache under the empty-hash key
-      # (which would collapse to the constant `xx-hocon-expected-` and
-      # recreate the bug this PR is fixing). Copilot review thread.
-      - name: Save expected JSON cache
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            tests/testdata/expected
-            tests/testdata/hocon
-            .xx-hocon-version
-          key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}
       - run: cargo test
         if: matrix.rust == 'stable'
       # MSRV: remove criterion dev-dependency before testing because
@@ -69,34 +48,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      # Cache is split into restore+save so the save key is content-addressable
-      # via the post-fetch hash of `.xx-hocon-version`. On a fresh checkout,
-      # `.xx-hocon-version` is gitignored and absent at restore time, so the
-      # restore step relies on `restore-keys` to match the most recent entry.
-      # (closes #101)
-      - name: Restore expected JSON cache
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            tests/testdata/expected
-            tests/testdata/hocon
-            .xx-hocon-version
-          key: xx-hocon-expected-pending
-          restore-keys: xx-hocon-expected-
-      - name: Fetch expected JSON
+      # No cache — see the test job above.
+      - name: Fetch testdata fixtures
         run: make testdata
-      # Default `if: success()` — skip the save if `make testdata` failed so
-      # we don't write a partial/missing-pin cache under the empty-hash key
-      # (which would collapse to the constant `xx-hocon-expected-` and
-      # recreate the bug this PR is fixing). Copilot review thread.
-      - name: Save expected JSON cache
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            tests/testdata/expected
-            tests/testdata/hocon
-            .xx-hocon-version
-          key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: cargo llvm-cov --features serde --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CI: testdata cache no longer skips the `.conf` fixture download** (follow-up
+  to [#101](https://github.com/o3co/rs.hocon/issues/101)). Two defects let
+  `make testdata` short-circuit while `tests/testdata/hocon/` (the `.conf`
+  fixtures) was absent, causing nondeterministic `No such file` failures on
+  whichever matrix jobs (macOS / Windows / coverage) hit a warm cache:
+  (1) the cache only stored `tests/testdata/expected` + `.xx-hocon-version`, not
+  `tests/testdata/hocon`, so a cache hit restored the sidecars but never the
+  `.conf` files; and (2) the Makefile's early-exit checked `EXPECTED_DIR` but not
+  `TESTDATA_DIR`, and treated an empty pin (`"" = ""`, e.g. an unauthenticated
+  GitHub API rate-limit returning no SHA) as up-to-date. Fixed by caching
+  `tests/testdata/hocon` alongside `tests/testdata/expected` in both workflows
+  and gating the Makefile early-exit on `[ -d TESTDATA_DIR ]` + a non-empty
+  remote SHA. No production code touched.
+
 ## [1.7.0] - 2026-05-30
 
 Cross-impl release coordinated to land at v1.7.0 across go.hocon / ts.hocon / rs.hocon. The minor bump is driven by [go.hocon#142](https://github.com/o3co/go.hocon/issues/142) (additive `GetXxxE` accessor family in go.hocon — rs.hocon's `Result`-primary API was the prior art that inspired the go-side addition). **No functional changes in rs.hocon**: this release exists to keep cross-impl version parity per project convention (precedent: v1.6.0's coordinated minor sync). No public API changes; safe drop-in upgrade from v1.6.1. `Cargo.toml` is pre-bumped to `1.7.0` (the publish workflow's version-set step is idempotent).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **CI: testdata cache no longer skips the `.conf` fixture download** (follow-up
-  to [#101](https://github.com/o3co/rs.hocon/issues/101)). Two defects let
-  `make testdata` short-circuit while `tests/testdata/hocon/` (the `.conf`
-  fixtures) was absent, causing nondeterministic `No such file` failures on
-  whichever matrix jobs (macOS / Windows / coverage) hit a warm cache:
-  (1) the cache only stored `tests/testdata/expected` + `.xx-hocon-version`, not
-  `tests/testdata/hocon`, so a cache hit restored the sidecars but never the
-  `.conf` files; and (2) the Makefile's early-exit checked `EXPECTED_DIR` but not
-  `TESTDATA_DIR`, and treated an empty pin (`"" = ""`, e.g. an unauthenticated
-  GitHub API rate-limit returning no SHA) as up-to-date. Fixed by caching
-  `tests/testdata/hocon` alongside `tests/testdata/expected` in both workflows
-  and gating the Makefile early-exit on `[ -d TESTDATA_DIR ]` + a non-empty
-  remote SHA. No production code touched.
+- **CI: testdata fixtures are fetched fresh instead of partially cached**
+  (follow-up to [#101](https://github.com/o3co/rs.hocon/issues/101)). The
+  testdata cache stored only `tests/testdata/expected` + `.xx-hocon-version`,
+  not the `tests/testdata/hocon/` `.conf` fixtures. On a warm-cache job
+  `make testdata` short-circuited (matching pin) and never downloaded the
+  fetched-only `.conf` files, so `cargo test` panicked with `No such file` on
+  fixtures like `concat-errors/ce09`, `ce15` — nondeterministically across
+  macOS / Windows / coverage depending on which jobs hit a warm vs cold cache.
+  Rather than patch the partial cache (caching the whole `hocon/` tree would
+  clobber git-tracked fixtures with stale cached copies), the CI cache is
+  removed and `make testdata` now fetches the fixtures fresh each run: it
+  resolves the xx.hocon SHA once via `git ls-remote` (no REST API rate-limit),
+  downloads the archive for that exact SHA (pin always matches content), and
+  writes the same SHA to `.xx-hocon-version`, with `set -e` so any failed step
+  aborts instead of leaving partial/empty state. No production code touched.
 
 ## [1.7.0] - 2026-05-30
 

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ EXPECTED_DIR   := tests/testdata/expected
 .PHONY: testdata test
 
 testdata:
-	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ]; then \
+	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ] && [ -d "$(TESTDATA_DIR)" ]; then \
 	  remote_sha=$$(curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4) && \
 	  local_sha=$$(cat .xx-hocon-version) && \
-	  if [ "$$remote_sha" = "$$local_sha" ]; then \
+	  if [ -n "$$remote_sha" ] && [ "$$remote_sha" = "$$local_sha" ]; then \
 	    echo "Expected JSON up to date ($$local_sha)"; exit 0; \
 	  fi; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -2,26 +2,43 @@ TESTDATA_REPO  := o3co/xx.hocon
 TESTDATA_REF   := main
 TESTDATA_DIR   := tests/testdata/hocon
 EXPECTED_DIR   := tests/testdata/expected
+# Fetched-only (gitignored) subdir used as the "fixtures already present"
+# sentinel. tests/testdata/hocon/ also holds git-tracked vendored fixtures, so
+# the dir's mere existence is NOT evidence the fetched-only fixtures (which the
+# conformance tests need) were downloaded — only a fetched-only subdir is.
+FETCH_SENTINEL := $(TESTDATA_DIR)/concat-errors
 
 .PHONY: testdata test
 
+# Fetch conformance fixtures from xx.hocon. No CI cache is involved: the SHA is
+# resolved once via `git ls-remote` (not the REST API, so no unauthenticated
+# rate-limit), the archive is downloaded for that EXACT SHA (pin always matches
+# content), and the same SHA is written to .xx-hocon-version. `set -e` makes any
+# failed step abort rather than silently leaving partial/empty state. The
+# early-exit skips the download only when the fetched-only sentinel is present
+# AND the pin already matches the resolved SHA (local-dev convenience; in CI the
+# checkout is always fresh so the sentinel is absent and the fetch always runs).
 testdata:
-	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ] && [ -d "$(TESTDATA_DIR)" ]; then \
-	  remote_sha=$$(curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4) && \
-	  local_sha=$$(cat .xx-hocon-version) && \
-	  if [ -n "$$remote_sha" ] && [ "$$remote_sha" = "$$local_sha" ]; then \
-	    echo "Expected JSON up to date ($$local_sha)"; exit 0; \
-	  fi; \
+	@set -e; \
+	sha="$$(git ls-remote "https://github.com/$(TESTDATA_REPO).git" "$(TESTDATA_REF)" | head -1 | cut -f1)"; \
+	if [ -z "$$sha" ]; then \
+	  echo "error: could not resolve $(TESTDATA_REPO)@$(TESTDATA_REF) SHA via git ls-remote" >&2; \
+	  exit 1; \
 	fi; \
-	tmpdir="$$(mktemp -d)" && \
-	trap 'rm -rf "$$tmpdir"' EXIT INT TERM && \
-	mkdir -p "$(TESTDATA_DIR)" "$(EXPECTED_DIR)" && \
-	curl -sfL "https://github.com/$(TESTDATA_REPO)/archive/$(TESTDATA_REF).tar.gz" -o "$$tmpdir/archive.tar.gz" && \
-	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1 && \
-	cp -R "$$tmpdir/testdata/hocon/." "$(TESTDATA_DIR)/" && \
-	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/" && \
-	curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version && \
-	echo "Done. Fetched $$(cat .xx-hocon-version)"
+	if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ] && [ -d "$(FETCH_SENTINEL)" ] && \
+	   [ "$$sha" = "$$(cat .xx-hocon-version)" ]; then \
+	  echo "Fixtures up to date ($$sha)"; \
+	  exit 0; \
+	fi; \
+	tmpdir="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmpdir"' EXIT INT TERM; \
+	mkdir -p "$(TESTDATA_DIR)" "$(EXPECTED_DIR)"; \
+	curl -sfL "https://github.com/$(TESTDATA_REPO)/archive/$$sha.tar.gz" -o "$$tmpdir/archive.tar.gz"; \
+	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1; \
+	cp -R "$$tmpdir/testdata/hocon/." "$(TESTDATA_DIR)/"; \
+	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/"; \
+	printf '%s\n' "$$sha" > .xx-hocon-version; \
+	echo "Done. Fetched $$sha"
 
 test:
 	cargo test


### PR DESCRIPTION
## Summary

Fixes nondeterministic CI failures (`No such file or directory` on `tests/testdata/hocon/concat-errors/ce09…`, `ce15…`) that hit whichever matrix jobs landed on a **warm testdata cache** — macOS / Windows / coverage went red while ubuntu stayed green. **No production code touched.**

Surfaced while reviewing PR #136, whose macOS/Windows/coverage checks went red with missing-fixture panics unrelated to that PR's resolver changes. Root cause is in the shared testdata caching.

## Root cause

`tests/testdata/hocon/` is a **mixed** directory: 194 git-tracked vendored fixtures **plus** fetched-only (gitignored) subdirs (`concat-errors`, `env-var-list`, …) that only `make testdata` creates. The CI cache stored only `tests/testdata/expected` + `.xx-hocon-version` — **not** the fetched-only `.conf` files. On a warm-cache job, `make testdata` saw a matching pin, short-circuited, and never downloaded those `.conf` files → `cargo test` panicked. Whether a job hit a warm or cold cache varied by OS/timing, hence the nondeterminism.

## Approach (revised after review)

The initial commit tried to patch the cache (add `hocon/` to the cache path + guard the early-exit). Multi-agent review (Claude + Codex) and Copilot converged on three flaws:
1. `[ -d TESTDATA_DIR ]` is inert — `hocon/` always exists from the 194 tracked files.
2. Caching the whole `hocon/` tree clobbers tracked fixtures with stale cached copies (cache key tracks only the upstream pin, not local fixture edits) — a new staleness regression.
3. With the pin unchanged, the early-exit still fired and the cache save was a no-op → the fix neither took effect nor self-healed.

So the partial-cache + lax-early-exit structure (the same shape behind #101) is removed rather than patched:

- **Drop the CI cache** (restore + save) from `test.yml` (test + coverage jobs) and `publish.yml`.
- **`make testdata` always fetches fresh** (~1-2s tarball): resolve the SHA once via `git ls-remote` (no REST API rate-limit) and fail hard if undeterminable; download the archive for that **exact SHA** (pin always matches content — fixes the pin/content race Copilot flagged); write that same SHA to `.xx-hocon-version`; `set -e` aborts on any failed step (fixes the masked `curl | grep | head | cut` pin-write).
- A **local-dev** early-exit remains, gated on a **fetched-only sentinel** (`tests/testdata/hocon/concat-errors`) so a tree with only the tracked fixtures still re-fetches. In CI the checkout is always fresh → the fetch always runs.

## Verification

```
fresh checkout (fetched dirs + pin removed)         → fetches; concat-errors present; tracked fixtures intact
sentinel (concat-errors) absent but pin present     → re-fetches (the original bug)
empty pin                                           → re-fetches
all present + pin matches                            → "Fixtures up to date" (local-dev short-circuit)
```

`cargo test`: **801 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)