### PR TITLE
release(v1.8.0): finalize CHANGELOG + bump Cargo.toml (cross-impl minor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-06-16
+
 ### Added — deserialize any node + `HoconValue` accessors
 
 Closes the "value → type for any node" gap: previously only the whole config root
@@ -309,7 +311,8 @@ Behaviour:
 
 - **CI: content-addressable testdata cache** (closes [#101](https://github.com/o3co/rs.hocon/issues/101)). `.github/workflows/test.yml` and `.github/workflows/publish.yml` previously used `actions/cache@v5` with `key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}`. The hash evaluated BEFORE the cache restore step ran, but `.xx-hocon-version` is gitignored and absent on fresh checkouts — so the key collapsed to a constant and cache entries shared the same slot. Split into `actions/cache/restore@v5` (matches via `restore-keys`) + `actions/cache/save@v5` (writes with the post-fetch hash, gated on `make testdata` success). No production code touched.
 
-[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.7.1...HEAD
+[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/o3co/rs.hocon/compare/v1.7.1...v1.8.0
 [1.7.1]: https://github.com/o3co/rs.hocon/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/o3co/rs.hocon/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/o3co/rs.hocon/compare/v1.6.0...v1.6.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hocon-parser"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "criterion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hocon-parser"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2021"
 rust-version = "1.82"
 description = "Full Lightbend HOCON specification-compliant parser for Rust"


### PR DESCRIPTION
Finalizes `[Unreleased]` as `[1.8.0] - 2026-06-16`, adds the compare link, and bumps `Cargo.toml`/`Cargo.lock` to `1.8.0` for the coordinated v1.8.0 release (rs: `from_value`/`get_as` deserialize-any-node + `HoconValue` accessors #140; integer-coercion precision fix xx.hocon#56 #141).

🤖 Generated with [Claude Code](https://claude.com/claude-code)