### PR TITLE
fix(parser): include file() no longer swallows same-line sibling fields (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `include file()` no longer swallows same-line sibling fields ([#149](https://github.com/o3co/rs.hocon/issues/149))
+
+- **`aa = {include file("x.conf"), b = "ww"}` now keeps `b`.** After the quoted
+  path of a `file()` include, the parser skipped everything up to the end of
+  the line instead of consuming just the closing `)`, so any `, field = value`
+  following the include inside an object literal was silently dropped —
+  regardless of whether the included file existed. The parser now consumes
+  only the closing-paren token(s) — spaced forms like
+  `required( file( "x" ) )` lex as consecutive `)` tokens and are consumed
+  too. Behaviour note: non-paren junk after the closing `)` on the include
+  line was previously skipped silently; it now stays in the token stream and
+  surfaces as a parse error.
+  Found by the harvested ecosystem corpus
+  ([xx.hocon#66](https://github.com/o3co/xx.hocon/pull/66),
+  `mikai233-hocon-rs/demo.conf`). Pinned by
+  `tests/issue149_include_file_trailing_fields.rs`.
+
 ## [1.9.0] - 2026-07-23
 
 Cross-impl release coordinated to land at v1.9.0 across ts.hocon / go.hocon / rs.hocon / py.hocon. Covers the two same-day spec corrections from [xx.hocon#62](https://github.com/o3co/xx.hocon/pull/62) (S3.1 — empty document parses to `{}`) and [xx.hocon#64](https://github.com/o3co/xx.hocon/pull/64) (S3.5 — array-root document rejected with a type error), plus the S19.8 case-sensitive duration units breaking change (queued since the previous cycle, shipped here). MINOR (not PATCH): rs adds public API surface (the `HoconError::Config(ConfigError)` variant — additive, `HoconError` is `#[non_exhaustive]`), and the error-taxonomy / empty-document behavior changes are consumer-observable. `Cargo.toml` bumped to 1.9.0 in this release-prep (the publish workflow's `if TAG_VERSION != CURRENT` guard makes this idempotent).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regardless of whether the included file existed. The parser now consumes
   only the closing-paren token(s) — spaced forms like
   `required( file( "x" ) )` lex as consecutive `)` tokens and are consumed
-  too. Behaviour note: non-paren junk after the closing `)` on the include
-  line was previously skipped silently; it now stays in the token stream and
-  surfaces as a parse error.
+  too, while a fused `)junk` token is not treated as a closing paren.
+  Behaviour note: junk after the include path (spaced or fused with the
+  paren) was previously skipped silently; it now surfaces as a parse error,
+  and a `file()` include with no closing `)` at all is now a parse error as
+  well.
   Found by the harvested ecosystem corpus
   ([xx.hocon#66](https://github.com/o3co/xx.hocon/pull/66),
   `mikai233-hocon-rs/demo.conf`). Pinned by

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -822,13 +822,28 @@ impl<'a> Parser<'a> {
             self.advance();
             // Consume the closing paren token(s): `))` lexes fused, but spaced
             // forms like `required( file( "x" ) )` produce consecutive
-            // standalone ")" tokens, so loop while the next token is
-            // paren-initial. Anything else stays in the stream: an include
-            // inside an object literal may be followed by `, field = value`
-            // on the same line (issue #149 — the previous skip-to-end-of-line
-            // here swallowed those sibling fields).
-            while self.peek_kind() == TokenKind::Unquoted && self.peek_value().starts_with(')') {
+            // standalone ")" tokens. Only tokens consisting entirely of ')'
+            // characters count — a fused `)junk` token is NOT a closing paren
+            // and stays in the stream to surface as a parse error (Copilot
+            // review on #149; `,` / `}` are lexer stop chars, so `),` never
+            // fuses). Anything after the parens also stays: an include inside
+            // an object literal may be followed by `, field = value` on the
+            // same line (issue #149 — the previous skip-to-end-of-line here
+            // swallowed those sibling fields).
+            let mut saw_close_paren = false;
+            while self.peek_kind() == TokenKind::Unquoted
+                && !self.peek_value().is_empty()
+                && self.peek_value().chars().all(|c| c == ')')
+            {
+                saw_close_paren = true;
                 self.advance();
+            }
+            if !saw_close_paren {
+                return Err(ParseError {
+                    message: "expected closing ')' after include file path".into(),
+                    line: err_line,
+                    col: err_col,
+                });
             }
         } else {
             let line = self.peek_line();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -820,11 +820,14 @@ impl<'a> Parser<'a> {
             }
             path = self.peek_value().to_string();
             self.advance();
-            // Skip closing ) and anything else on this line
-            while self.peek_kind() != TokenKind::Newline
-                && self.peek_kind() != TokenKind::RBrace
-                && self.peek_kind() != TokenKind::Eof
-            {
+            // Consume the closing paren token(s): `))` lexes fused, but spaced
+            // forms like `required( file( "x" ) )` produce consecutive
+            // standalone ")" tokens, so loop while the next token is
+            // paren-initial. Anything else stays in the stream: an include
+            // inside an object literal may be followed by `, field = value`
+            // on the same line (issue #149 — the previous skip-to-end-of-line
+            // here swallowed those sibling fields).
+            while self.peek_kind() == TokenKind::Unquoted && self.peek_value().starts_with(')') {
                 self.advance();
             }
         } else {

--- a/tests/issue149_include_file_trailing_fields.rs
+++ b/tests/issue149_include_file_trailing_fields.rs
@@ -61,6 +61,33 @@ fn issue149_required_file_include_keeps_trailing_field() {
     assert_eq!(cfg.get_string("aa.b").unwrap(), "ww", "trailing field swallowed");
 }
 
+// Fused junk after the closing paren lexes into the same Unquoted token
+// (`)junk`); that token is not a pure closing paren and must surface as a
+// parse error rather than being silently swallowed (Copilot review).
+#[test]
+fn issue149_fused_junk_after_paren_is_parse_error() {
+    let (_d, dir) = setup();
+    let input = format!(
+        "aa = {{include file(\"{}/exists.conf\")junk, b = \"ww\"}}\n",
+        dir
+    );
+    assert!(
+        hocon::parse(&input).is_err(),
+        "fused junk after ')' must be a parse error, not silently swallowed"
+    );
+}
+
+// A file() include whose closing paren never appears is a parse error.
+#[test]
+fn issue149_missing_close_paren_is_parse_error() {
+    let (_d, dir) = setup();
+    let input = format!("aa = {{include file(\"{}/exists.conf\", b = \"ww\"}}\n", dir);
+    assert!(
+        hocon::parse(&input).is_err(),
+        "missing ')' after include file path must be a parse error"
+    );
+}
+
 // Guards: behaviours that already worked and must not regress.
 
 #[test]

--- a/tests/issue149_include_file_trailing_fields.rs
+++ b/tests/issue149_include_file_trailing_fields.rs
@@ -1,0 +1,80 @@
+//! Issue #149: `include file("…")` inside an object literal swallowed every
+//! field that followed it on the same line (`aa = {include file("x"), b = 1}`
+//! lost `b`), because the parser skipped "anything else on this line" after
+//! the quoted path instead of consuming just the closing `)`. The bug was
+//! independent of whether the included file exists; a missing optional
+//! include must contribute an empty object (HOCON.md §Include semantics) and
+//! leave sibling fields intact either way.
+
+use tempfile::tempdir;
+
+fn setup() -> (tempfile::TempDir, String) {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("exists.conf"), "x = 1\n").unwrap();
+    let dir_str = dir.path().display().to_string().replace('\\', "/");
+    (dir, dir_str)
+}
+
+#[test]
+fn issue149_existing_file_include_keeps_trailing_field() {
+    let (_d, dir) = setup();
+    let input = format!("aa = {{include file(\"{}/exists.conf\"), b = \"ww\"}}\n", dir);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("aa.x").unwrap(), 1, "included content lost");
+    assert_eq!(cfg.get_string("aa.b").unwrap(), "ww", "trailing field swallowed");
+}
+
+#[test]
+fn issue149_missing_file_include_keeps_trailing_field() {
+    let (_d, dir) = setup();
+    let input = format!("aa = {{include file(\"{}/nope.conf\"), b = \"ww\"}}\n", dir);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_string("aa.b").unwrap(), "ww", "trailing field swallowed");
+}
+
+// Spaced closing parens lex as separate ")" tokens (unlike fused `))`); the
+// paren-consume loop must eat all of them without touching the `, b = …`.
+#[test]
+fn issue149_spaced_parens_keep_trailing_field() {
+    let (_d, dir) = setup();
+    let input = format!(
+        "aa = {{include required( file( \"{}/exists.conf\" ) ), b = \"ww\"}}\n",
+        dir
+    );
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("aa.x").unwrap(), 1);
+    assert_eq!(cfg.get_string("aa.b").unwrap(), "ww", "trailing field swallowed");
+}
+
+// Guard (passed pre-fix too): fused `required(file("…"))` routes through the
+// QuotedString+required branch, not the file() branch — kept as a regression
+// guard for that adjacent code path.
+#[test]
+fn issue149_required_file_include_keeps_trailing_field() {
+    let (_d, dir) = setup();
+    let input = format!(
+        "aa = {{include required(file(\"{}/exists.conf\")), b = \"ww\"}}\n",
+        dir
+    );
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_i64("aa.x").unwrap(), 1);
+    assert_eq!(cfg.get_string("aa.b").unwrap(), "ww", "trailing field swallowed");
+}
+
+// Guards: behaviours that already worked and must not regress.
+
+#[test]
+fn issue149_bare_include_keeps_trailing_field() {
+    let (_d, dir) = setup();
+    let input = format!("aa = {{include \"{}/nope.conf\", b = \"ww\"}}\n", dir);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_string("aa.b").unwrap(), "ww");
+}
+
+#[test]
+fn issue149_field_before_file_include_still_survives() {
+    let (_d, dir) = setup();
+    let input = format!("aa = {{b = \"ww\", include file(\"{}/nope.conf\")}}\n", dir);
+    let cfg = hocon::parse(&input).unwrap();
+    assert_eq!(cfg.get_string("aa.b").unwrap(), "ww");
+}

--- a/tests/issue149_include_file_trailing_fields.rs
+++ b/tests/issue149_include_file_trailing_fields.rs
@@ -18,10 +18,17 @@ fn setup() -> (tempfile::TempDir, String) {
 #[test]
 fn issue149_existing_file_include_keeps_trailing_field() {
     let (_d, dir) = setup();
-    let input = format!("aa = {{include file(\"{}/exists.conf\"), b = \"ww\"}}\n", dir);
+    let input = format!(
+        "aa = {{include file(\"{}/exists.conf\"), b = \"ww\"}}\n",
+        dir
+    );
     let cfg = hocon::parse(&input).unwrap();
     assert_eq!(cfg.get_i64("aa.x").unwrap(), 1, "included content lost");
-    assert_eq!(cfg.get_string("aa.b").unwrap(), "ww", "trailing field swallowed");
+    assert_eq!(
+        cfg.get_string("aa.b").unwrap(),
+        "ww",
+        "trailing field swallowed"
+    );
 }
 
 #[test]
@@ -29,7 +36,11 @@ fn issue149_missing_file_include_keeps_trailing_field() {
     let (_d, dir) = setup();
     let input = format!("aa = {{include file(\"{}/nope.conf\"), b = \"ww\"}}\n", dir);
     let cfg = hocon::parse(&input).unwrap();
-    assert_eq!(cfg.get_string("aa.b").unwrap(), "ww", "trailing field swallowed");
+    assert_eq!(
+        cfg.get_string("aa.b").unwrap(),
+        "ww",
+        "trailing field swallowed"
+    );
 }
 
 // Spaced closing parens lex as separate ")" tokens (unlike fused `))`); the
@@ -43,7 +54,11 @@ fn issue149_spaced_parens_keep_trailing_field() {
     );
     let cfg = hocon::parse(&input).unwrap();
     assert_eq!(cfg.get_i64("aa.x").unwrap(), 1);
-    assert_eq!(cfg.get_string("aa.b").unwrap(), "ww", "trailing field swallowed");
+    assert_eq!(
+        cfg.get_string("aa.b").unwrap(),
+        "ww",
+        "trailing field swallowed"
+    );
 }
 
 // Guard (passed pre-fix too): fused `required(file("…"))` routes through the
@@ -58,7 +73,11 @@ fn issue149_required_file_include_keeps_trailing_field() {
     );
     let cfg = hocon::parse(&input).unwrap();
     assert_eq!(cfg.get_i64("aa.x").unwrap(), 1);
-    assert_eq!(cfg.get_string("aa.b").unwrap(), "ww", "trailing field swallowed");
+    assert_eq!(
+        cfg.get_string("aa.b").unwrap(),
+        "ww",
+        "trailing field swallowed"
+    );
 }
 
 // Fused junk after the closing paren lexes into the same Unquoted token
@@ -81,7 +100,10 @@ fn issue149_fused_junk_after_paren_is_parse_error() {
 #[test]
 fn issue149_missing_close_paren_is_parse_error() {
     let (_d, dir) = setup();
-    let input = format!("aa = {{include file(\"{}/exists.conf\", b = \"ww\"}}\n", dir);
+    let input = format!(
+        "aa = {{include file(\"{}/exists.conf\", b = \"ww\"}}\n",
+        dir
+    );
     assert!(
         hocon::parse(&input).is_err(),
         "missing ')' after include file path must be a parse error"


### PR DESCRIPTION
Fixes #149.

After the quoted path of an `include file("…")`, the parser skipped everything up to the end of the line instead of consuming just the closing `)`, so any `, field = value` following the include inside an object literal was silently dropped — regardless of whether the included file existed:

```hocon
aa = {include file("x.conf"), b = "ww"}   # before: aa = {…}, b lost   after: b kept
```

## Change

Consume only the closing-paren token(s) after the quoted path. `))` lexes fused (one token), but spaced forms like `required( file( "x" ) )` lex as consecutive standalone `)` tokens, so the consume is a loop over paren-initial unquoted tokens (regression caught in pre-PR review and covered by a test).

Behaviour note (in CHANGELOG): non-paren junk after the closing `)` was previously skipped silently; it now stays in the token stream and surfaces as a parse error — stricter, and closer to the reference.

## Spec basis

HOCON.md §Include semantics: a missing non-required include "should be silently ignored (as if the included file contained only an empty object)" — an empty contribution to the enclosing object merge, never the loss of sibling fields. The bug also affected *existing* includes' siblings, which had no spec reading at all.

## Tests

`tests/issue149_include_file_trailing_fields.rs`: existing-file + trailing field, missing-file + trailing field, spaced-parens form, fused `required(file("…"))` guard, bare-include guard, field-before-include guard. Full suite green (`make testdata` + `cargo test`, 51 suites).

Verified against the harvested ecosystem corpus (xx.hocon#66): `mikai233-hocon-rs/demo.conf` now matches the reference-generated expected JSON.

Reviewed pre-PR via multi-agent-review (Claude reviewer; Codex unavailable on this machine) — the Important finding (spaced-paren regression) is fixed and tested in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)