### PR TITLE
fix!: duration unit names are case-sensitive (S19.8) + spec-compliance doc sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — **BREAKING**: duration unit names are case-sensitive (S19.8, HOCON.md L1304)
+
+- **`get_duration` (and `get_duration_option`) now reject non-lowercase duration units** per HOCON.md L1304 ("The
+  supported unit strings for duration are case sensitive and must be lowercase").
+  Previously `parse_duration` lowercased the unit before matching, so `"100 MS"`,
+  `"100 Seconds"` etc. were wrongly accepted; they now return `Err`. Lowercase units
+  are unaffected. This also makes `get_duration` consistent with `get_period`, whose
+  unit match was already case-sensitive under the same spec rule. Aligns with
+  go.hocon (already compliant) and ts.hocon's equivalent fix in the same cross-impl
+  cycle. Flips the S19.8 compliance cell ❌ → ✅.
+
 ## [1.8.0] - 2026-06-16
 
 ### Added — deserialize any node + `HoconValue` accessors

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -677,9 +677,9 @@ same item descriptions verbatim.
   tests: src/config.rs:765 (get_duration_days); tests/integration_test.rs:211 (test_duration_missing_units)
   status: ✅
 - **S19.8** Duration unit names are case sensitive (lowercase only) — §Duration format (L1304)
-  tests: tests/spec_phase5.rs (s19_8_pin_uppercase_ms_accepted; s19_8_spec_uppercase_ms_rejected [#ignore]; s19_8_pin_mixed_case_seconds_accepted; s19_8_spec_mixed_case_seconds_rejected [#ignore]; s19_8_lowercase_units_accepted)
-  status: ❌
-  notes: `parse_duration` calls `.to_lowercase()` on the unit string before matching, so `"MS"`, `"Seconds"`, `"NS"` etc. are wrongly accepted. Spec (L1304) requires lowercase only. Lowercase units still work correctly.
+  tests: tests/spec_phase5.rs (s19_8_spec_uppercase_ms_rejected; s19_8_spec_mixed_case_seconds_rejected; s19_8_lowercase_units_accepted)
+  status: ✅
+  notes: `parse_duration` matches the unit string case-sensitively (the former `.to_lowercase()` was removed), consistent with `parse_period` which was already case-sensitive per the same L1304 rule. `"MS"`, `"Seconds"` etc. now return an error (BREAKING: previously accepted). Lowercase units unaffected.
 
 ## S20. Period format
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -332,8 +332,9 @@ same item descriptions verbatim.
   tests: src/resolver/mod.rs:211 (resolves_last_assignment_wins_for_substitution); tests/lightbend_test.rs:275 (lightbend_test06_delayed_merge)
   status: ✅
 - **S13.9** `null` in config blocks env var lookup — §Substitutions (L618)
-  tests: tests/integration_test.rs:1014 (s13_9_null_blocks_env_var_lookup_pin); tests/integration_test.rs:1028 (s13_9_null_blocks_env_var_lookup_spec)
-  status: ❌ (see #74)
+  tests: tests/integration_test.rs (s13_9_null_in_config_blocks_env_var_and_stays_in_tree)
+  status: ✅ — Lightbend-aligned per the xx.hocon `ProbeS13_9.java` ground-truth audit (2026-05-22): "null treated same as missing" (L630) is a getter-level statement; the resolved tree keeps the field as an explicit null scalar, the env value does not leak, and getter-level null rejection is covered by S17.6. [#74](https://github.com/o3co/rs.hocon/issues/74) closed as "not a spec violation"; the former `#[ignore]` spec test (which asserted tree-level erasure) was removed as canon-incorrect.
+
 - **S13.10** Required substitution undefined → error — §Substitutions (L627)
   tests: src/resolver/mod.rs:183 (throws_on_unresolved_mandatory); tests/integration_test.rs:470 (resolve_error_is_hocon_error_resolve_variant); tests/testdata/hocon/cycle-expected-error.json (fixture)
   status: ✅
@@ -347,12 +348,13 @@ same item descriptions verbatim.
   tests: tests/integration_test.rs:1041 (s13_13_optional_undefined_in_string_concat_is_empty)
   status: ✅
 - **S13.14** Optional undefined in obj/array concat → empty obj/array — §Substitutions (L637)
-  tests: tests/integration_test.rs:1054 (s13_14_optional_undefined_in_array_concat_pin); tests/integration_test.rs:1066 (s13_14_optional_undefined_in_array_concat_spec); tests/integration_test.rs:1078 (s13_14_optional_undefined_in_object_concat)
-  status: ⚠️ (see #75) — array case broken (whitespace artefacts leak as extra elements); object case ✅
+  tests: tests/integration_test.rs (s13_14_optional_undefined_in_array_concat_spec, s13_14_optional_undefined_in_object_concat)
+  status: ✅ — both the array and object concat cases pass (the former whitespace-artefact leak in the array case, tracked in [#75](https://github.com/o3co/rs.hocon/issues/75), is fixed; the pin test was removed when the spec test was enabled).
+
 - **S13.15** `foo : ${?bar}${?baz}` skipped only when BOTH undefined — §Substitutions (L640)
-  tests: tests/spec_phase5.rs (s13_15_pin_both_optional_undefined_field_exists; s13_15_spec_both_optional_undefined_field_absent [#ignore]; s13_15_one_defined_field_is_created)
-  status: ❌
-  notes: when both `${?bar}` and `${?baz}` are undefined, `foo` is still created with a null value instead of being dropped. The single-defined sub-case (`bar=hello, foo=${?bar}${?baz}`) correctly produces `foo=hello`.
+  tests: tests/spec_phase5.rs (s13_15_spec_both_optional_undefined_field_absent; s13_15_one_defined_field_is_created)
+  status: ✅ — when both `${?bar}` and `${?baz}` are undefined, `foo` is dropped entirely; the single-defined sub-case produces `foo=hello`. The former field-created-with-null violation is fixed and the spec test runs un-ignored.
+
 - **S13.16** Substitutions only in field values / array elements — §Substitutions (L644)
   tests: tests/integration_test.rs:1087 (s13_16_substitution_in_key_is_rejected)
   status: ✅
@@ -418,8 +420,9 @@ same item descriptions verbatim.
   tests: src/resolver/mod.rs:103 (handles_plus_equals_on_existing_array); tests/integration_test.rs:84 (parse_with_plus_equals)
   status: ✅
 - **S13b.2** `+=` on non-array prior value → error — §`+=` field separator (L732)
-  tests: tests/integration_test.rs:941 (s13b_2_plus_eq_on_non_array_pin); tests/integration_test.rs:956 (s13b_2_plus_eq_on_non_array_spec)
-  status: ❌ (see #72)
+  tests: tests/integration_test.rs (s13b_2_plus_eq_on_non_array_errors, s13b_2_plus_eq_on_object_errors, s13b_2_plus_eq_under_allow_unresolved_defers_on_unresolved_prior); tests/s13b_2_plus_equals_include_accumulation.rs
+  status: ✅ — `+=` on a scalar or object prior errors instead of silently wrapping ([#72](https://github.com/o3co/rs.hocon/issues/72) fixed).
+
 - **S13b.3** `+=` works on first mention of key (no prior `=`) — §`+=` field separator (L734)
   tests: src/resolver/mod.rs:113 (handles_plus_equals_on_missing_key)
   status: ✅
@@ -626,9 +629,9 @@ same item descriptions verbatim.
   status: ➖
   note: rs.hocon has no `get_null()` typed getter — the "null requested" path does not exist in the API. Internally, quoted `"null"` is correctly stored as `ScalarType::String` (not `Null`), which is consistent with spec intent. Out-of-scope until a null-accessor is added.
 - **S17.6** null → other type: error — §Automatic type conversions (L1252)
-  tests: tests/integration_test.rs:1470 (s17_6_null_to_numeric_and_bool_errors); tests/integration_test.rs:1483 (s17_6_null_to_string_pin); tests/integration_test.rs:1495 (s17_6_null_to_string_spec)
-  status: ⚠️
-  note: `get_i64` and `get_bool` on null correctly error. `get_string` on null returns `Ok("null")` instead of an error — spec requires an error for all typed getters. Bug tracked in #80.
+  tests: tests/integration_test.rs (s17_6_null_to_numeric_and_bool_errors, s17_6_null_to_string_errors)
+  status: ✅ — all typed getters error on null, including `get_string` (fixed in `a7d7aea`, [#80](https://github.com/o3co/rs.hocon/issues/80)).
+
 - **S17.7** object → other type: error — §Automatic type conversions (L1254)
   tests: src/config.rs:563 (get_string_error_on_object)
   status: ✅
@@ -677,7 +680,7 @@ same item descriptions verbatim.
   tests: src/config.rs:765 (get_duration_days); tests/integration_test.rs:211 (test_duration_missing_units)
   status: ✅
 - **S19.8** Duration unit names are case sensitive (lowercase only) — §Duration format (L1304)
-  tests: tests/spec_phase5.rs (s19_8_spec_uppercase_ms_rejected; s19_8_spec_mixed_case_seconds_rejected; s19_8_lowercase_units_accepted)
+  tests: tests/spec_phase5.rs (s19_8_spec_uppercase_ms_rejected; s19_8_spec_mixed_case_seconds_rejected; s19_8_spec_uppercase_single_letter_rejected; s19_8_lowercase_units_accepted)
   status: ✅
   notes: `parse_duration` matches the unit string case-sensitively (the former `.to_lowercase()` was removed), consistent with `parse_period` which was already case-sensitive per the same L1304 rule. `"MS"`, `"Seconds"` etc. now return an error (BREAKING: previously accepted). Lowercase units unaffected.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -466,6 +466,10 @@ impl Config {
     /// `ms`/`milli`/`millis`/`millisecond`/`milliseconds`,
     /// `s`/`second`/`seconds`, `m`/`minute`/`minutes`,
     /// `h`/`hour`/`hours`, `d`/`day`/`days`, `w`/`week`/`weeks`.
+    ///
+    /// Unit names are case-sensitive and must be lowercase (HOCON spec,
+    /// S19.8): `"100 MS"` and `"100 Seconds"` are errors. This also applies
+    /// to [`get_duration_option`](Self::get_duration_option).
     pub fn get_duration(&self, path: &str) -> Result<std::time::Duration, ConfigError> {
         match self.lookup_node(path) {
             None => Err(missing(path)),
@@ -821,14 +825,15 @@ fn parse_duration(s: &str) -> Option<std::time::Duration> {
         .find(|c: char| !c.is_ascii_digit() && c != '.' && c != '-' && c != '+')
         .unwrap_or(s.len());
     let num_str = s[..num_end].trim();
-    // Trim HOCON whitespace between number and unit, then lowercase the unit.
-    let unit_str = trim_hocon_ws(&s[num_end..]).to_lowercase();
+    // Trim HOCON whitespace between number and unit. The unit match below is
+    // case-sensitive per HOCON.md L1304 (S19.8): only lowercase unit names are valid.
+    let unit_str = trim_hocon_ws(&s[num_end..]);
 
     if num_str.is_empty() {
         return None;
     }
 
-    let nanos_per_unit: f64 = match unit_str.as_str() {
+    let nanos_per_unit: f64 = match unit_str {
         // Default: milliseconds (HOCON.md L1301).
         "" | "ms" | "milli" | "millis" | "millisecond" | "milliseconds" => 1_000_000.0,
         "ns" | "nano" | "nanos" | "nanosecond" | "nanoseconds" => 1.0,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1262,42 +1262,29 @@ fn s13_5_no_subst_in_quoted_string() {
 // --- S13.9: `null` in config blocks env var lookup (spec L618) ------------------
 // Spec: if the config tree has `key = null`, an optional substitution `${?key}`
 // must NOT fall back to the environment; the explicit null takes precedence.
-// BUG: rs.hocon currently falls through to the env var.
 #[test]
-fn s13_9_null_blocks_env_var_lookup_pin() {
-    // [pin] Current behaviour: rs.hocon does NOT leak the env value, but it
-    // also does NOT treat null-as-missing (which would erase the field per
-    // L618). Instead it resolves ${?HOME} to the explicit null scalar, so
-    // `result` ends up present with value null. The spec wants the field
-    // absent. Pinning the exact Some(Scalar(null)) shape catches both
-    // (a) regression to env leak ("/x/y") and
-    // (b) accidental progress to None (which the spec test would then catch).
+fn s13_9_null_in_config_blocks_env_var_and_stays_in_tree() {
+    // Lightbend-aligned (ProbeS13_9.java, xx.hocon 2026-05-22): "null treated
+    // same as missing" (L630) is a GETTER-level statement. The resolved tree
+    // keeps `result` as an explicit null scalar and the env value must not
+    // leak; getter-level null rejection is covered by S17.6. rs.hocon#74 was
+    // closed as "not a spec violation". Pinning the exact Some(Scalar(null))
+    // shape catches both an env leak ("/x/y") and an accidental erase (None).
     let mut env = std::collections::HashMap::new();
     env.insert("HOME".to_string(), "/x/y".to_string());
     let cfg = hocon::parse_with_env("HOME = null\nresult = ${?HOME}", &env)
         .expect("parse should succeed");
-    let v = cfg.get("result").expect("[pin] result must be present");
+    let v = cfg
+        .get("result")
+        .expect("result must be present in the tree");
     match v {
         hocon::HoconValue::Scalar(s) => assert_eq!(
             s.value_type,
             hocon::ScalarType::Null,
-            "[pin] result must be the explicit null scalar — env value must not leak"
+            "result must be the explicit null scalar — env value must not leak"
         ),
-        other => panic!("[pin] result must be a null scalar, got {:?}", other),
+        other => panic!("result must be a null scalar, got {:?}", other),
     }
-}
-
-#[test]
-#[ignore = "spec violation: null in config must block env fallback per HOCON L618, see #74"]
-fn s13_9_null_blocks_env_var_lookup_spec() {
-    let mut env = std::collections::HashMap::new();
-    env.insert("HOME".to_string(), "/x/y".to_string());
-    let cfg = hocon::parse_with_env("HOME = null\nresult = ${?HOME}", &env)
-        .expect("parse should succeed");
-    assert!(
-        cfg.get("result").is_none(),
-        "null in config must block env var fallback; result must be absent per HOCON L618"
-    );
 }
 
 // --- S13.13: optional undefined in string concat → empty string (spec L636) -----

--- a/tests/spec_phase5.rs
+++ b/tests/spec_phase5.rs
@@ -350,22 +350,10 @@ fn s18_4_spec_duration_string_no_unit_uses_default() {
 
 // ─────────────────────────────────────────────────────────────────────────────
 // S19.8  Duration unit names are case sensitive (lowercase only)  (L1304)
-// Status: ❌  — impl lowercases the unit before matching, so uppercase passes
+// Status: ✅
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Pin: impl currently accepts uppercase "MS" as milliseconds.
 #[test]
-fn s19_8_pin_uppercase_ms_accepted() {
-    let cfg = hocon::parse_with_env(r#"t = "100 MS""#, &HashMap::new()).unwrap();
-    // impl succeeds — pin that it does succeed (wrong behavior)
-    assert!(
-        cfg.get_duration("t").is_ok(),
-        "[pin] S19.8: impl currently accepts uppercase 'MS' (should reject per spec L1304)"
-    );
-}
-
-#[test]
-#[ignore = "spec violation per S19.8 (L1304): duration unit names are case sensitive and must be lowercase; impl lowercases unit before matching, so 'MS', 'Seconds', 'NS' etc. are wrongly accepted"]
 fn s19_8_spec_uppercase_ms_rejected() {
     let cfg = hocon::parse_with_env(r#"t = "100 MS""#, &HashMap::new()).unwrap();
     assert!(
@@ -375,21 +363,22 @@ fn s19_8_spec_uppercase_ms_rejected() {
 }
 
 #[test]
-fn s19_8_pin_mixed_case_seconds_accepted() {
-    let cfg = hocon::parse_with_env(r#"t = "100 Seconds""#, &HashMap::new()).unwrap();
-    assert!(
-        cfg.get_duration("t").is_ok(),
-        "[pin] S19.8: impl currently accepts 'Seconds' (should reject per spec L1304)"
-    );
-}
-
-#[test]
-#[ignore = "spec violation per S19.8 (L1304): 'Seconds' (mixed case) must be rejected; impl accepts it due to .to_lowercase() in parse_duration"]
 fn s19_8_spec_mixed_case_seconds_rejected() {
     let cfg = hocon::parse_with_env(r#"t = "100 Seconds""#, &HashMap::new()).unwrap();
     assert!(
         cfg.get_duration("t").is_err(),
         "S19.8: 'Seconds' must be rejected (spec requires lowercase only)"
+    );
+}
+
+#[test]
+fn s19_8_spec_uppercase_single_letter_rejected() {
+    // Unlike byte units (where `K`/`k` etc. both exist per Lightbend), duration
+    // units have no uppercase forms at all.
+    let cfg = hocon::parse_with_env(r#"t = "100 S""#, &HashMap::new()).unwrap();
+    assert!(
+        cfg.get_duration("t").is_err(),
+        "S19.8: uppercase 'S' must be rejected (only lowercase duration units allowed)"
     );
 }
 


### PR DESCRIPTION
## Summary
- **BREAKING (S19.8, HOCON.md L1304)**: `get_duration` (and `get_duration_option`) now reject non-lowercase duration units — `parse_duration` no longer calls `.to_lowercase()` before matching, so `"100 MS"` / `"100 Seconds"` return `Err`. Lowercase units unchanged. This makes `get_duration` consistent with `parse_period`, which already matched case-sensitively under the same rule, and aligns with go.hocon (already compliant); ts.hocon ships the equivalent fix in the same cycle. Pin tests removed, `#[ignore]` spec tests enabled, plus a new uppercase-single-letter case, rustdoc case-sensitivity note, and CHANGELOG Unreleased entry.
- **docs(spec-compliance) sync**: five rows still carried ❌/⚠️ from before their fixes / canon rulings landed — S13.14 (⚠️→✅, #75), S13.15 (❌→✅), S13b.2 (❌→✅, #72), S17.6 (⚠️→✅, #80 / a7d7aea), and S13.9 per-impl cleanup per the v1.5.0 Lightbend ProbeS13_9 canon (#74 closed as not-a-violation): the obsolete `#[ignore]` spec test asserting tree-level erasure is removed and the pin test renamed to a canon-aligned regression test.

With this PR rs.hocon's ground truth is ✅192 / ⚠️0 / ❌0 (spec-total 91.9%, **in-scope 100.0%** — zero in-scope violations). Cross-impl matrix re-roll-up lands in xx.hocon (PR to follow).

## Review
Pre-PR multi-agent review (Claude + Codex) ran on the S19.8 commit: no Critical/Important findings; both Minor nits (rustdoc note, get_duration_option in CHANGELOG) are applied.

## Verification
- `cargo test` (default + serde): all suites green; `cargo +1.82 test` (MSRV) unaffected by this change
- `cargo fmt --check`: clean; clippy delta vs develop: zero (pre-existing bench/example lints on newer local clippy are untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)