### PR TITLE
fix(adapters/yaml)!: refuse sibling keys that coincide, instead of last-wins (F5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `adapters::yaml`: coinciding sibling keys were last-wins, not an error
+
+**BREAKING** (input previously accepted is now refused; quote the key you mean
+to keep distinct).
+
+`yaml::parse("1: a\n'1': b\n")` produced a config holding only `"1" = "b"`. The
+integer key and the string key are distinct in the decoded `Yaml::Hash` but
+`key_string` maps both to `"1"`, so writing the second dropped the first's value
+with nothing to show for it — the silent loss F5.3 exists to prevent. The same
+held for `1.0`/`"1.0"`, `~`/`"null"`, `true`/`"true"` and `0x10`/`"16"`, at any
+nesting depth ([#160](https://github.com/o3co/rs.hocon/issues/160)).
+
+The collision is now an error naming both source keys and the path. Merge keys
+stay exempt: `<<: *defaults` bringing in a key the mapping then overrides is
+YAML's own semantics.
+
+Which forms coincide follows from `yaml-rust2`'s scalar resolution and is not
+aligned across implementations (F5.1) — `1.0` gives `"1.0"` here and in
+py.hocon, `"1"` in go.hocon and ts.hocon. What is common is that a coincidence
+errors.
+
 ### Fixed — documentation that had drifted away from the code
 
 Nothing was checking the README's factual claims, so they aged with each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed — `adapters::yaml`: coinciding sibling keys were last-wins, not an error
 
-**BREAKING** (input previously accepted is now refused; quote the key you mean
-to keep distinct).
+**BREAKING** (input previously accepted is now refused; rename one of the two
+keys — quoting only helps where it changes the key text, as `0x10` → `"0x10"`
+does and `1` → `"1"` does not).
 
 `yaml::parse("1: a\n'1': b\n")` produced a config holding only `"1" = "b"`. The
 integer key and the string key are distinct in the decoded `Yaml::Hash` but

--- a/src/adapters/yaml.rs
+++ b/src/adapters/yaml.rs
@@ -85,12 +85,24 @@ fn convert(v: &Yaml, at: &str) -> Result<HoconValue, AdapterError> {
             // be a structural difference, which this spec does own (F5.2).
             // Explicit keys win over merged ones.
             let mut merged: IndexMap<String, HoconValue> = IndexMap::new();
+            // The source key behind each written key, so a second one landing
+            // on it can name what it collided with (F5.3).
+            let mut seen: IndexMap<String, &Yaml> = IndexMap::new();
             for (k, e) in h {
                 if matches!(k, Yaml::String(s) if s == "<<") {
                     collect_merge(e, at, &mut merged)?;
                     continue;
                 }
                 let ks = key_string(k, at)?;
+                if let Some(prev) = seen.get(&ks) {
+                    // Two source keys, one object key: the integer 1 and the
+                    // string "1", `~` and "null", 0x10 and "16". `yaml-rust2`
+                    // keys its Hash by `Yaml`, so both are still here — writing
+                    // the second would drop the first's value with nothing left
+                    // to notice, so neither wins (spec F5.3).
+                    return Err(collision(at, &ks, prev, k));
+                }
+                seen.insert(ks.clone(), k);
                 let path = if at.is_empty() {
                     ks.clone()
                 } else {
@@ -163,6 +175,36 @@ fn collect_merge(
         _ => Err(AdapterError::new(format!(
             "yaml: at {at}: a merge key must reference a mapping (spec F5.2)"
         ))),
+    }
+}
+
+/// The F5.3 error for two sibling keys that give one object key.
+fn collision(at: &str, ks: &str, a: &Yaml, b: &Yaml) -> AdapterError {
+    let where_ = if at.is_empty() {
+        format!("{ks:?}")
+    } else {
+        format!("{:?} at {at}", ks)
+    };
+    AdapterError::new(format!(
+        "yaml: sibling mapping keys {} and {} both give the key {where_}; quote the one \
+         you mean to keep distinct, because one of the two values would otherwise be \
+         lost (spec F5.3)",
+        key_form(a),
+        key_form(b)
+    ))
+}
+
+/// Render a source key for the F5.3 collision error: a string is quoted, every
+/// other scalar names its kind, so the integer `1` and the string `"1"` stay
+/// apart in the message the way they failed to in the mapping.
+fn key_form(k: &Yaml) -> String {
+    match k {
+        Yaml::String(s) => format!("{s:?}"),
+        Yaml::Integer(i) => format!("{i} (integer)"),
+        Yaml::Real(r) => format!("{r} (float)"),
+        Yaml::Boolean(b) => format!("{b} (boolean)"),
+        Yaml::Null => "~ (null)".to_string(),
+        _ => "a collection".to_string(),
     }
 }
 

--- a/src/adapters/yaml.rs
+++ b/src/adapters/yaml.rs
@@ -186,9 +186,10 @@ fn collision(at: &str, ks: &str, a: &Yaml, b: &Yaml) -> AdapterError {
         format!("{:?} at {at}", ks)
     };
     AdapterError::new(format!(
-        "yaml: sibling mapping keys {} and {} both give the key {where_}; quote the one \
-         you mean to keep distinct, because one of the two values would otherwise be \
-         lost (spec F5.3)",
+        "yaml: sibling mapping keys {} and {} both give the key {where_}; rename one of \
+         them, because one of the two values would otherwise be lost. Quoting a \
+         non-string key helps only where that changes the key text, as 0x10 does and 1 \
+         does not (spec F5.3)",
         key_form(a),
         key_form(b)
     ))

--- a/tests/adapters_test.rs
+++ b/tests/adapters_test.rs
@@ -359,6 +359,48 @@ fn yaml_stringifies_non_string_keys() {
     assert_eq!(cfg.get_string("\"true\"").unwrap(), "t");
 }
 
+/// F5.3 — two source keys with one string form used to be last-wins, and the
+/// loser's value was gone with nothing left to notice. Which forms coincide
+/// follows from `yaml-rust2`'s scalar resolution (F5.1) and is not aligned
+/// across implementations; what is pinned here is that a coincidence errors.
+#[test]
+fn yaml_refuses_sibling_keys_that_coincide() {
+    for (src, key) in [
+        ("1: a\n'1': b\n", "\"1\""),
+        ("'1': b\n1: a\n", "\"1\""),
+        ("1.0: a\n'1.0': b\n", "\"1.0\""),
+        ("~: a\n'null': b\n", "\"null\""),
+        ("true: a\n'true': b\n", "\"true\""),
+        ("0x10: a\n'16': b\n", "\"16\""),
+    ] {
+        let Err(err) = yaml::parse(src, None) else {
+            panic!("{src:?} was accepted, want an F5.3 error");
+        };
+        assert!(err.message.contains("F5.3"), "{}", err.message);
+        assert!(
+            err.message.contains(&format!("both give the key {key}")),
+            "{}",
+            err.message
+        );
+    }
+}
+
+/// The collision message names where it happened, not just what.
+#[test]
+fn yaml_collision_names_the_path() {
+    let err = yaml::parse("outer:\n  1: a\n  '1': b\n", None).unwrap_err();
+    assert!(err.message.contains("at outer"), "{}", err.message);
+}
+
+/// A merge key legitimately brings in a key the mapping then overrides, which
+/// is YAML's own semantics rather than a collision — the check must not fire.
+#[test]
+fn yaml_merge_key_override_is_not_a_collision() {
+    let cfg = yaml::parse("base: &b\n  x: 1\nchild:\n  <<: *b\n  x: 2\n  y: 3\n", None).unwrap();
+    assert_eq!(cfg.get_i64("child.x").unwrap(), 2);
+    assert_eq!(cfg.get_i64("child.y").unwrap(), 3);
+}
+
 /// F5.7 — decoding one document and dropping the rest would be silent loss.
 #[test]
 fn yaml_refuses_a_multi_document_stream() {

--- a/tests/adapters_test.rs
+++ b/tests/adapters_test.rs
@@ -385,6 +385,18 @@ fn yaml_refuses_sibling_keys_that_coincide() {
     }
 }
 
+/// Quoting `1` gives `'1'`, which is the same key again — so the message must
+/// not offer it as the fix. Renaming is what always works.
+#[test]
+fn yaml_collision_does_not_advise_quoting_when_that_cannot_help() {
+    let err = yaml::parse("1: a\n'1': b\n", None).unwrap_err();
+    assert!(
+        err.message.contains("rename one of them"),
+        "{}",
+        err.message
+    );
+}
+
 /// The collision message names where it happened, not just what.
 #[test]
 fn yaml_collision_names_the_path() {


### PR DESCRIPTION
Closes #160.

Found by cross-checking o3co/ts.hocon#171 against the other three
implementations: rs.hocon and py.hocon carry the same defect, go.hocon does not.

## The bug

`yaml::parse("1: a\n'1': b\n")` produced a config holding only `"1" = "b"`. The
two keys are distinct in the decoded `Yaml::Hash`, `key_string` maps both to
`"1"`, and `out.insert` overwrote — so the first value was gone with nothing to
show for it, the silent loss F5.3 exists to prevent.

| document | before | after |
|---|---|---|
| `1: a` / `'1': b` | `{"1": "b"}` | F5.3 error |
| `'1': b` / `1: a` | `{"1": "a"}` | F5.3 error |
| `1.0: a` / `'1.0': b` | collapsed | F5.3 error |
| `~: a` / `'null': b` | collapsed | F5.3 error |
| `true: a` / `'true': b` | collapsed | F5.3 error |
| `0x10: a` / `'16': b` | collapsed | F5.3 error |
| `outer: {1: a, '1': b}` | collapsed | F5.3 error, naming `outer` |

## Shape of the fix

`yaml-rust2` keys its `Hash` by `Yaml`, so **both source keys are still present
when `convert` runs** — no AST pass is needed. go.hocon needed one
(o3co/go.hocon#165) only because goccy collapses the keys before the adapter
sees the map, and ts.hocon had to switch to `mapAsMap` (o3co/ts.hocon#176) for
the same reason.

Merge keys stay exempt: `<<: *defaults` bringing in a key the mapping then
overrides is YAML's own semantics rather than a collision, and there is a test
pinning that.

## What is deliberately *not* aligned

The string form of a non-string scalar key differs per library and this PR does
not change it: `1.0` gives `"1.0"` here and in py.hocon, `"1"` in go.hocon and
ts.hocon. That follows from each library's scalar resolution, which F5.1 leaves
to the library, and is the S1.2.6 class of language-natural divergence. What is
now common across all four is that a coincidence is an error rather than a loss.

Verified: `cargo test --features adapters` (57 test binaries, all green),
`cargo fmt --check`, `cargo clippy --all-features -- -D warnings`.

## SemVer

`BREAKING` in the CHANGELOG under a minor: input previously accepted is now
refused. The workaround is to quote the key you mean to keep distinct.