### PR TITLE
fix(S3.1): empty document parses to {} — remove reject guard (spec corrected)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — empty document parses to `{}` (S3.1 corrected, [xx.hocon#62](https://github.com/o3co/xx.hocon/pull/62))
+
+- **`parse("")` (and whitespace-only / comment-only / BOM-only input) returns an empty
+  `Config` instead of erroring.** The S3.1 checklist item "Empty file is invalid
+  (HOCON.md L130)" misread the L130-132 *JSON baseline* as HOCON-normative; the
+  L134-136 brace-omission relaxation parses any document not beginning with `[` or `{`
+  as if enclosed in `{}` — an empty document is therefore the empty object. Confirmed
+  by the reference implementation (Lightbend's `"Empty document"` error is
+  `ConfigSyntax.JSON`-only; `ConfigFactory.parseString("")` is a valid empty config in
+  its own test suite). The Phase 6 #3h `assert_non_empty_document` guard (a
+  regression) is removed from all four parse entry points (`parse_with_options`,
+  `parse_string_with_options`, `parse_file_with_env`, `parse_with_env`), and the
+  file-include #105 carve-out in `include_loader.rs` is gone — `parse_tokens` yields
+  an empty object AST naturally, so the rule is uniform across top-level, file
+  includes, and E11 package includes (which never carried the guard; whitespace/
+  comment-only registered content is now pinned for cross-impl parity). Pure
+  loosening — no previously-valid input changes meaning; previously-rejected empty
+  documents now succeed. Pinned by `tests/spec_s3_1_empty_file.rs`,
+  `tests/conformance_empty_file.rs` (ef01–ef06 `{}` sidecars now normative),
+  `tests/issue105_empty_include.rs`, and `tests/include_package_test.rs`.
+
 ### Changed — **BREAKING**: duration unit names are case-sensitive (S19.8, HOCON.md L1304)
 
 - **`get_duration` (and `get_duration_option`) now reject non-lowercase duration units** per HOCON.md L1304 ("The

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -61,9 +61,9 @@ same item descriptions verbatim.
 
 ## S3. Omit root braces
 
-- **S3.1** Empty file is invalid — §Omit root braces (L130)
-  tests: tests/spec_s3_1_empty_file.rs (s3_1_1_empty_string, s3_1_2_whitespace_only, s3_1_3_newlines_only, s3_1_4_comment_only, s3_1_5_bom_only, s3_1_6_mixed_ws_comment); tests/conformance_empty_file.rs (ef01-ef06); src/parser.rs (parses_empty_input — updated to expect Err via hocon::parse)
-  status: ✅ (was ⚠️; guard added at parse_with_env/parse_file_with_env entry — Phase 6 #3h)
+- **S3.1** Empty document (empty / whitespace-only / comment-only / BOM-only file) parses to the empty object `{}` — §Omit root braces (L130-136)
+  tests: tests/spec_s3_1_empty_file.rs (s3_1_1–s3_1_6 + positives); tests/conformance_empty_file.rs (ef01-ef06, `{}` sidecars normative); tests/spec_s3_1_empty_include.rs; tests/issue105_empty_include.rs (issue105_top_level_empty_parses_to_empty_object); tests/include_package_test.rs (ipk08 + whitespace/comment variants); src/parser.rs (parses_empty_input)
+  status: ✅ — Corrected 2026-07-23 (xx.hocon E10). The item previously read "Empty file is invalid" — a misreading of the L130-132 JSON baseline as HOCON-normative; the L134 brace-omission relaxation makes an empty document the empty object. The Phase 6 #3h `assert_non_empty_document` guard (a regression) is removed from all four parse entry points, and the include-path carve-out is gone — empty documents parse to `{}` uniformly on every path.
 - **S3.2** Root non-object/non-array is invalid (when explicitly enclosed) — §Omit root braces (L131)
   tests: tests/integration_test.rs:651 (s3_2_root_bare_string_rejected)
   status: ✅

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,7 +323,9 @@ impl Parser {
     /// inlined at phase 1 so the registry is not needed after this call returns.
     pub fn parse_with_options(self, input: &str, opts: ParseOptions) -> Result<Config, HoconError> {
         let tokens = lexer::tokenize(input)?;
-        assert_non_empty_document(&tokens)?;
+        // S3.1 (corrected, xx.hocon E10): an empty / whitespace-only /
+        // comment-only / BOM-only document parses to the empty object per the
+        // HOCON.md L134-136 brace-omission relaxation — no emptiness guard.
         let ast = parser::parse_tokens(&tokens)?;
 
         let env: HashMap<String, String> = opts.env.clone().unwrap_or_else(|| {
@@ -406,7 +408,6 @@ pub fn parse(input: &str) -> Result<Config, HoconError> {
 /// use [`Parser::parse_with_options`] (feature `include-package`).
 pub fn parse_string_with_options(input: &str, opts: ParseOptions) -> Result<Config, HoconError> {
     let tokens = lexer::tokenize(input)?;
-    assert_non_empty_document(&tokens)?;
     let ast = parser::parse_tokens(&tokens)?;
 
     let env: HashMap<String, String> = opts.env.clone().unwrap_or_else(|| {
@@ -477,7 +478,6 @@ pub fn parse_file_with_env<P: AsRef<Path>>(
     let content = std::fs::read_to_string(path)
         .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {}", path.display(), e)))?;
     let tokens = lexer::tokenize(&content)?;
-    assert_non_empty_document(&tokens)?;
     let ast = parser::parse_tokens(&tokens)?;
     let mut opts = resolver::InternalResolveOptions::new(env.clone());
     if let Some(dir) = path.parent() {
@@ -497,7 +497,6 @@ pub fn parse_file_with_env<P: AsRef<Path>>(
 /// Parse a HOCON string with a custom environment variable map.
 pub fn parse_with_env(input: &str, env: &HashMap<String, String>) -> Result<Config, HoconError> {
     let tokens = lexer::tokenize(input)?;
-    assert_non_empty_document(&tokens)?;
     let ast = parser::parse_tokens(&tokens)?;
     let opts = resolver::InternalResolveOptions::new(env.clone());
     let value = resolver::resolve(ast, &opts)?;
@@ -583,23 +582,3 @@ pub fn _render_json_for_test(config: &Config) -> String {
     out
 }
 
-/// Guard: reject token streams that carry no semantic content (HOCON.md L130).
-///
-/// An empty document is one whose token stream contains only `Newline` and `Eof`
-/// tokens after the lexer has already stripped whitespace, BOM, and comments.
-/// A document with at least one structural or value token (including `{`, `}`,
-/// unquoted/quoted text, substitutions, …) is not empty even if it resolves to
-/// an empty object.
-fn assert_non_empty_document(tokens: &[lexer::Token]) -> Result<(), HoconError> {
-    let has_content = tokens
-        .iter()
-        .any(|t| !matches!(t.kind, lexer::TokenKind::Newline | lexer::TokenKind::Eof));
-    if !has_content {
-        return Err(HoconError::Parse(ParseError {
-            message: "empty file is not a valid HOCON document (HOCON.md L130)".into(),
-            line: 1,
-            col: 1,
-        }));
-    }
-    Ok(())
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -581,4 +581,3 @@ pub fn _render_json_for_test(config: &Config) -> String {
     out.push('}');
     out
 }
-

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1103,10 +1103,11 @@ mod tests {
         // relaxation. Verify via the public `hocon::parse` API so the full
         // pipeline is exercised.
         let cfg = crate::parse("").expect("S3.1: hocon::parse(\"\") must return an empty config");
+        let keys = cfg.keys();
         assert!(
-            cfg.keys().is_empty(),
+            keys.is_empty(),
             "S3.1: empty input must produce an empty config, got keys {:?}",
-            cfg.keys()
+            keys
         );
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1098,13 +1098,15 @@ mod tests {
 
     #[test]
     fn parses_empty_input() {
-        // S3.1: empty file is not a valid HOCON document (HOCON.md L130).
-        // The guard fires at the library entry point (`parse_with_env`) after
-        // tokenise, before `parse_tokens`. Verify via the public `hocon::parse`
-        // API so the full pipeline is exercised.
+        // S3.1 (corrected, xx.hocon E10): an empty document is valid HOCON and
+        // parses to the empty object per the HOCON.md L134-136 brace-omission
+        // relaxation. Verify via the public `hocon::parse` API so the full
+        // pipeline is exercised.
+        let cfg = crate::parse("").expect("S3.1: hocon::parse(\"\") must return an empty config");
         assert!(
-            crate::parse("").is_err(),
-            "S3.1: hocon::parse(\"\") must return Err (empty file is invalid)"
+            cfg.keys().is_empty(),
+            "S3.1: empty input must produce an empty config, got keys {:?}",
+            cfg.keys()
         );
     }
 

--- a/src/resolver/include_loader.rs
+++ b/src/resolver/include_loader.rs
@@ -208,25 +208,15 @@ pub(crate) fn load_package_include(
         }
     };
 
-    // E11 decision 4 note: empty registered content => empty merge object, not an error.
-    // Do NOT call assert_non_empty_document here.
+    // S3.1 (corrected, xx.hocon E10): empty registered content parses to `{}`
+    // naturally via `parse_tokens` — same uniform rule as top-level parses and
+    // file includes (E11 decision 4 note: empty content is not an error).
     let tokens = crate::lexer::tokenize(content).map_err(|e| ResolveError {
         message: e.message,
         path: format!("package({:?}, {:?})", identifier, file),
         line: e.line,
         col: e.col,
     })?;
-
-    let has_content = tokens.iter().any(|t| {
-        !matches!(
-            t.kind,
-            crate::lexer::TokenKind::Newline | crate::lexer::TokenKind::Eof
-        )
-    });
-    if !has_content {
-        // Empty registered content → empty merge object (E11 decision 4 note)
-        return Ok(ResObj::new());
-    }
 
     let ast = crate::parser::parse_tokens(&tokens).map_err(|e| ResolveError {
         message: e.message,

--- a/src/resolver/include_loader.rs
+++ b/src/resolver/include_loader.rs
@@ -132,23 +132,11 @@ fn load_single_include(
         col: e.col,
     })?;
 
-    // Lightbend-compat carve-out (#105 cross-impl): an empty / whitespace-only /
-    // comment-only included file contributes an empty config rather than
-    // erroring with S3.1. Top-level parses (`parse` / `parse_with_env` /
-    // `parse_string_with_options` / `parse_file_with_options` on a
-    // top-level empty document) continue to enforce S3.1 in `parse_with_env` /
-    // `parse_file_with_env` (src/lib.rs); the carve-out is scoped to the
-    // file-include path only. E11 package includes are unchanged.
-    let has_content = tokens.iter().any(|t| {
-        !matches!(
-            t.kind,
-            crate::lexer::TokenKind::Newline | crate::lexer::TokenKind::Eof
-        )
-    });
-    if !has_content {
-        return Ok(ResObj::new());
-    }
-
+    // S3.1 (corrected, xx.hocon E10): an empty / whitespace-only / comment-only
+    // included file is a valid empty document — `parse_tokens` yields an empty
+    // object AST contributing `{}`. The former #105 Lightbend-compat carve-out
+    // is now simply the rule, uniform with top-level parses (src/lib.rs) and
+    // E11 package includes.
     let ast = crate::parser::parse_tokens(&tokens).map_err(|e| ResolveError {
         message: e.message,
         path: candidate.display().to_string(),

--- a/tests/conformance_empty_file.rs
+++ b/tests/conformance_empty_file.rs
@@ -23,11 +23,12 @@ fn run_empty_file_fixture(name: &str) {
             name, e
         )
     });
+    let keys = cfg.keys();
     assert!(
-        cfg.keys().is_empty(),
+        keys.is_empty(),
         "S3.1 conformance: {}.conf must produce an empty config, got keys {:?}",
         name,
-        cfg.keys()
+        keys
     );
 }
 

--- a/tests/conformance_empty_file.rs
+++ b/tests/conformance_empty_file.rs
@@ -1,12 +1,11 @@
 //! S3.1 conformance — empty-file fixtures from xx.hocon.
 //!
-//! All ef01-ef06 fixtures must produce a parse error per HOCON.md L130.
+//! All ef01-ef06 fixtures parse to the empty object `{}` per HOCON.md §Omit
+//! root braces L134-136 (L130-132 is the JSON baseline, not HOCON-normative).
 //! Fixture dir: tests/testdata/hocon/empty-file/
-//! Expected dir: tests/testdata/expected/empty-file/ (contains `-expected.json`
-//! with `{}` that marks the ground truth; however per the cluster override-list
-//! these are known-error fixtures — the impl MUST error for all of them).
-//!
-//! RED: fails until S3.1 empty-stream guard is implemented.
+//! Expected dir: tests/testdata/expected/empty-file/ — the `-expected.json`
+//! sidecars contain `{}` and are normative as-is; the former per-impl
+//! override list (assert-error) was revoked 2026-07-23 (xx.hocon E10).
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -18,11 +17,17 @@ fn fixture_dir() -> PathBuf {
 fn run_empty_file_fixture(name: &str) {
     let path = fixture_dir().join(format!("{}.conf", name));
     let env: HashMap<String, String> = HashMap::new();
-    let result = hocon::parse_file_with_env(&path, &env);
+    let cfg = hocon::parse_file_with_env(&path, &env).unwrap_or_else(|e| {
+        panic!(
+            "S3.1 conformance: {}.conf must parse to {{}} per the expected sidecar, got error: {}",
+            name, e
+        )
+    });
     assert!(
-        result.is_err(),
-        "S3.1 conformance: {}.conf must produce an error (HOCON.md L130 — empty file invalid), got Ok",
-        name
+        cfg.keys().is_empty(),
+        "S3.1 conformance: {}.conf must produce an empty config, got keys {:?}",
+        name,
+        cfg.keys()
     );
 }
 

--- a/tests/include_package_test.rs
+++ b/tests/include_package_test.rs
@@ -190,6 +190,38 @@ fn ipk08_empty_content_succeeds() {
     );
 }
 
+// ── ipk08 variants: whitespace-only / comment-only registered content ────────
+// Same S3.1 rule as zero-byte (an empty document parses to the empty object;
+// corrected 2026-07-23, xx.hocon E10). Cross-impl parity pin: the rs package
+// path never carried the reject guard, but ts/go did — pinning here keeps the
+// three impls' package-include behavior aligned.
+
+#[test]
+fn ipk08_whitespace_only_content_succeeds() {
+    let input = r#"
+        app = host
+        include package("github.com/example/lib", "empty.conf")
+    "#;
+    let cfg = Parser::new()
+        .register_package("github.com/example/lib", "empty.conf", "   \n\t\n")
+        .parse(input)
+        .expect("ipk08 variant: whitespace-only registered content should contribute {}");
+    assert_eq!(cfg.get_string("app").unwrap(), "host");
+}
+
+#[test]
+fn ipk08_comment_only_content_succeeds() {
+    let input = r#"
+        app = host
+        include package("github.com/example/lib", "empty.conf")
+    "#;
+    let cfg = Parser::new()
+        .register_package("github.com/example/lib", "empty.conf", "# nothing here\n")
+        .parse(input)
+        .expect("ipk08 variant: comment-only registered content should contribute {}");
+    assert_eq!(cfg.get_string("app").unwrap(), "host");
+}
+
 // ── ipk09: empty string file argument ────────────────────────────────────────
 
 #[test]

--- a/tests/issue105_empty_include.rs
+++ b/tests/issue105_empty_include.rs
@@ -80,7 +80,10 @@ fn issue105_top_level_empty_parses_to_empty_object() {
         ("// only a comment\n", "slash-comment-only"),
     ] {
         let cfg = hocon::parse(input).unwrap_or_else(|e| {
-            panic!("{} top-level must parse to {{}} per corrected S3.1, got error: {}", label, e)
+            panic!(
+                "{} top-level must parse to {{}} per corrected S3.1, got error: {}",
+                label, e
+            )
         });
         assert!(
             cfg.keys().is_empty(),

--- a/tests/issue105_empty_include.rs
+++ b/tests/issue105_empty_include.rs
@@ -85,11 +85,12 @@ fn issue105_top_level_empty_parses_to_empty_object() {
                 label, e
             )
         });
+        let keys = cfg.keys();
         assert!(
-            cfg.keys().is_empty(),
+            keys.is_empty(),
             "{} top-level must produce an empty config, got keys {:?}",
             label,
-            cfg.keys()
+            keys
         );
     }
 }

--- a/tests/issue105_empty_include.rs
+++ b/tests/issue105_empty_include.rs
@@ -1,9 +1,9 @@
 //! Cross-impl fix for go.hocon#105 — empty / whitespace-only / comment-only /
-//! BOM-only INCLUDED files contribute an empty config instead of erroring
-//! with S3.1's "empty file is not a valid HOCON document". Top-level parses
-//! (`parse` / `parse_with_env` / `parse_file_with_options` on a top-level
-//! empty file) continue to error
-//! per S3.1.
+//! BOM-only INCLUDED files contribute an empty config. Originally a narrow
+//! include-path carve-out while top-level parses still rejected; since the
+//! S3.1 correction (xx.hocon E10, 2026-07-23) the same rule applies
+//! everywhere — an empty document parses to `{}` at top level too
+//! (HOCON.md §Omit root braces L134-136).
 
 use tempfile::tempdir;
 
@@ -70,21 +70,25 @@ fn issue105_bom_only_include_is_noop() {
 }
 
 #[test]
-fn issue105_top_level_empty_still_rejected() {
-    // S3.1 enforcement for top-level parses must remain intact.
-    assert!(hocon::parse("").is_err(), "empty top-level must error");
-    assert!(
-        hocon::parse("   \n\t  ").is_err(),
-        "whitespace-only top-level must error",
-    );
-    assert!(
-        hocon::parse("# only a comment\n").is_err(),
-        "hash-comment-only top-level must error",
-    );
-    assert!(
-        hocon::parse("// only a comment\n").is_err(),
-        "slash-comment-only top-level must error",
-    );
+fn issue105_top_level_empty_parses_to_empty_object() {
+    // Corrected S3.1: top-level parity with the include path — an empty
+    // document parses to {} everywhere (xx.hocon E10).
+    for (input, label) in [
+        ("", "empty"),
+        ("   \n\t  ", "whitespace-only"),
+        ("# only a comment\n", "hash-comment-only"),
+        ("// only a comment\n", "slash-comment-only"),
+    ] {
+        let cfg = hocon::parse(input).unwrap_or_else(|e| {
+            panic!("{} top-level must parse to {{}} per corrected S3.1, got error: {}", label, e)
+        });
+        assert!(
+            cfg.keys().is_empty(),
+            "{} top-level must produce an empty config, got keys {:?}",
+            label,
+            cfg.keys()
+        );
+    }
 }
 
 #[test]

--- a/tests/spec_s3_1_empty_file.rs
+++ b/tests/spec_s3_1_empty_file.rs
@@ -20,11 +20,12 @@ fn assert_parses_to_empty(input: &str, label: &str) {
             label, e
         )
     });
+    let keys = cfg.keys();
     assert!(
-        cfg.keys().is_empty(),
+        keys.is_empty(),
         "S3.1: {} must produce an empty config, got keys {:?}",
         label,
-        cfg.keys()
+        keys
     );
 }
 

--- a/tests/spec_s3_1_empty_file.rs
+++ b/tests/spec_s3_1_empty_file.rs
@@ -1,69 +1,69 @@
-//! S3.1 — Empty file is invalid (HOCON.md L130).
+//! S3.1 — An empty document is valid HOCON and parses to the empty object `{}`
+//! (HOCON.md §Omit root braces L130-136).
 //!
-//! RED tests: these must FAIL until the S3.1 empty-stream guard is added to
-//! `parse_with_env` and `parse_file_with_env` in `src/lib.rs`.
+//! L130-132 ("Empty files are invalid documents") is the *JSON baseline*
+//! description; the HOCON-normative sentence is L134-136: a file that does not
+//! begin with `[` or `{` is parsed as if enclosed in `{}` — an empty document
+//! vacuously qualifies. Confirmed by the Lightbend reference implementation,
+//! whose "Empty document" error is ConfigSyntax.JSON-only.
+//!
+//! History: cluster 3h added an `assert_non_empty_document` guard rejecting
+//! these inputs, misreading the JSON baseline as HOCON-normative — a behavior
+//! regression. The posture was revoked 2026-07-23 (xx.hocon E10); these tests
+//! pin the corrected behavior.
 
-/// s3_1_1: completely empty string must error.
+/// Assert that `input` parses successfully to an empty config.
+fn assert_parses_to_empty(input: &str, label: &str) {
+    let cfg = hocon::parse(input)
+        .unwrap_or_else(|e| panic!("S3.1: {} must parse to an empty config, got error: {}", label, e));
+    assert!(
+        cfg.keys().is_empty(),
+        "S3.1: {} must produce an empty config, got keys {:?}",
+        label,
+        cfg.keys()
+    );
+}
+
+/// s3_1_1: completely empty string parses to `{}`.
 #[test]
 fn s3_1_1_empty_string() {
-    assert!(
-        hocon::parse("").is_err(),
-        "S3.1: empty string must be a parse error (HOCON.md L130)"
-    );
+    assert_parses_to_empty("", "empty string");
 }
 
-/// s3_1_2: whitespace-only string must error.
+/// s3_1_2: whitespace-only string parses to `{}`.
 #[test]
 fn s3_1_2_whitespace_only() {
-    assert!(
-        hocon::parse("   \n  ").is_err(),
-        "S3.1: whitespace-only input must be a parse error (HOCON.md L130)"
-    );
+    assert_parses_to_empty("   \n  ", "whitespace-only input");
 }
 
-/// s3_1_3: newlines-only must error.
+/// s3_1_3: newlines-only parses to `{}`.
 #[test]
 fn s3_1_3_newlines_only() {
-    assert!(
-        hocon::parse("\n\n\n").is_err(),
-        "S3.1: newlines-only input must be a parse error (HOCON.md L130)"
-    );
+    assert_parses_to_empty("\n\n\n", "newlines-only input");
 }
 
-/// s3_1_4: comment-only must error (comment has no semantic content).
+/// s3_1_4: comment-only parses to `{}` (comment has no semantic content).
 #[test]
 fn s3_1_4_comment_only() {
-    assert!(
-        hocon::parse("# only a comment\n").is_err(),
-        "S3.1: comment-only input must be a parse error (HOCON.md L130)"
-    );
+    assert_parses_to_empty("# only a comment\n", "comment-only input");
 }
 
-/// s3_1_5: BOM-only must error.
+/// s3_1_5: BOM-only parses to `{}`.
 #[test]
 fn s3_1_5_bom_only() {
-    assert!(
-        hocon::parse("\u{FEFF}").is_err(),
-        "S3.1: BOM-only input must be a parse error (HOCON.md L130)"
-    );
+    assert_parses_to_empty("\u{FEFF}", "BOM-only input");
 }
 
-/// s3_1_6: mixed whitespace + comment must error.
+/// s3_1_6: mixed whitespace + comment parses to `{}`.
 #[test]
 fn s3_1_6_mixed_ws_comment() {
-    assert!(
-        hocon::parse("  # comment\n  \n").is_err(),
-        "S3.1: mixed whitespace+comment input must be a parse error (HOCON.md L130)"
-    );
+    assert_parses_to_empty("  # comment\n  \n", "mixed whitespace+comment input");
 }
 
-/// s3_1_pos1: explicit empty object `{}` must succeed (not trigger empty guard).
+/// s3_1_pos1: explicit empty object `{}` succeeds and equals the empty-document result.
 #[test]
 fn s3_1_pos1_explicit_empty_object() {
-    assert!(
-        hocon::parse("{}").is_ok(),
-        "S3.1 (positive): explicit empty object must succeed"
-    );
+    assert_parses_to_empty("{}", "explicit empty object");
 }
 
 /// s3_1_pos2: single-field document must succeed.

--- a/tests/spec_s3_1_empty_file.rs
+++ b/tests/spec_s3_1_empty_file.rs
@@ -14,8 +14,12 @@
 
 /// Assert that `input` parses successfully to an empty config.
 fn assert_parses_to_empty(input: &str, label: &str) {
-    let cfg = hocon::parse(input)
-        .unwrap_or_else(|e| panic!("S3.1: {} must parse to an empty config, got error: {}", label, e));
+    let cfg = hocon::parse(input).unwrap_or_else(|e| {
+        panic!(
+            "S3.1: {} must parse to an empty config, got error: {}",
+            label, e
+        )
+    });
     assert!(
         cfg.keys().is_empty(),
         "S3.1: {} must produce an empty config, got keys {:?}",
@@ -64,6 +68,17 @@ fn s3_1_6_mixed_ws_comment() {
 #[test]
 fn s3_1_pos1_explicit_empty_object() {
     assert_parses_to_empty("{}", "explicit empty object");
+}
+
+/// s3_1_neg1: a `/* block comment */`-only document is NOT an empty document —
+/// block comments are not HOCON syntax (`#` and `//` only), so the S3.1
+/// empty-parses-to-{} rule must not mask the syntax error.
+#[test]
+fn s3_1_neg1_block_comment_only_is_rejected() {
+    assert!(
+        hocon::parse("/* multi\nline\ncomment */\n").is_err(),
+        "S3.1 (negative): block-comment-only input must be a syntax error, not an empty document"
+    );
 }
 
 /// s3_1_pos2: single-field document must succeed.

--- a/tests/spec_s3_1_empty_include.rs
+++ b/tests/spec_s3_1_empty_include.rs
@@ -1,11 +1,11 @@
-//! Lightbend-compat carve-out for go.hocon#105 — empty / whitespace-only /
-//! comment-only / BOM-only INCLUDED files contribute an empty config
-//! instead of erroring with S3.1.
-//!
-//! S3.1 (HOCON.md L130) "empty files are invalid documents" remains
-//! enforced for TOP-LEVEL parses — see `tests/spec_s3_1_empty_file.rs`.
-//! This file pins the narrower include-path carve-out and serves as a
-//! regression guard against the previous strict-reject behaviour returning.
+//! S3.1 — empty / whitespace-only / comment-only / BOM-only INCLUDED files
+//! contribute an empty config. Originally shipped as a narrow Lightbend-compat
+//! carve-out for go.hocon#105 while top-level parses still rejected; since the
+//! S3.1 correction (xx.hocon E10, revoked 2026-07-23) this is simply the rule —
+//! an empty document parses to `{}` everywhere, top-level and include path
+//! alike (see `tests/spec_s3_1_empty_file.rs` for the top-level pins). This
+//! file pins the include path and serves as a regression guard against any
+//! strict-reject behaviour returning.
 
 use std::io::Write;
 use tempfile::Builder;

--- a/tests/spec_s3_1_empty_include.rs
+++ b/tests/spec_s3_1_empty_include.rs
@@ -1,11 +1,12 @@
 //! S3.1 — empty / whitespace-only / comment-only / BOM-only INCLUDED files
 //! contribute an empty config. Originally shipped as a narrow Lightbend-compat
 //! carve-out for go.hocon#105 while top-level parses still rejected; since the
-//! S3.1 correction (xx.hocon E10, revoked 2026-07-23) this is simply the rule —
-//! an empty document parses to `{}` everywhere, top-level and include path
-//! alike (see `tests/spec_s3_1_empty_file.rs` for the top-level pins). This
-//! file pins the include path and serves as a regression guard against any
-//! strict-reject behaviour returning.
+//! S3.1 correction (the prior reject-posture was revoked by xx.hocon E10 on
+//! 2026-07-23) this is simply the rule — an empty document parses to `{}`
+//! everywhere, top-level and include path alike (see
+//! `tests/spec_s3_1_empty_file.rs` for the top-level pins). This file pins the
+//! include path and serves as a regression guard against any strict-reject
+//! behaviour returning.
 
 use std::io::Write;
 use tempfile::Builder;


### PR DESCRIPTION
## Summary

Implements the S3.1 correction from [xx.hocon#62](https://github.com/o3co/xx.hocon/pull/62): an empty HOCON document (empty / whitespace-only / comment-only / BOM-only) is **valid** and parses to the empty object `{}`, per HOCON.md §Omit root braces L134-136. The former "Empty file is invalid (L130)" reading — the basis for the cluster 3h `assert_non_empty_document` guard — misread the L130-132 *JSON baseline* as HOCON-normative and was a behavior regression. Confirmed against the reference implementation: Lightbend's `"Empty document"` error is `ConfigSyntax.JSON`-only, and `ConfigFactory.parseString("")` is a valid empty config throughout its own test suite.

Sibling PRs: [ts.hocon#153](https://github.com/o3co/ts.hocon/pull/153), [go.hocon#155](https://github.com/o3co/go.hocon/pull/155).

## Changes

- **`src/lib.rs`** — remove `assert_non_empty_document` and its 4 call sites (`Parser::parse_with_options`, `parse_string_with_options`, `parse_file_with_env`, `parse_with_env`); `parse_tokens` yields an empty object AST structurally (`parse_object(false)` breaks on EOF).
- **`src/resolver/include_loader.rs`** — remove the #105 file-include carve-out AND the package-path `has_content` short-circuit — every path now flows through `parse_tokens` uniformly.
- **Tests** — TDD RED→GREEN: ef01–ef06 conformance asserts `{}` per the normative sidecars; spec_s3_1 suites + issue105 top-level flipped to `{}` expectations; ipk08 whitespace/comment-only variants (cross-impl parity pins); `/* block comment */`-only rejection pinned (block comments are not HOCON — the empty rule must not mask syntax errors); parser unit test flipped.
- **Docs** — `docs/spec-compliance.md` S3.1 redefined; CHANGELOG Unreleased entry.

**Pure loosening** — no previously-valid input changes meaning; previously-rejected empty documents now succeed. No public API changes.

## Verification

- RED observed first: 13 failures, all guard-caused.
- GREEN: `cargo test --all-features --no-fail-fast` 0 failures across 49 test binaries; deferred lifecycle (`resolve_substitutions=false`) verified; `cargo fmt --all -- --check` clean; clippy shows only 2 pre-existing warnings in untouched files.
- Multi-agent review (Claude + Codex): merge-ready; findings (package-path uniformity, block-comment pin, rustfmt) addressed in the follow-up commit.

## Cross-impl

py.hocon PR follows; compliance-matrix re-roll-up in xx.hocon once all four land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)