### PR TITLE
chore(release): 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-26
+
 ### Fixed
 
 - **A single-line `/* */` comment in a JSONC document no longer splices its
@@ -549,7 +551,8 @@ Behaviour:
 
 - **CI: content-addressable testdata cache** (closes [#101](https://github.com/o3co/rs.hocon/issues/101)). `.github/workflows/test.yml` and `.github/workflows/publish.yml` previously used `actions/cache@v5` with `key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}`. The hash evaluated BEFORE the cache restore step ran, but `.xx-hocon-version` is gitignored and absent on fresh checkouts — so the key collapsed to a constant and cache entries shared the same slot. Split into `actions/cache/restore@v5` (matches via `restore-keys`) + `actions/cache/save@v5` (writes with the post-fetch hash, gated on `make testdata` success). No production code touched.
 
-[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/o3co/rs.hocon/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/o3co/rs.hocon/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/o3co/rs.hocon/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/o3co/rs.hocon/compare/v1.7.1...v1.8.0


### PR DESCRIPTION
Cuts 1.11.0 from the merged fixes (#154).

**Why 1.11.0 and not 1.10.1.** By this crate's own semver arithmetic it is a patch. The version is aligned across the four implementations, and go.hocon's release in this wave adds public API, so the whole line moves together.

**Two things a reader of this release should know.**

The non-UTF-8 environment fix changes behaviour that used to be a panic: `hocon::parse` no longer aborts because some unrelated variable in the environment is not valid UTF-8. Per F1.9 the entry is absent to substitution, and `adapters::env::load` refuses one matching its mount prefix rather than silently omitting it.

The env path change is the one that can reshape an existing config: a literal `.` in a variable name is now key text, so `APP_FOO.BAR` yields the single key `"foo.bar"` instead of nesting. If you used `.` to build hierarchy, respell it with `__`.

Also in this release: MSRV is a single true 1.82 again for every feature combination (`toml` capped to `~1.0`), and the MSRV CI row runs the full `--all-features` suite rather than a partial compile-check.

CHANGELOG only; the publish workflow sets the crate version from the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)