### PR TITLE
release(v1.7.1): cross-impl coordinated patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-06-14
+
+Cross-impl coordinated patch release (v1.7.1 across go.hocon / ts.hocon / rs.hocon). The substantive change is in rs.hocon: a false-positive `circular substitution` fix from a cross-impl audit of the cycle-recovery path ([#135](https://github.com/o3co/rs.hocon/issues/135) / [#136](https://github.com/o3co/rs.hocon/pull/136)); go.hocon already resolved the same shapes at v1.7.0 (its #135 defer-substitution work) and ts.hocon was unaffected, so their v1.7.1 carries no functional change and exists for cross-impl version parity. Also includes a CI testdata-cache fix ([#137](https://github.com/o3co/rs.hocon/pull/137)). No public API changes; safe drop-in upgrade from v1.7.0.
+
 ### Fixed — false-positive `circular substitution` from cycle-recovery on chained self-refs nested below an outer-merge boundary
 
 Two related defects in the cycle-recovery path:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,7 +265,8 @@ Behaviour:
 
 - **CI: content-addressable testdata cache** (closes [#101](https://github.com/o3co/rs.hocon/issues/101)). `.github/workflows/test.yml` and `.github/workflows/publish.yml` previously used `actions/cache@v5` with `key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}`. The hash evaluated BEFORE the cache restore step ran, but `.xx-hocon-version` is gitignored and absent on fresh checkouts — so the key collapsed to a constant and cache entries shared the same slot. Split into `actions/cache/restore@v5` (matches via `restore-keys`) + `actions/cache/save@v5` (writes with the post-fetch hash, gated on `make testdata` success). No production code touched.
 
-[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.7.1...HEAD
+[1.7.1]: https://github.com/o3co/rs.hocon/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/o3co/rs.hocon/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/o3co/rs.hocon/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/o3co/rs.hocon/compare/v1.5.2...v1.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hocon-parser"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "criterion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hocon-parser"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2021"
 rust-version = "1.82"
 description = "Full Lightbend HOCON specification-compliant parser for Rust"


### PR DESCRIPTION
## Summary

Release-prep for **v1.7.1** (cross-impl coordinated patch across go.hocon / ts.hocon / rs.hocon).

rs.hocon's v1.7.1 ships:
- **#136** — false-positive `circular substitution` fix from a cross-impl audit of the cycle-recovery path (`fold_nested_self_refs` in the outer-merge prior save + resolve the descended value on cycle recovery). Closes #135.
- **#137** — CI testdata-cache fix (fetch fixtures fresh instead of partial-cache).

Finalizes `[Unreleased]` → `[1.7.1] - 2026-06-14` and bumps `Cargo.toml` 1.7.0 → 1.7.1 (publish workflow's `cargo set-version` is idempotent).

No public API changes; safe drop-in from v1.7.0.

After merge: tag `v1.7.1` on develop HEAD → publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)