### PR TITLE
docs(readme): add py.hocon cross-link (4th sibling parser)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ conformance rate.
 
 **Library stance** — This library is a HOCON config loader. Its purpose is reading `.hocon` config files and providing typed access via the `Config` API (`get_string`, `get_i64`, `get_f64`, `get_bool`, `get_duration`, `get_bytes`). It is not a low-level parser API; internal types like `ScalarValue` may change between minor versions.
 
-**Cross-language conformance** — This implementation is tested against shared expected-JSON fixtures from [o3co/xx.hocon](https://github.com/o3co/xx.hocon) alongside [ts.hocon](https://github.com/o3co/ts.hocon) and [go.hocon](https://github.com/o3co/go.hocon), ensuring all three implementations meet the same Lightbend HOCON specification.
+**Cross-language conformance** — This implementation is tested against shared expected-JSON fixtures from [o3co/xx.hocon](https://github.com/o3co/xx.hocon) alongside [ts.hocon](https://github.com/o3co/ts.hocon), [go.hocon](https://github.com/o3co/go.hocon), and [py.hocon](https://github.com/o3co/py.hocon), ensuring all four implementations meet the same Lightbend HOCON specification.
 
 ## Quick Start
 
@@ -341,9 +341,10 @@ The MSRV is **1.82**.
 |---------|----------|----------|-------------|
 | [ts.hocon](https://github.com/o3co/ts.hocon) | TypeScript | [npm](https://www.npmjs.com/package/@o3co/ts.hocon) | HOCON parser for TypeScript/Node.js |
 | [go.hocon](https://github.com/o3co/go.hocon) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/go.hocon) | HOCON parser for Go |
+| [py.hocon](https://github.com/o3co/py.hocon) | Python | [PyPI](https://pypi.org/project/hocon-parser/) | HOCON parser for Python |
 | [hocon2](https://github.com/o3co/hocon2) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/hocon2) | HOCON → JSON/YAML/TOML/Properties CLI |
 
-The three parser implementations ([ts.hocon](https://github.com/o3co/ts.hocon), [rs.hocon](https://github.com/o3co/rs.hocon), [go.hocon](https://github.com/o3co/go.hocon)) are all tracked against the same Lightbend HOCON spec — see the [cross-impl roll-up](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for per-impl conformance rates.
+The four parser implementations ([ts.hocon](https://github.com/o3co/ts.hocon), [rs.hocon](https://github.com/o3co/rs.hocon), [go.hocon](https://github.com/o3co/go.hocon), [py.hocon](https://github.com/o3co/py.hocon)) are all tracked against the same Lightbend HOCON spec — see the [cross-impl roll-up](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for per-impl conformance rates.
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary

Adds a cross-link to **py.hocon** — the 4th sibling o3co HOCON parser (Python, PyPI: `hocon-parser`, at spec-corpus parity 134/134) — in the rs.hocon README, and updates the sibling parser count from three to four.

## Changes (README.md only)

- **Related Projects** table: new `py.hocon` row (Python / PyPI), placed after `go.hocon` so the parser siblings stay grouped (ts, go, py) ahead of the `hocon2` CLI.
- **Cross-language conformance** note (top of README): added py.hocon alongside ts.hocon and go.hocon; "all three implementations" → "all four implementations".
- **Cross-impl roll-up** paragraph: "The three parser implementations" → "The four parser implementations", with py.hocon added to the list.

Links:
- GitHub: https://github.com/o3co/py.hocon
- PyPI: https://pypi.org/project/hocon-parser/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
