### PR TITLE
fix(adapters/env): render a path in an error as a JSON string literal (F0.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `adapters::env`: control characters went into error messages raw
+
+`display_path` escaped only `\` and `"`, so a variable name holding a newline or
+a NUL put it straight into the collision message — the one place the escaping
+exists to prevent, since such a name can break the line a reader sees in a log.
+go.hocon and py.hocon spelled the same segment two other ways again
+([xx.hocon#76](https://github.com/o3co/xx.hocon/issues/76)).
+
+A quoted segment is a JSON string literal now — which is also HOCON's own
+quoted-string syntax — pinned as spec F0.10, so all three produce the same text
+for the same key. **U+2028 / U+2029 are escaped** although JSON permits them
+raw, for the same log-safety reason. Printable non-ASCII stays itself (`é`,
+`İ`), because F1.3 leaves such segments unfolded and escaping them would bury
+the common case.
+
+The bare-segment rule now admits `A`–`Z` as well, matching go.hocon: HOCON's own
+grammar accepts an uppercase key unquoted, and the adapters that do not
+case-fold share this renderer.
+
+The rendered path is **not** guaranteed to paste into a getter — measured, no
+implementation's path parser decodes escapes inside a quoted segment. What it
+does guarantee, and what a collision message needs, is that two different paths
+never render alike.
+
 ### Fixed — deeply nested input aborted the process instead of returning an error
 
 **BREAKING** (a document nested deeper than 128 levels is now refused).

--- a/src/adapters/env.rs
+++ b/src/adapters/env.rs
@@ -233,10 +233,11 @@ fn to_path(rest: &str, name: &str) -> Result<Vec<String>, AdapterError> {
 
 /// Render a segment list as a HOCON path expression for an error message.
 ///
-/// A segment is written bare when it is safely unquoted (`[a-z0-9_-]`, the
-/// shape F1.3 lowercasing produces) and double-quoted otherwise, with `\` and
-/// `"` escaped so two different paths can never render identically. Matches
-/// py.hocon's format so the four implementations report collisions alike.
+/// Segments are joined with `.`, each rendered by [`render_segment`] — bare
+/// where it can be, otherwise as a JSON string literal (spec F0.10). What the
+/// join has to preserve is that two different paths never render identically:
+/// `APP_FOO.BAR` is one segment and must read `"foo.bar"`, while
+/// `APP_FOO__BAR` is two and must read `foo.bar`.
 fn display_path(segments: &[String]) -> String {
     segments
         .iter()

--- a/src/adapters/env.rs
+++ b/src/adapters/env.rs
@@ -240,18 +240,54 @@ fn to_path(rest: &str, name: &str) -> Result<Vec<String>, AdapterError> {
 fn display_path(segments: &[String]) -> String {
     segments
         .iter()
-        .map(|s| {
-            let bare = !s.is_empty()
-                && s.chars()
-                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-');
-            if bare {
-                s.clone()
-            } else {
-                format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
-            }
-        })
+        .map(|s| render_segment(s))
         .collect::<Vec<_>>()
         .join(".")
+}
+
+/// Render one path segment as a HOCON path expression element (spec F0.10):
+/// bare when it can be, otherwise as a **JSON string literal** — which is also
+/// HOCON's own quoted-string syntax, and which go.hocon and py.hocon produce
+/// for the same segment.
+///
+/// The escaping used to cover only `\` and `"`, so a NUL or a newline in a
+/// variable name went into the error message raw and could break the line a
+/// reader saw in a log. Two departures from plain JSON, both deliberate:
+/// U+2028 and U+2029 are escaped although JSON permits them raw, being line
+/// separators to enough log viewers to matter; and printable non-ASCII stays
+/// itself, because F1.3 leaves such segments unfolded and escaping them would
+/// bury the common case.
+///
+/// The result is **not** guaranteed to paste into a getter: no implementation's
+/// path parser decodes escapes inside a quoted segment. What it does guarantee,
+/// and what an error message needs, is that two different paths never render
+/// alike.
+fn render_segment(seg: &str) -> String {
+    let bare = !seg.is_empty()
+        && seg
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    if bare {
+        return seg.to_string();
+    }
+    let mut out = String::with_capacity(seg.len() + 2);
+    out.push('"');
+    for c in seg.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\u{8}' => out.push_str("\\b"),
+            '\u{c}' => out.push_str("\\f"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{2028}' | '\u{2029}' => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 /// Nest segment-list paths, applying the objects-win rule over the whole set

--- a/tests/adapters_test.rs
+++ b/tests/adapters_test.rs
@@ -599,3 +599,62 @@ fn properties_refuses_a_key_deeper_than_the_segment_limit() {
     let err = properties::parse(&format!("{} = 1", key(65)), None).unwrap_err();
     assert!(err.to_string().contains("over the limit of 64"), "{}", err);
 }
+
+// --- F0.10: a rendered path is a JSON string literal -------------------------
+
+/// The escaping used to cover only `\\` and `"`, so a NUL or a newline in a
+/// variable name reached the log raw and could break the line a reader saw.
+/// It is a JSON string literal now — HOCON's own quoted-string syntax — and
+/// go.hocon and py.hocon render the same segment the same way.
+#[test]
+fn a_rendered_path_segment_is_a_json_string_literal() {
+    let render = |seg: &str| -> String {
+        let mut vars: HashMap<String, String> = HashMap::new();
+        vars.insert(format!("APP_{seg}"), "1".to_string());
+        vars.insert(format!("APP_{}", seg.to_uppercase()), "2".to_string());
+        let err = env::load_from(&vars, env_opts("APP_")).unwrap_err();
+        err.message
+            .rsplit("both map to ")
+            .next()
+            .expect("the collision message names the path")
+            .to_string()
+    };
+
+    assert_eq!(render("a b"), "\"a b\"");
+    assert_eq!(render("a.b"), "\"a.b\"");
+    assert_eq!(render("a\nb"), "\"a\\nb\"");
+    assert_eq!(render("a\tb"), "\"a\\tb\"");
+    assert_eq!(
+        render("a\u{0}b"),
+        "\"a\\u0000b\"",
+        "NUL is JSON's escape, not Rust's"
+    );
+    assert_eq!(render("a\"b"), "\"a\\\"b\"");
+    // U+2028 is legal raw in JSON and escaped anyway: it is a line separator to
+    // enough log viewers that a key could otherwise break its own message.
+    assert_eq!(render("a\u{2028}b"), "\"a\\u2028b\"");
+    // Printable non-ASCII stays itself — F1.3 leaves these unfolded, so they
+    // arrive here in normal use and escaping them would bury the common case.
+    assert_eq!(render("\u{130}a"), "\"\u{130}a\"");
+}
+
+/// The property an error message actually needs: two different paths never
+/// render alike, so a collision report can be acted on. Pasting the result into
+/// a getter is deliberately *not* promised — no implementation's path parser
+/// decodes escapes inside a quoted segment.
+#[test]
+fn distinct_paths_render_distinctly() {
+    let render_one = |name: &str| -> String {
+        let mut vars: HashMap<String, String> = HashMap::new();
+        vars.insert(format!("APP_{name}"), "1".to_string());
+        vars.insert(format!("APP_{}", name.to_uppercase()), "2".to_string());
+        let err = env::load_from(&vars, env_opts("APP_")).unwrap_err();
+        err.message
+            .rsplit("both map to ")
+            .next()
+            .unwrap()
+            .to_string()
+    };
+    // A literal dot in one segment must not read as the two-segment path.
+    assert_ne!(render_one("foo.bar"), render_one("foo__bar"));
+}

--- a/tests/adapters_test.rs
+++ b/tests/adapters_test.rs
@@ -613,11 +613,14 @@ fn a_rendered_path_segment_is_a_json_string_literal() {
         vars.insert(format!("APP_{seg}"), "1".to_string());
         vars.insert(format!("APP_{}", seg.to_uppercase()), "2".to_string());
         let err = env::load_from(&vars, env_opts("APP_")).unwrap_err();
-        err.message
-            .rsplit("both map to ")
-            .next()
-            .expect("the collision message names the path")
-            .to_string()
+        // rsplit_once, not rsplit().next(): the latter yields the whole string
+        // when the delimiter is absent, so the test would pass on a message
+        // that never named a path at all.
+        let (_, path) = err
+            .message
+            .rsplit_once("both map to ")
+            .expect("the collision message names the path");
+        path.to_string()
     };
 
     assert_eq!(render("a b"), "\"a b\"");
@@ -649,11 +652,11 @@ fn distinct_paths_render_distinctly() {
         vars.insert(format!("APP_{name}"), "1".to_string());
         vars.insert(format!("APP_{}", name.to_uppercase()), "2".to_string());
         let err = env::load_from(&vars, env_opts("APP_")).unwrap_err();
-        err.message
-            .rsplit("both map to ")
-            .next()
-            .unwrap()
-            .to_string()
+        let (_, path) = err
+            .message
+            .rsplit_once("both map to ")
+            .expect("the collision message names the path");
+        path.to_string()
     };
     // A literal dot in one segment must not read as the two-segment path.
     assert_ne!(render_one("foo.bar"), render_one("foo__bar"));


### PR DESCRIPTION
Refs o3co/xx.hocon#76 — sibling of o3co/go.hocon#177. Pinned as spec F0.10 in the hocon scope.

## The decision

The issue offered two options: pin the rendering in the spec, or state that
error text is not portable and drop the paste-ability claim. **Measuring made
both necessary**, not either-or.

Pinning is clearly right — JSON string syntax *is* HOCON's quoted-string syntax,
py.hocon already used it, and the cross-language fixtures compare this text.

But part of the reason to prefer JSON was that it would make the rendered path
pasteable into a getter, and that turns out to be false in **every**
implementation, py.hocon included:

```text
py:  from_map({"a<LF>b": "v"}).get_string('"a\nb"')   ->   path not found
```

No implementation's path parser decodes escapes inside a quoted segment, and the
spec checklist has no S-item requiring it (S11.10 covers quoted segments in the
getter API, not escapes within them). So the claim is dropped everywhere rather
than narrowed again, and the guarantee an error message actually needs — that
two different paths never render alike — is pinned by a test instead.

Whether quoted path segments *should* decode escapes is a real question, but it
is an S-item about core path-expression semantics, not an adapter concern.

## The pinned rule (spec F0.10)

Segments joined with `.`, each bare only if it matches `[A-Za-z0-9_-]+`,
otherwise a JSON string literal. Two departures from plain JSON, both
deliberate:

- **NUL is the JSON escape**, not Go's `\x00` or Rust's `\u{0}`.
- **U+2028 / U+2029 are escaped** although JSON permits them raw — they are line
  separators to enough log viewers that a key could otherwise break the message
  reporting it, which is the whole point of escaping.

Hex escapes are lowercase, matching `json.dumps`. Printable non-ASCII stays
itself (`é`, `İ`) because F1.3 leaves such segments unfolded, so they occur in
normal use and escaping them would bury the common case.

## What changed here — this was the worst of the three

The issue's table listed rs.hocon as rendering with `{:?}`. It does not:
`display_path` escaped **only** `\` and `"`, so every control character went into
the collision message **raw**. A variable name holding a newline put a real line
break into the log line reporting it — the one outcome the escaping exists to
prevent.

Now a JSON string literal, matching go.hocon and py.hocon.

Also here: the bare-segment rule admitted only lowercase, so an uppercase
segment was quoted for no reason. HOCON's own grammar accepts an uppercase key
unquoted, and this renderer serves adapters that do not case-fold, so it now
matches go.hocon's `[A-Za-z0-9_-]+`. Environment segments are folded before they
reach here, so `env::load` itself is unchanged.

Verified: `cargo test --all-features`, `cargo fmt --check`, and all three clippy
configurations CI runs with `-D warnings`.
