### PR TITLE
feat(S3.5): array-root document rejected with a type error, not a syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — array-root document rejected with a type error (S3.5, [xx.hocon#64](https://github.com/o3co/xx.hocon/pull/64))
+
+- **`parse("[1,2]")` now returns the new `HoconError::Config(ConfigError)` variant
+  ("document has type array rather than object at file root", HOCON.md L989-991, with
+  origin + bracket position) instead of `HoconError::Parse` "expected key".** An
+  array-root document is syntactically valid HOCON; the reference implementation
+  parses it and rejects at the Config boundary (`Parseable.forceParsedToObject`,
+  `ConfigException.WrongType`). `parse_tokens` now parses the root array (malformed
+  arrays and trailing content remain `ParseError`s); all four parse entry points
+  reject via `reject_array_root`. Include paths (file + package) raise
+  `HoconError::Resolve` "included file has array at file root … (HOCON.md L993-994)"
+  naming the **innermost** included source (the AST is checked at each parse site, so
+  nested chains cannot accuse an intermediate file). `ConfigError`'s `Display` omits
+  the path clause when `path` is empty (file-root errors have no access path).
+  **API note**: `HoconError` gains a `Config(ConfigError)` variant — non-breaking
+  (`HoconError` is `#[non_exhaustive]`). Net behavior is unchanged (array-root
+  documents still error) — only the error class, layer, and message change. Pinned by
+  `tests/spec_s3_5_array_root.rs` (xx.hocon `array-root/ar01–ar03` `.error` sidecars).
+
 ### Fixed — empty document parses to `{}` (S3.1 corrected, [xx.hocon#62](https://github.com/o3co/xx.hocon/pull/62))
 
 - **`parse("")` (and whitespace-only / comment-only / BOM-only input) returns an empty

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -2,7 +2,7 @@
 
 This file extends the canonical checklist at
 [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx.hocon/blob/main/docs/spec-checklist.md)
-with rs.hocon-specific status for all 209 items, in the same order and with the
+with rs.hocon-specific status for all 210 items, in the same order and with the
 same item descriptions verbatim.
 
 - **`tests:`** records the test path (or fixture) that exercises each item, or `—` if no test covers it.

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -73,6 +73,17 @@ same item descriptions verbatim.
 - **S3.4** Unbalanced trailing `}` without opening `{` is invalid — §Omit root braces (L138)
   tests: tests/integration_test.rs:277 (test_stray_brace_after_root)
   status: ✅
+- **S3.5** Array-root document is valid syntax; object-rooted parse API rejects with a type error — §Include semantics: merging (L989-991)
+  tests: tests/spec_s3_5_array_root.rs (top-level + position + deferred + malformed guards + include/package variants + nested-chain pins + ar01–ar03 conformance loop)
+  status: ✅ — Added 2026-07-23. `parse_tokens` parses the root array (anchored at the
+  opening `[`; malformed arrays / trailing content stay `ParseError`s); the four parse
+  entry points reject via the new `HoconError::Config(ConfigError)` variant ("document
+  has type array rather than object at file root", with origin + bracket position),
+  matching Lightbend's `Parseable.forceParsedToObject` (`WrongType`). Include paths
+  check the AST at the parse site, so nested chains name the innermost source.
+  Previously `ParseError` "expected key, got LBracket" — right net outcome, wrong kind
+  at the wrong layer. `HoconError` is `#[non_exhaustive]`, so the variant addition is
+  non-breaking.
 
 ## S4. Key-value separator
 
@@ -489,7 +500,10 @@ same item descriptions verbatim.
 
 - **S14b.1** Included root must be an object (array → error) — §Include semantics: merging (L993)
   tests: tests/integration_test.rs:1155 (s14b_1_array_root_include_is_error)
-  status: ✅
+  status: ✅ — Diagnostics improved with S3.5 (2026-07-23): the include loader raises
+  `ResolveError` "included file has array at file root … (HOCON.md L993-994)" naming
+  the included source (file path or `package(...)` descriptor) with the bracket
+  position, instead of the parser's generic syntax error.
 - **S14b.2** Included keys merge per duplicate-key rules — §Include semantics: merging (L997)
   tests: tests/include_test.rs:21 (include_merges_into_current)
   status: ✅

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,6 +90,10 @@ pub struct ConfigError {
 
 impl fmt::Display for ConfigError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.path.is_empty() {
+            // File-root errors (S3.5 array-at-root) have no access path.
+            return write!(f, "ConfigError: {}", self.message);
+        }
         write!(f, "ConfigError: {} (path: {})", self.message, self.path)
     }
 }
@@ -157,6 +161,12 @@ pub enum HoconError {
     /// A getter was called on a path whose value contains an unresolved
     /// substitution placeholder. Per E12 decision 12.
     NotResolved(NotResolvedError),
+    /// Type-mismatch error at the Config boundary (the Lightbend
+    /// `ConfigException.WrongType` analog). Returned by the parse functions
+    /// for an array-root document (S3.5, HOCON.md L989-991): the document is
+    /// valid syntax, but the object-rooted Config API requires an object at
+    /// file root. `ConfigError.path` is empty for file-root errors.
+    Config(ConfigError),
 }
 
 impl fmt::Display for HoconError {
@@ -166,6 +176,7 @@ impl fmt::Display for HoconError {
             HoconError::Resolve(e) => write!(f, "{}", e),
             HoconError::Io(e) => write!(f, "I/O error: {}", e),
             HoconError::NotResolved(e) => write!(f, "{}", e),
+            HoconError::Config(e) => write!(f, "{}", e),
         }
     }
 }
@@ -177,6 +188,7 @@ impl std::error::Error for HoconError {
             HoconError::Resolve(e) => Some(e),
             HoconError::Io(e) => Some(e),
             HoconError::NotResolved(e) => Some(e),
+            HoconError::Config(e) => Some(e),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,7 +84,9 @@ impl std::error::Error for ResolveError {}
 pub struct ConfigError {
     /// Human-readable description of the error.
     pub message: String,
-    /// The dot-separated path that was looked up.
+    /// The dot-separated path that was looked up. Empty for file-root errors
+    /// (e.g. the S3.5 array-at-file-root rejection), where no access path
+    /// exists.
     pub path: String,
 }
 
@@ -146,9 +148,11 @@ impl std::error::Error for NotResolvedError {}
 
 /// Unified error type returned by top-level parse functions.
 ///
-/// Wraps the three possible failure modes: syntax errors ([`ParseError`]),
-/// substitution resolution failures ([`ResolveError`]), and file I/O
-/// errors ([`std::io::Error`]).
+/// Wraps the possible failure modes: syntax errors ([`ParseError`]),
+/// substitution resolution failures ([`ResolveError`]), file I/O errors
+/// ([`std::io::Error`]), unresolved-getter errors ([`NotResolvedError`]),
+/// and Config-boundary type errors ([`ConfigError`] — e.g. the S3.5
+/// array-at-file-root rejection).
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum HoconError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,16 @@ impl Parser {
         let content = std::fs::read_to_string(path)
             .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {}", path.display(), e)))?;
         let base_dir = path.parent().map(|p| p.to_path_buf());
-        let opts = ParseOptions { base_dir, ..opts };
+        // Default the origin to the file path so diagnostics (e.g. the S3.5
+        // array-at-file-root error) name the file, matching Lightbend origins.
+        let origin_description = opts
+            .origin_description
+            .or_else(|| Some(path.display().to_string()));
+        let opts = ParseOptions {
+            base_dir,
+            origin_description,
+            ..opts
+        };
         self.parse_with_options(&content, opts)
     }
 
@@ -462,7 +471,16 @@ pub fn parse_file_with_options<P: AsRef<Path>>(
     let content = std::fs::read_to_string(path)
         .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {}", path.display(), e)))?;
     let base_dir = path.parent().map(|p| p.to_path_buf());
-    let opts = ParseOptions { base_dir, ..opts };
+    // Default the origin to the file path so diagnostics (e.g. the S3.5
+    // array-at-file-root error) name the file, matching Lightbend origins.
+    let origin_description = opts
+        .origin_description
+        .or_else(|| Some(path.display().to_string()));
+    let opts = ParseOptions {
+        base_dir,
+        origin_description,
+        ..opts
+    };
     parse_string_with_options(&content, opts)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,7 @@ impl Parser {
         // comment-only / BOM-only document parses to the empty object per the
         // HOCON.md L134-136 brace-omission relaxation — no emptiness guard.
         let ast = parser::parse_tokens(&tokens)?;
+        reject_array_root(&ast, opts.origin_description.as_deref().unwrap_or("input"))?;
 
         let env: HashMap<String, String> = opts.env.clone().unwrap_or_else(|| {
             if opts.resolve_substitutions {
@@ -409,6 +410,7 @@ pub fn parse(input: &str) -> Result<Config, HoconError> {
 pub fn parse_string_with_options(input: &str, opts: ParseOptions) -> Result<Config, HoconError> {
     let tokens = lexer::tokenize(input)?;
     let ast = parser::parse_tokens(&tokens)?;
+    reject_array_root(&ast, opts.origin_description.as_deref().unwrap_or("input"))?;
 
     let env: HashMap<String, String> = opts.env.clone().unwrap_or_else(|| {
         if opts.resolve_substitutions {
@@ -479,6 +481,7 @@ pub fn parse_file_with_env<P: AsRef<Path>>(
         .map_err(|e| std::io::Error::new(e.kind(), format!("{}: {}", path.display(), e)))?;
     let tokens = lexer::tokenize(&content)?;
     let ast = parser::parse_tokens(&tokens)?;
+    reject_array_root(&ast, &path.display().to_string())?;
     let mut opts = resolver::InternalResolveOptions::new(env.clone());
     if let Some(dir) = path.parent() {
         opts = opts.with_base_dir(dir.to_path_buf());
@@ -494,10 +497,29 @@ pub fn parse_file_with_env<P: AsRef<Path>>(
     }
 }
 
+/// S3.5 (HOCON.md L989-991): an array-root document is valid syntax, but the
+/// object-rooted Config API rejects it at the Config boundary with a TYPE
+/// error, matching Lightbend's `Parseable.forceParsedToObject`
+/// (`ConfigException.WrongType` "has type LIST rather than object at file
+/// root"). The message carries the origin and the opening bracket's position.
+fn reject_array_root(ast: &parser::AstNode, origin: &str) -> Result<(), HoconError> {
+    if let parser::AstNode::Array { pos, .. } = ast {
+        return Err(HoconError::Config(ConfigError {
+            message: format!(
+                "{}: {}:{}: document has type array rather than object at file root (HOCON.md L989-991); the Config API requires an object at file root",
+                origin, pos.line, pos.col
+            ),
+            path: String::new(),
+        }));
+    }
+    Ok(())
+}
+
 /// Parse a HOCON string with a custom environment variable map.
 pub fn parse_with_env(input: &str, env: &HashMap<String, String>) -> Result<Config, HoconError> {
     let tokens = lexer::tokenize(input)?;
     let ast = parser::parse_tokens(&tokens)?;
+    reject_array_root(&ast, "input")?;
     let opts = resolver::InternalResolveOptions::new(env.clone());
     let value = resolver::resolve(ast, &opts)?;
     match value {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -127,6 +127,37 @@ pub fn parse_tokens(tokens: &[Token]) -> Result<AstNode, ParseError> {
             fields: all_fields,
             pos: first_pos,
         })
+    } else if parser.peek_kind() == TokenKind::LBracket {
+        // S3.5 (HOCON.md L989-991): "both JSON and HOCON allow arrays as root
+        // values in a document" — an array-root document is valid syntax. The
+        // object-rooted Config API rejects it AFTER the parse, at the Config
+        // boundary (src/lib.rs) or include-load site (include_loader.rs),
+        // matching Lightbend's Parseable.forceParsedToObject (WrongType, not
+        // a syntax error). Malformed arrays and trailing content remain
+        // syntax errors. The node is anchored at the opening `[` so the type
+        // error can point at the bracket.
+        let bracket_pos = parser.current_pos();
+        parser.pos += 1;
+        let arr = parser.parse_array()?;
+        parser.skip(&[TokenKind::Newline]);
+        if parser.peek_kind() != TokenKind::Eof {
+            let pos = parser.current_pos();
+            return Err(ParseError {
+                message: format!(
+                    "unexpected token after root array: {:?}",
+                    parser.peek_kind()
+                ),
+                line: pos.line,
+                col: pos.col,
+            });
+        }
+        match arr {
+            AstNode::Array { items, .. } => Ok(AstNode::Array {
+                items,
+                pos: bracket_pos,
+            }),
+            _ => unreachable!("parse_array returns AstNode::Array"),
+        }
     } else {
         parser.parse_object(false)
     }

--- a/src/resolver/include_loader.rs
+++ b/src/resolver/include_loader.rs
@@ -143,6 +143,22 @@ fn load_single_include(
         line: e.line,
         col: e.col,
     })?;
+    // S14b.1 (HOCON.md L993-994): an included file must contain an object, not
+    // an array. The document is valid syntax (S3.5) — surface the type
+    // constraint as a ResolveError naming THIS file. Checking the AST at the
+    // parse site means nested include chains name the innermost file that
+    // actually has the array root.
+    if let crate::parser::AstNode::Array { pos, .. } = &ast {
+        return Err(ResolveError {
+            message: format!(
+                "included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994): {}",
+                candidate.display()
+            ),
+            path: candidate.display().to_string(),
+            line: pos.line,
+            col: pos.col,
+        });
+    }
 
     let mut child_opts = InternalResolveOptions::new(opts.env.clone());
     if let Some(parent) = candidate.parent() {
@@ -224,6 +240,20 @@ pub(crate) fn load_package_include(
         line: e.line,
         col: e.col,
     })?;
+    // S14b.1: registered package content with an array root — same type
+    // constraint as file includes, naming the package source (checked at the
+    // parse site so nested chains name the innermost source).
+    if let crate::parser::AstNode::Array { pos, .. } = &ast {
+        return Err(ResolveError {
+            message: format!(
+                "included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994): package({:?}, {:?})",
+                identifier, file
+            ),
+            path: format!("package({:?}, {:?})", identifier, file),
+            line: pos.line,
+            col: pos.col,
+        });
+    }
 
     // Build child ResolveOptions: inherit env + registry; push cycle key
     let mut child_opts = InternalResolveOptions::new(opts.env.clone());

--- a/src/resolver/include_loader.rs
+++ b/src/resolver/include_loader.rs
@@ -149,11 +149,10 @@ fn load_single_include(
     // parse site means nested include chains name the innermost file that
     // actually has the array root.
     if let crate::parser::AstNode::Array { pos, .. } = &ast {
+        // The included-source identity lives in `path` (Display prints it);
+        // keeping it out of the message avoids the path rendering twice.
         return Err(ResolveError {
-            message: format!(
-                "included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994): {}",
-                candidate.display()
-            ),
+            message: "included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994)".to_string(),
             path: candidate.display().to_string(),
             line: pos.line,
             col: pos.col,
@@ -244,11 +243,9 @@ pub(crate) fn load_package_include(
     // constraint as file includes, naming the package source (checked at the
     // parse site so nested chains name the innermost source).
     if let crate::parser::AstNode::Array { pos, .. } = &ast {
+        // Same as the file-include variant: identity in `path` only.
         return Err(ResolveError {
-            message: format!(
-                "included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994): package({:?}, {:?})",
-                identifier, file
-            ),
+            message: "included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994)".to_string(),
             path: format!("package({:?}, {:?})", identifier, file),
             line: pos.line,
             col: pos.col,

--- a/tests/spec_s3_5_array_root.rs
+++ b/tests/spec_s3_5_array_root.rs
@@ -1,0 +1,214 @@
+//! S3.5 — an array-root document (`[1,2]`) is syntactically valid HOCON
+//! (HOCON.md L989-991: "both JSON and HOCON allow arrays as root values in a
+//! document"), but the object-rooted Config API rejects it with a TYPE error
+//! after a successful syntax parse. Reference: Lightbend parses the document,
+//! then `Parseable.forceParsedToObject` throws `ConfigException.WrongType`
+//! "has type LIST rather than object at file root". The former behavior — a
+//! `ParseError` "expected key, got LBracket" — was the right net outcome
+//! (reject) as the wrong kind of error at the wrong layer.
+//!
+//! S14b.1 (HOCON.md L993-994): an INCLUDED file with an array root is
+//! invalid; the error names the *innermost* included source.
+//!
+//! Fixtures: xx.hocon array-root/ar01-ar03 with `.error` sidecars (see the
+//! conformance loop at the bottom).
+
+use hocon::HoconError;
+
+/// Assert the error is the Config (type-mismatch) variant naming the
+/// array-at-file-root condition, and NOT a Parse (syntax) error.
+fn assert_array_root_config_error(err: HoconError, label: &str) -> String {
+    match err {
+        HoconError::Config(ce) => {
+            assert!(
+                ce.message.contains("array rather than object at file root"),
+                "{}: message must name the array-at-file-root condition, got: {}",
+                label,
+                ce.message
+            );
+            assert!(
+                ce.path.is_empty(),
+                "{}: file-root errors carry no access path, got: {}",
+                label,
+                ce.path
+            );
+            ce.message
+        }
+        HoconError::Parse(pe) => panic!(
+            "{}: got ParseError {:?}; array-root documents are valid syntax — expected HoconError::Config",
+            label, pe.message
+        ),
+        other => panic!("{}: expected HoconError::Config, got {:?}", label, other),
+    }
+}
+
+#[test]
+fn s3_5_top_level_is_type_error() {
+    for (label, src) in [
+        ("basic", "[1,2]"),
+        ("multiline-objects", "[\n  { a : 1 },\n  { b : 2 }\n]\n"),
+        ("empty-array", "[]"),
+    ] {
+        let err = hocon::parse(src).expect_err(label);
+        assert_array_root_config_error(err, label);
+    }
+}
+
+#[test]
+fn s3_5_error_carries_position() {
+    let err = hocon::parse("\n  [1,2]").expect_err("position");
+    let msg = assert_array_root_config_error(err, "position");
+    assert!(
+        msg.contains("2:3"),
+        "message must carry the opening bracket position 2:3, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn s3_5_deferred_lifecycle() {
+    let opts = hocon::ParseOptions::defaults().with_resolve_substitutions(false);
+    let err = hocon::parse_string_with_options("[1,2]", opts).expect_err("deferred");
+    assert_array_root_config_error(err, "deferred");
+}
+
+#[test]
+fn s3_5_malformed_arrays_stay_syntax_errors() {
+    for (label, src) in [
+        ("unterminated", "[1,2"),
+        ("trailing-content", "[1,2]\na = 1"),
+    ] {
+        match hocon::parse(src) {
+            Err(HoconError::Parse(_)) => {}
+            other => panic!(
+                "{}: expected HoconError::Parse (syntax), got {:?}",
+                label, other
+            ),
+        }
+    }
+}
+
+#[test]
+fn s3_5_include_of_array_root_names_included_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(dir.path().join("arr.conf"), "[1,2]\n").unwrap();
+    let input = format!("include \"{}/arr.conf\"\na = 1\n", dir_str);
+    match hocon::parse(&input) {
+        Err(HoconError::Resolve(re)) => {
+            assert!(
+                re.message.contains("array at file root"),
+                "message must name the array-at-file-root condition, got: {}",
+                re.message
+            );
+            assert!(
+                re.message.contains("arr.conf") || re.path.contains("arr.conf"),
+                "error must name the included file, got: {:?}",
+                re
+            );
+        }
+        other => panic!("expected HoconError::Resolve, got {:?}", other),
+    }
+}
+
+#[test]
+fn s3_5_nested_include_names_innermost_file() {
+    // parent -> mid -> arr: the error must accuse arr.conf (the file that
+    // actually has the array root), never the intermediate mid.conf.
+    let dir = tempfile::tempdir().unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    std::fs::write(dir.path().join("arr.conf"), "[1,2]\n").unwrap();
+    std::fs::write(dir.path().join("mid.conf"), "include \"arr.conf\"\nb = 2\n").unwrap();
+    let input = format!("include \"{}/mid.conf\"\na = 1\n", dir_str);
+    match hocon::parse(&input) {
+        Err(HoconError::Resolve(re)) => {
+            assert!(
+                re.message.contains("array at file root"),
+                "message must name the array-at-file-root condition, got: {}",
+                re.message
+            );
+            let all = format!("{} {}", re.message, re.path);
+            assert!(
+                all.contains("arr.conf"),
+                "error must name the innermost file arr.conf, got: {:?}",
+                re
+            );
+            assert!(
+                !re.message.contains("mid.conf"),
+                "error must not accuse the intermediate file mid.conf, got: {}",
+                re.message
+            );
+        }
+        other => panic!("expected HoconError::Resolve, got {:?}", other),
+    }
+}
+
+#[cfg(feature = "include-package")]
+#[test]
+fn s3_5_package_include_of_array_root_is_error() {
+    let input = r#"
+        a = 1
+        include package("test/s3-5-array-root", "ref.conf")
+    "#;
+    match hocon::Parser::new()
+        .register_package("test/s3-5-array-root", "ref.conf", "[1,2]\n")
+        .parse(input)
+    {
+        Err(HoconError::Resolve(re)) => {
+            assert!(
+                re.message.contains("array at file root"),
+                "message must name the array-at-file-root condition, got: {}",
+                re.message
+            );
+        }
+        other => panic!("expected HoconError::Resolve, got {:?}", other),
+    }
+}
+
+#[test]
+fn s3_5_non_root_arrays_unaffected() {
+    let cfg = hocon::parse("a = [1,2]").expect("field-value array");
+    assert_eq!(cfg.get_i64("a.0").unwrap_or(1), 1);
+    assert!(
+        hocon::parse("{ a = [1,2] }").is_ok(),
+        "braced root with array field"
+    );
+}
+
+/// Conformance loop over the xx.hocon array-root fixtures (ar01-ar03,
+/// `.error` sidecars — Lightbend WrongType ground truth). ar03-inner.conf is
+/// a sibling include-target, not a standalone fixture.
+#[test]
+fn s3_5_conformance_fixture_loop() {
+    let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/testdata/hocon/array-root");
+    if !dir.is_dir() {
+        eprintln!("skip: array-root fixtures missing; run `make testdata` (requires xx.hocon#64)");
+        return;
+    }
+    let env: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let mut ran = 0;
+    for entry in std::fs::read_dir(&dir).unwrap() {
+        let path = entry.unwrap().path();
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        if !name.ends_with(".conf") || name.ends_with("-inner.conf") {
+            continue;
+        }
+        let err = hocon::parse_file_with_env(&path, &env)
+            .err()
+            .unwrap_or_else(|| panic!("{}: expected array-at-file-root error, got Ok", name));
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("array") && msg.contains("file root"),
+            "{}: error must name the array-at-file-root condition, got: {}",
+            name,
+            msg
+        );
+        ran += 1;
+    }
+    assert!(
+        ran >= 3,
+        "expected at least 3 array-root fixtures, ran {}",
+        ran
+    );
+}

--- a/tests/spec_s3_5_array_root.rs
+++ b/tests/spec_s3_5_array_root.rs
@@ -66,6 +66,32 @@ fn s3_5_error_carries_position() {
 }
 
 #[test]
+fn s3_5_origin_naming() {
+    // Custom origin_description is honored.
+    let opts = hocon::ParseOptions::defaults().with_origin_description("my-source".to_string());
+    let err = hocon::parse_string_with_options("[1,2]", opts).expect_err("custom origin");
+    let msg = assert_array_root_config_error(err, "custom origin");
+    assert!(
+        msg.contains("my-source"),
+        "message must carry the custom origin, got: {}",
+        msg
+    );
+
+    // File-based entry points name the file (not "input").
+    let dir = tempfile::tempdir().unwrap();
+    let f = dir.path().join("arr.conf");
+    std::fs::write(&f, "[1,2]\n").unwrap();
+    let err = hocon::parse_file_with_options(&f, hocon::ParseOptions::defaults())
+        .expect_err("file origin");
+    let msg = assert_array_root_config_error(err, "file origin");
+    assert!(
+        msg.contains("arr.conf") && !msg.starts_with("input:"),
+        "file parse must name the file in the origin, got: {}",
+        msg
+    );
+}
+
+#[test]
 fn s3_5_deferred_lifecycle() {
     let opts = hocon::ParseOptions::defaults().with_resolve_substitutions(false);
     let err = hocon::parse_string_with_options("[1,2]", opts).expect_err("deferred");

--- a/tests/spec_s3_5_array_root.rs
+++ b/tests/spec_s3_5_array_root.rs
@@ -127,9 +127,11 @@ fn s3_5_include_of_array_root_names_included_file() {
                 "message must name the array-at-file-root condition, got: {}",
                 re.message
             );
+            // The included-source identity is carried in `path` (rendered by
+            // Display), not embedded in the message.
             assert!(
-                re.message.contains("arr.conf") || re.path.contains("arr.conf"),
-                "error must name the included file, got: {:?}",
+                re.path.contains("arr.conf"),
+                "path must name the included file, got: {:?}",
                 re
             );
         }
@@ -153,16 +155,15 @@ fn s3_5_nested_include_names_innermost_file() {
                 "message must name the array-at-file-root condition, got: {}",
                 re.message
             );
-            let all = format!("{} {}", re.message, re.path);
             assert!(
-                all.contains("arr.conf"),
-                "error must name the innermost file arr.conf, got: {:?}",
+                re.path.contains("arr.conf"),
+                "path must name the innermost file arr.conf, got: {:?}",
                 re
             );
             assert!(
-                !re.message.contains("mid.conf"),
-                "error must not accuse the intermediate file mid.conf, got: {}",
-                re.message
+                !re.path.contains("mid.conf") && !re.message.contains("mid.conf"),
+                "error must not accuse the intermediate file mid.conf, got: {:?}",
+                re
             );
         }
         other => panic!("expected HoconError::Resolve, got {:?}", other),
@@ -194,7 +195,8 @@ fn s3_5_package_include_of_array_root_is_error() {
 #[test]
 fn s3_5_non_root_arrays_unaffected() {
     let cfg = hocon::parse("a = [1,2]").expect("field-value array");
-    assert_eq!(cfg.get_i64("a.0").unwrap_or(1), 1);
+    let items = cfg.get_list("a").expect("a must be a list");
+    assert_eq!(items.len(), 2, "a must have 2 elements, got {:?}", items);
     assert!(
         hocon::parse("{ a = [1,2] }").is_ok(),
         "braced root with array field"


### PR DESCRIPTION
## Summary

Implements S3.5 from [xx.hocon#64](https://github.com/o3co/xx.hocon/pull/64): an array-root document (`[1,2]`) is **syntactically valid HOCON** (HOCON.md L989-991); the reference implementation parses it, then rejects at the Config boundary via `Parseable.forceParsedToObject` with `ConfigException.WrongType` "has type LIST rather than object at file root". Previously rs.hocon rejected with `ParseError` "expected key, got LBracket" — the right net outcome as the wrong kind of error at the wrong layer.

Sibling PRs: [ts.hocon#154](https://github.com/o3co/ts.hocon/pull/154), [go.hocon#156](https://github.com/o3co/go.hocon/pull/156).

## Changes

- **Parser** — `parse_tokens` parses the root array on `[` (anchored at the opening bracket; malformed arrays and trailing content stay `ParseError`s).
- **Error taxonomy** — new **`HoconError::Config(ConfigError)`** variant: the type-mismatch class (Lightbend WrongType analog). **Non-breaking**: `HoconError` is `#[non_exhaustive]`. Public-API self-check: the variant name expresses the Config-layer type-error responsibility that `ConfigError` already owns; `ConfigError::path` is empty for file-root errors (documented) and `Display` omits the path clause then.
- **Config boundary** — `reject_array_root` at all four parse entry points with origin + bracket position (covers the deferred lifecycle). File-based entry points (`parse_file_with_options`, `Parser::parse_file*`) now default the origin to the file path, so diagnostics — and `Config` origins on success — name the file (Lightbend origin parity).
- **Include paths** — the AST is checked at both parse sites (file + package): `HoconError::Resolve` "included file has array at file root … (HOCON.md L993-994)" naming the **innermost** source with the bracket position; nested chains cannot accuse an intermediate file (pinned, mirroring the go.hocon review finding).
- **Tests** — TDD RED→GREEN: Config-variant + position + origin-naming + deferred pins, malformed guards, include / nested-include / package variants, non-root guards, conformance ar01–ar03 loop (self-skipping until xx#64 merges; the rs Makefile copies testdata wholesale — no Makefile change needed).
- **Docs** — spec-compliance S3.5 added (210 items) + S14b.1 notes; CHANGELOG (incl. the API note).

**Net behavior unchanged** — array-root documents still error; only the error class, layer, and message change.

## Verification

- RED observed first (6 failures on the old classification); GREEN: `cargo test --all-features --no-fail-fast` 0 failures; `cargo fmt --check` clean; clippy shows only pre-existing warnings in untouched files.
- Multi-agent review (Claude + Codex): both Importants (file-origin naming, vacuous non-root assertion) + doc minors addressed in the follow-up commit; Codex confirmed the follow-up introduces no blocking issues. The reviewer verified the conformance loop 8/8 green against the real xx#64 fixtures and confirmed the differential adapter emits a sane `Config`-type error record.

## Cross-impl

py.hocon PR follows; matrix roll-up in xx.hocon once all four land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)