### PR TITLE
test(adapters): dispatch the properties format in the ingestion harness

### DIFF
--- a/tests/format_ingestion_test.rs
+++ b/tests/format_ingestion_test.rs
@@ -9,7 +9,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use hocon::adapters::{env, jsonc, toml, yaml, AdapterError};
+use hocon::adapters::{env, jsonc, properties, toml, yaml, AdapterError};
 use hocon::{Config, HoconValue};
 
 fn root() -> PathBuf {
@@ -61,6 +61,7 @@ struct EnvFixture {
 fn ingest(format: &str, kind: Option<&str>, text: &str, id: &str) -> Result<Config, AdapterError> {
     match format {
         "jsonc" => jsonc::parse(text, Some(id)),
+        "properties" => properties::parse(text, Some(id)),
         "toml" => toml::parse(text, Some(id)),
         "yaml" => yaml::parse(text, Some(id)),
         "env" => {


### PR DESCRIPTION
Preparation for a new fixture group in xx.hocon.

The shared `format-ingestion` corpus is gaining `properties` cases — needed because F2.9 (`__proto__`, `constructor`, `prototype` survive as ordinary keys) **cannot be expressed through the env format**: `__proto__` begins and ends with the `__` separator, so it maps to empty segments in all four implementations.

This runner panics on an unknown format and the Makefile pins `TESTDATA_REF := main`, so the arm lands first. Until the fixtures merge it is unused.

`cargo test --all-features --test format_ingestion_test` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)