### PR TITLE
fix(coercion): derive i64 wholeness from raw text, not f64 (xx.hocon#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@ deserialized, and a borrowed `HoconValue` had no typed accessors. All additive.
   to unquoted `Number`-typed scalars, so `get_i64` and the serde path disagreed on
   quoted numeric strings; they are now consistent.
 
+### Fixed — integer coercion precision hole for float-like literals ≥ 2^52 ([xx.hocon#56](https://github.com/o3co/xx.hocon/issues/56))
+
+- **Float-like integer coercion now derives wholeness and the integer value from
+  the raw decimal text instead of an intermediate `f64`**, across all three i64
+  coercion surfaces (`Config::get_i64`, `HoconValue::as_i64`, serde `get_as::<i64>`
+  / `from_value`). The previous `f64::fract() == 0.0` check was unsound at high
+  magnitudes: above 2^52 an `f64` cannot represent fractional parts, so a non-whole
+  literal like `9007199254740992.5` rounded to a whole `f64` and was wrongly
+  accepted, and a would-be-whole literal like `9007199254740993.0` rounded to the
+  wrong integer (silent off-by-one). The text-based check rejects genuinely
+  non-whole values at any magnitude and yields the exact integer for whole ones,
+  while still accepting large whole literals such as `1e16`. The triplicated f64
+  fallback is replaced by a single shared `whole_float_to_i64` helper. ts.hocon is
+  unaffected (no integer coercion: `number` is float64, int-ness is a zod concern).
+  Pinned by `tests/issue56_i64_coercion_precision.rs`.
+
 ## [1.7.1] - 2026-06-14
 
 Cross-impl coordinated patch release (v1.7.1 across go.hocon / ts.hocon / rs.hocon). The substantive change is in rs.hocon: a false-positive `circular substitution` fix from a cross-impl audit of the cycle-recovery path ([#135](https://github.com/o3co/rs.hocon/issues/135) / [#136](https://github.com/o3co/rs.hocon/pull/136)); go.hocon already resolved the same shapes at v1.7.0 (its #135 defer-substitution work) and ts.hocon was unaffected, so their v1.7.1 carries no functional change and exists for cross-impl version parity. Also includes a CI testdata-cache fix ([#137](https://github.com/o3co/rs.hocon/pull/137)). No public API changes; safe drop-in upgrade from v1.7.0.

--- a/src/config.rs
+++ b/src/config.rs
@@ -344,25 +344,13 @@ impl Config {
             None => Err(missing(path)),
             Some(HoconValue::Placeholder(_)) => Err(not_resolved(path)),
             Some(HoconValue::Scalar(sv)) => {
-                // Try direct i64 parse first
-                if let Ok(n) = sv.raw.parse::<i64>() {
-                    return Ok(n);
-                }
-                // Only use f64 fallback for float-like literals (contains '.' or exponent)
-                let is_float_like =
-                    sv.raw.contains('.') || sv.raw.contains('e') || sv.raw.contains('E');
-                if is_float_like {
-                    if let Ok(f) = sv.raw.parse::<f64>() {
-                        if f.fract() == 0.0
-                            && f.is_finite()
-                            && f >= i64::MIN as f64
-                            && f < (i64::MAX as f64)
-                        {
-                            return Ok(f as i64);
-                        }
-                    }
-                }
-                Err(type_mismatch(path, "i64"))
+                // Direct i64 parse, else exact whole-number float/exponent
+                // coercion from the raw text (xx.hocon#56: never via f64).
+                sv.raw
+                    .parse::<i64>()
+                    .ok()
+                    .or_else(|| crate::value::whole_float_to_i64(&sv.raw))
+                    .ok_or_else(|| type_mismatch(path, "i64"))
             }
             _ => Err(type_mismatch(path, "i64")),
         }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -75,17 +75,12 @@ where
     if let Ok(n) = sv.raw.parse::<T>() {
         return Ok(n);
     }
-    // Whole-number float/exponent truncation fallback, for any float-like raw
-    // (quoted or not) — consistent with `Config::get_i64`.
-    let is_float_like = sv.raw.contains('.') || sv.raw.contains('e') || sv.raw.contains('E');
-    if is_float_like {
-        if let Ok(f) = sv.raw.parse::<f64>() {
-            if f.fract() == 0.0 && f.is_finite() && f >= i64::MIN as f64 && f < (i64::MAX as f64) {
-                let as_i64 = f as i64;
-                if let Ok(n) = T::try_from(as_i64) {
-                    return Ok(n);
-                }
-            }
+    // Whole-number float/exponent coercion fallback, for any float-like raw
+    // (quoted or not) — consistent with `Config::get_i64`. Wholeness/value are
+    // derived from the raw text, never via f64 (xx.hocon#56).
+    if let Some(as_i64) = crate::value::whole_float_to_i64(&sv.raw) {
+        if let Ok(n) = T::try_from(as_i64) {
+            return Ok(n);
         }
     }
     Err(DeserializeError {

--- a/src/value.rs
+++ b/src/value.rs
@@ -188,6 +188,13 @@ pub(crate) fn whole_float_to_i64(raw: &str) -> Option<i64> {
     // The decimal point sits `r` places from the right after applying exponent.
     let combined = format!("{int_part}{frac_part}");
     let digits = combined.trim_start_matches('0');
+    // An all-zero mantissa is exactly 0 regardless of the exponent; handle it
+    // before the append-zeros guard below (which is keyed off the exponent and
+    // would otherwise reject e.g. "0e2147483647"). After this, `digits` is
+    // non-empty, so its leading byte is always a non-zero digit.
+    if digits.is_empty() {
+        return Some(0);
+    }
     let r = frac_part.len() as i64 - exp as i64;
     // i64 has at most 19 decimal digits; any longer magnitude cannot fit, so it
     // is reported as out-of-range below — but for the right-shift (append-zeros)
@@ -204,30 +211,22 @@ pub(crate) fn whole_float_to_i64(raw: &str) -> Option<i64> {
         t
     } else {
         let r = r as usize;
+        // `digits` is non-empty with a non-zero leading byte, so if every
+        // significant digit is fractional the value is < 1 and not whole.
         if r >= digits.len() {
-            // |value| < 1: whole only if every digit is zero.
-            if digits.bytes().all(|b| b == b'0') {
-                String::from("0")
-            } else {
-                return None;
-            }
-        } else {
-            let (head, tail) = digits.split_at(digits.len() - r);
-            // Whole only if the fractional digits are all zero.
-            if !tail.bytes().all(|b| b == b'0') {
-                return None;
-            }
-            head.to_string()
+            return None;
         }
+        let (head, tail) = digits.split_at(digits.len() - r);
+        // Whole only if the fractional digits are all zero.
+        if !tail.bytes().all(|b| b == b'0') {
+            return None;
+        }
+        head.to_string()
     };
     // Parse the unsigned magnitude, then apply the sign with an explicit range
     // check so that i64::MIN (magnitude 2^63, which does not fit i64) is
     // preserved for float-like spellings like "-9223372036854775808.0".
-    let mag: u64 = if mag_str.is_empty() {
-        0
-    } else {
-        mag_str.parse().ok()? // overflow -> None
-    };
+    let mag: u64 = mag_str.parse().ok()?; // overflow -> None
     if neg {
         match mag.cmp(&((i64::MAX as u64) + 1)) {
             std::cmp::Ordering::Less => Some(-(mag as i64)),

--- a/src/value.rs
+++ b/src/value.rs
@@ -132,20 +132,111 @@ impl HoconValue {
 
 /// Coerce a scalar to `i64` with the same rules as [`Config::get_i64`] and the
 /// serde integer path (`parse_int_from_scalar`): direct parse, else whole-number
-/// float/exponent truncation for any float-like raw (quoted or not). Kept in sync
+/// float/exponent coercion for any float-like raw (quoted or not). Kept in sync
 /// so `HoconValue::as_i64`, `Config::get_i64`, and `get_as::<i64>` all agree.
 fn scalar_as_i64(sv: &ScalarValue) -> Option<i64> {
-    if let Ok(n) = sv.raw.parse::<i64>() {
-        return Some(n);
+    sv.raw
+        .parse::<i64>()
+        .ok()
+        .or_else(|| whole_float_to_i64(&sv.raw))
+}
+
+/// Coerce a whole-number float/exponent **raw string** to an exact `i64`.
+///
+/// This is the float-like fallback shared by [`HoconValue::as_i64`],
+/// [`Config::get_i64`](crate::Config::get_i64), and the serde integer path; it is
+/// used only after a direct `parse::<i64>()` of the raw string fails. Returns
+/// `None` unless the text is float-like (`.`/`e`/`E`), denotes a whole number, and
+/// fits `i64`.
+///
+/// Wholeness and the integer value are derived from the decimal digits, never
+/// from an intermediate `f64` (xx.hocon#56). Above 2^52 an `f64` can no longer
+/// represent fractional parts, so `"4503599627370496.5".parse::<f64>().fract()`
+/// is `0.0` (false-accept) and `"9007199254740993.0"` rounds to the wrong integer
+/// (silent off-by-one). Parsing the digits directly avoids both, while still
+/// accepting genuinely whole large literals such as `1e16`.
+pub(crate) fn whole_float_to_i64(raw: &str) -> Option<i64> {
+    // Plain integers are handled by the caller's direct `parse::<i64>()`.
+    if !raw.contains(['.', 'e', 'E']) {
+        return None;
     }
-    if sv.raw.contains('.') || sv.raw.contains('e') || sv.raw.contains('E') {
-        if let Ok(f) = sv.raw.parse::<f64>() {
-            if f.fract() == 0.0 && f.is_finite() && f >= i64::MIN as f64 && f < (i64::MAX as f64) {
-                return Some(f as i64);
-            }
+    let s = raw.trim();
+    let (neg, body) = match s.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, s.strip_prefix('+').unwrap_or(s)),
+    };
+    // Mantissa and base-10 exponent (default 0).
+    let (mantissa, exp) = match body.split_once(['e', 'E']) {
+        Some((m, e)) => (m, e.parse::<i32>().ok()?),
+        None => (body, 0),
+    };
+    // Integer and fractional digit runs.
+    let (int_part, frac_part) = match mantissa.split_once('.') {
+        Some((i, f)) => (i, f),
+        None => (mantissa, ""),
+    };
+    if int_part.is_empty() && frac_part.is_empty() {
+        return None;
+    }
+    if !int_part.bytes().all(|b| b.is_ascii_digit())
+        || !frac_part.bytes().all(|b| b.is_ascii_digit())
+    {
+        return None;
+    }
+    // Significant digits as one run; leading zeros never affect the value, so
+    // drop them (keeps the overflow guard and u64 parse below significant-only).
+    // The decimal point sits `r` places from the right after applying exponent.
+    let combined = format!("{int_part}{frac_part}");
+    let digits = combined.trim_start_matches('0');
+    let r = frac_part.len() as i64 - exp as i64;
+    // i64 has at most 19 decimal digits; any longer magnitude cannot fit, so it
+    // is reported as out-of-range below — but for the right-shift (append-zeros)
+    // branch we must bound BEFORE materializing the zeros, or a huge exponent
+    // such as "1e2147483647" would allocate gigabytes before failing.
+    let mag_str: String = if r <= 0 {
+        let zeros = (-r) as usize;
+        if digits.len().saturating_add(zeros) > 19 {
+            return None;
         }
+        let mut t = String::with_capacity(digits.len() + zeros);
+        t.push_str(digits);
+        t.extend(std::iter::repeat_n('0', zeros));
+        t
+    } else {
+        let r = r as usize;
+        if r >= digits.len() {
+            // |value| < 1: whole only if every digit is zero.
+            if digits.bytes().all(|b| b == b'0') {
+                String::from("0")
+            } else {
+                return None;
+            }
+        } else {
+            let (head, tail) = digits.split_at(digits.len() - r);
+            // Whole only if the fractional digits are all zero.
+            if !tail.bytes().all(|b| b == b'0') {
+                return None;
+            }
+            head.to_string()
+        }
+    };
+    // Parse the unsigned magnitude, then apply the sign with an explicit range
+    // check so that i64::MIN (magnitude 2^63, which does not fit i64) is
+    // preserved for float-like spellings like "-9223372036854775808.0".
+    let mag: u64 = if mag_str.is_empty() {
+        0
+    } else {
+        mag_str.parse().ok()? // overflow -> None
+    };
+    if neg {
+        match mag.cmp(&((i64::MAX as u64) + 1)) {
+            std::cmp::Ordering::Less => Some(-(mag as i64)),
+            std::cmp::Ordering::Equal => Some(i64::MIN),
+            std::cmp::Ordering::Greater => None,
+        }
+    } else {
+        i64::try_from(mag).ok()
     }
-    None
 }
 
 /// The type tag for a scalar value.

--- a/tests/issue56_i64_coercion_precision.rs
+++ b/tests/issue56_i64_coercion_precision.rs
@@ -1,0 +1,138 @@
+//! xx.hocon#56: integer coercion of a float-like scalar must derive wholeness
+//! from the raw decimal text, not from an intermediate `f64`. Above 2^52 an
+//! `f64` cannot represent fractional parts, so the previous `f.fract() == 0.0`
+//! check both (a) false-accepted non-whole values and (b) off-by-one'd would-be
+//! whole values. Pinned across all three i64 coercion surfaces (`Config::get_i64`,
+//! `HoconValue::as_i64`, serde `get_as::<i64>`).
+
+use hocon::parse;
+
+#[test]
+fn rejects_non_whole_float_at_2_pow_53() {
+    // 2^53 + 0.5: f64 rounds to 9007199254740992.0, so fract()==0.0 false-accepts.
+    let c = parse("n = 9007199254740992.5").unwrap();
+    assert_eq!(c.get("n").unwrap().as_i64(), None);
+    assert!(c.get_i64("n").is_err());
+}
+
+#[test]
+fn rejects_non_whole_half_integer_in_2_pow_52_window() {
+    // 2^52 + 0.5: ulp is already 1 here, so the .5 is lost to rounding — a
+    // magnitude threshold of 2^53 would miss this; raw-string wholeness catches it.
+    let c = parse("n = 4503599627370496.5").unwrap();
+    assert_eq!(c.get("n").unwrap().as_i64(), None);
+    assert!(c.get_i64("n").is_err());
+}
+
+#[test]
+fn accepts_exact_whole_float_above_2_pow_53_without_off_by_one() {
+    // 2^53 + 1 written as a whole float: via f64 this rounds to 2^53 (off by one).
+    // Raw-string parsing yields the exact integer.
+    let c = parse("n = 9007199254740993.0").unwrap();
+    assert_eq!(c.get("n").unwrap().as_i64(), Some(9007199254740993));
+    assert_eq!(c.get_i64("n").unwrap(), 9007199254740993);
+}
+
+#[test]
+fn accepts_large_whole_exponent_form() {
+    // 1e16 (> 2^53) is a whole number; it must still coerce (no regression).
+    let c = parse("n = 1e16").unwrap();
+    assert_eq!(c.get("n").unwrap().as_i64(), Some(10000000000000000));
+    assert_eq!(c.get_i64("n").unwrap(), 10000000000000000);
+}
+
+#[test]
+fn small_whole_floats_still_coerce_and_non_whole_reject() {
+    let c = parse(
+        r#"a = 1.0
+           b = 1e3
+           c = 1.5e1
+           d = 1.5
+           e = 1.234e2"#,
+    )
+    .unwrap();
+    assert_eq!(c.get("a").unwrap().as_i64(), Some(1));
+    assert_eq!(c.get("b").unwrap().as_i64(), Some(1000));
+    assert_eq!(c.get("c").unwrap().as_i64(), Some(15)); // 1.5e1 = 15 (whole)
+    assert_eq!(c.get("d").unwrap().as_i64(), None);
+    assert_eq!(c.get("e").unwrap().as_i64(), None); // 123.4 (non-whole)
+}
+
+#[test]
+fn negative_exponent_wholeness_is_text_based() {
+    let c = parse(
+        r#"a = 1e-3
+           b = 1000e-3
+           c = 1500e-3"#,
+    )
+    .unwrap();
+    assert_eq!(c.get("a").unwrap().as_i64(), None); // 0.001
+    assert_eq!(c.get("b").unwrap().as_i64(), Some(1)); // 1.0
+    assert_eq!(c.get("c").unwrap().as_i64(), None); // 1.5
+}
+
+#[test]
+fn overflow_float_form_rejects() {
+    let c = parse("n = 1e30").unwrap();
+    assert_eq!(c.get("n").unwrap().as_i64(), None);
+    assert!(c.get_i64("n").is_err());
+}
+
+#[test]
+fn i64_min_and_max_float_form_preserved() {
+    // i64::MIN's magnitude is 2^63, which does not fit i64 — the sign must be
+    // applied with a range check, not via `int.parse::<i64>()` on the magnitude.
+    let c = parse(
+        r#"min = -9223372036854775808.0
+           max = 9223372036854775807.0"#,
+    )
+    .unwrap();
+    assert_eq!(c.get("min").unwrap().as_i64(), Some(i64::MIN));
+    assert_eq!(c.get_i64("min").unwrap(), i64::MIN);
+    assert_eq!(c.get("max").unwrap().as_i64(), Some(i64::MAX));
+    // one past i64::MAX as a whole float must reject, not wrap
+    let c2 = parse("n = 9223372036854775808.0").unwrap();
+    assert_eq!(c2.get("n").unwrap().as_i64(), None);
+}
+
+#[test]
+fn huge_exponent_rejects_without_huge_allocation() {
+    // Must return None quickly, not attempt a multi-GB zero-padded string.
+    let c = parse("n = 1e2147483647").unwrap();
+    assert_eq!(c.get("n").unwrap().as_i64(), None);
+    assert!(c.get_i64("n").is_err());
+    let c2 = parse("n = 1e-2147483648").unwrap();
+    assert_eq!(c2.get("n").unwrap().as_i64(), None); // ~0, non-whole
+}
+
+#[test]
+fn negative_exponent_consistent_across_surfaces() {
+    let c = parse("a = 1000e-3").unwrap();
+    assert_eq!(c.get("a").unwrap().as_i64(), Some(1));
+    assert_eq!(c.get_i64("a").unwrap(), 1);
+    #[cfg(feature = "serde")]
+    assert_eq!(c.get_as::<i64>("a").unwrap(), 1);
+}
+
+#[test]
+fn leading_zero_float_forms_coerce() {
+    let c = parse(
+        r#"a = 0100.0
+           b = 0001e3"#,
+    )
+    .unwrap();
+    assert_eq!(c.get("a").unwrap().as_i64(), Some(100));
+    assert_eq!(c.get("b").unwrap().as_i64(), Some(1000));
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn serde_get_as_i64_matches() {
+    let c = parse(
+        r#"bad = 9007199254740992.5
+           good = 9007199254740993.0"#,
+    )
+    .unwrap();
+    assert!(c.get_as::<i64>("bad").is_err());
+    assert_eq!(c.get_as::<i64>("good").unwrap(), 9007199254740993);
+}

--- a/tests/issue56_i64_coercion_precision.rs
+++ b/tests/issue56_i64_coercion_precision.rs
@@ -115,6 +115,23 @@ fn negative_exponent_consistent_across_surfaces() {
 }
 
 #[test]
+fn all_zero_mantissa_is_zero_regardless_of_exponent() {
+    // An all-zero mantissa denotes 0 for any exponent; must not be rejected by
+    // the huge-exponent allocation guard.
+    let c = parse(
+        r#"a = 0.0
+           b = 0e2147483647
+           c = 0.000
+           d = -0.0"#,
+    )
+    .unwrap();
+    assert_eq!(c.get("a").unwrap().as_i64(), Some(0));
+    assert_eq!(c.get("b").unwrap().as_i64(), Some(0));
+    assert_eq!(c.get("c").unwrap().as_i64(), Some(0));
+    assert_eq!(c.get("d").unwrap().as_i64(), Some(0));
+}
+
+#[test]
 fn leading_zero_float_forms_coerce() {
     let c = parse(
         r#"a = 0100.0


### PR DESCRIPTION
## Summary

Fixes the integer-coercion precision hole reported in [xx.hocon#56](https://github.com/o3co/xx.hocon/issues/56). Float-like integer coercion checked wholeness via `f64::fract() == 0.0`, which is unsound at high magnitudes:

- above **2^52** an `f64` can no longer represent fractional parts, so `9007199254740992.5` (and `4503599627370496.5`, in the 2^52 window) rounded to a *whole* `f64` and was **wrongly accepted**;
- a would-be-whole literal like `9007199254740993.0` rounded to the **wrong integer** (silent off-by-one).

A magnitude threshold (e.g. reject `>= 2^53`) is **insufficient** — the half-integer hole opens at 2^52, and finer fractions below that.

## Fix

A single shared `whole_float_to_i64` helper derives **both wholeness and the exact integer from the raw decimal text** (sign / mantissa / exponent), never via `f64`. It replaces the previously *triplicated* f64 fallback in `scalar_as_i64` (`HoconValue::as_i64`), `Config::get_i64`, and the serde `parse_int_from_scalar` path — so all three i64 coercion surfaces are now identical. Genuinely whole large literals (e.g. `1e16`) still coerce; non-whole values reject at any magnitude.

## Review hardening (multi-agent — both reviewers converged)

- **Bounded exponent expansion**: a huge exponent like `1e2147483647` now returns `None` immediately instead of allocating gigabytes of zero-padding (DoS guard).
- **i64::MIN preserved**: the magnitude is parsed as `u64` and the sign applied with a range check, so `-9223372036854775808.0` yields `i64::MIN` (the old f64 path accepted it; a naive magnitude-as-i64 parse would reject it).

## Tests

`tests/issue56_i64_coercion_precision.rs` — 12 cases: the 2^53 / 2^52 false-accepts, the off-by-one exact case, `1e16` no-regression, negative-exponent text-wholeness (`1e-3`→None, `1000e-3`→1), i64::MIN/MAX float forms, huge-exponent no-alloc, leading-zero forms, and cross-surface agreement (`get_i64` / `as_i64` / `get_as::<i64>`).

## Scope

ts.hocon is **N/A** (no integer coercion — `number` is float64, int-ness is a zod concern). go.hocon gets the byte-identical fix in a sibling PR. Part of the coordinated 1.8 line; `[Unreleased]` `### Fixed`, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)