### PR TITLE
fix(adapters/env)!: filter by prefix before validating, and check the name (F1.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,12 @@ four implementations behaving identically by accident
   `OTHER__=x` was never checked at all. `load`'s contract already said which
   way this goes ("entries outside the prefix are never inspected", the F1.1
   principle); the two functions disagreeing was the actual inconsistency.
-- **`export` may be followed by any whitespace.** Matching the literal
+- **`export` may be followed by spaces or tabs.** Matching the literal
   `export ` missed a tab, so `export<TAB>FOO=bar` became the variable
-  `export<TAB>foo` — a key nothing would ever look up, produced silently. A
-  name that merely begins with `export` is still a name.
+  `export<TAB>foo` — a key nothing would ever look up, produced silently. Space
+  and tab specifically, matching what this dialect already trims on the value
+  side; anything else leaves `export` part of the name, where the rule below
+  refuses it. A name that merely begins with `export` is still a name.
 - **A name containing whitespace or `#` is an error.** F1.7's rule for values —
   an error naming the fix rather than a guess about the author's intent —
   applies to names too; both characters mean the line was mis-parsed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — `.env`: the prefix filter runs first, and names are validated (F1.7)
+
+**BREAKING both ways**: a line the prefix discards is no longer validated (so a
+`.env` that used to fail may now load), and a name containing whitespace or `#`
+is now refused (so one that used to load may now fail).
+
+Three things, all pinned by an amended spec F1.7 after cross-checking found all
+four implementations behaving identically by accident
+([xx.hocon#78](https://github.com/o3co/xx.hocon/issues/78)):
+
+- **The prefix filter moves ahead of validation.** The value was parsed before
+  the filter and the path mapped after it, so one check landed on each side —
+  `BAD=x # y` failed even when the caller only wanted `APP_*`, while
+  `OTHER__=x` was never checked at all. `load`'s contract already said which
+  way this goes ("entries outside the prefix are never inspected", the F1.1
+  principle); the two functions disagreeing was the actual inconsistency.
+- **`export` may be followed by any whitespace.** Matching the literal
+  `export ` missed a tab, so `export<TAB>FOO=bar` became the variable
+  `export<TAB>foo` — a key nothing would ever look up, produced silently. A
+  name that merely begins with `export` is still a name.
+- **A name containing whitespace or `#` is an error.** F1.7's rule for values —
+  an error naming the fix rather than a guess about the author's intent —
+  applies to names too; both characters mean the line was mis-parsed.
+  `FOO BAR=baz` and `FOO#x=1` used to become the keys `foo bar` and `foo#x`.
+  Deliberately narrower than a POSIX name grammar, which would reject
+  `APP_FOO.BAR` — a name F1.2 documents as valid.
+
 ### Fixed — `adapters::env`: control characters went into error messages raw
 
 `display_path` escaped only `\` and `"`, so a variable name holding a newline or

--- a/src/adapters/env.rs
+++ b/src/adapters/env.rs
@@ -168,7 +168,7 @@ pub fn parse_dotenv(input: &str, opts: Options) -> Result<Config, AdapterError> 
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
-        let line = line.strip_prefix("export ").unwrap_or(line);
+        let line = strip_export(line);
         let Some((name, rest)) = line.split_once('=') else {
             return Err(AdapterError::new(format!(
                 "{origin}:{}: expected NAME=value",
@@ -176,16 +176,20 @@ pub fn parse_dotenv(input: &str, opts: Options) -> Result<Config, AdapterError> 
             )));
         };
         let name = name.trim();
+        // The two checks before the filter are about the *line* rather than the
+        // entry: a line with no `=` is not a NAME=value pair at all, and an
+        // empty name gives nothing to compare the prefix against.
         if name.is_empty() {
             return Err(AdapterError::new(format!(
                 "{origin}:{}: empty variable name",
                 i + 1
             )));
         }
-        let value = dotenv_value(rest.trim_start_matches([' ', '\t']), &origin, i + 1, name)?;
         let Some(stripped) = name.strip_prefix(&opts.prefix) else {
             continue;
         };
+        check_name(name, &origin, i + 1)?;
+        let value = dotenv_value(rest.trim_start_matches([' ', '\t']), &origin, i + 1, name)?;
         pairs.push((to_path(stripped, name)?, value));
     }
 
@@ -392,4 +396,45 @@ fn dotenv_value(v: &str, origin: &str, line: usize, name: &str) -> Result<String
         }
     }
     Ok(trimmed.to_string())
+}
+
+/// Drop a leading `export` and the whitespace after it (spec F1.7).
+///
+/// Stripping the literal `"export "` missed a tab, so `export\tFOO=bar` became
+/// the variable `export\tfoo` — a key nothing would ever look up, produced
+/// silently. A name that merely *begins* with `export` (`exportFOO=1`) is still
+/// a name, so the whitespace is what makes it the keyword.
+fn strip_export(line: &str) -> &str {
+    let Some(rest) = line.strip_prefix("export") else {
+        return line;
+    };
+    let trimmed = rest.trim_start_matches([' ', '\t']);
+    if trimmed.len() == rest.len() {
+        // No whitespace after it, so this is a variable whose name merely
+        // begins with "export" (`exportFOO=1`), not the keyword.
+        return line;
+    }
+    trimmed
+}
+
+/// Refuse a name that cannot have been meant (spec F1.7).
+///
+/// F1.7's rule for values is an error naming the fix rather than a guess about
+/// the author's intent; names get the same treatment. Whitespace or `#` inside
+/// one means the line was mis-parsed — `FOO BAR=baz` and `FOO#x=1` used to
+/// become the keys `foo bar` and `foo#x`.
+///
+/// Deliberately narrower than a POSIX name grammar, which would reject
+/// `APP_FOO.BAR` — a name F1.2 documents as valid and the fixtures exercise.
+fn check_name(name: &str, origin: &str, line: usize) -> Result<(), AdapterError> {
+    for c in name.chars() {
+        if c.is_whitespace() || c == '#' {
+            let what = if c == '#' { "'#'" } else { "whitespace" };
+            return Err(AdapterError::new(format!(
+                "{origin}:{line}: variable name {name:?} contains {what}; \
+                 the line is not NAME=value (spec F1.7)"
+            )));
+        }
+    }
+    Ok(())
 }

--- a/src/adapters/env.rs
+++ b/src/adapters/env.rs
@@ -398,12 +398,18 @@ fn dotenv_value(v: &str, origin: &str, line: usize, name: &str) -> Result<String
     Ok(trimmed.to_string())
 }
 
-/// Drop a leading `export` and the whitespace after it (spec F1.7).
+/// Drop a leading `export` and the spaces or tabs after it (spec F1.7).
 ///
 /// Stripping the literal `"export "` missed a tab, so `export\tFOO=bar` became
 /// the variable `export\tfoo` — a key nothing would ever look up, produced
 /// silently. A name that merely *begins* with `export` (`exportFOO=1`) is still
 /// a name, so the whitespace is what makes it the keyword.
+///
+/// Space and tab specifically, not `char::is_whitespace`: that is what this
+/// dialect already trims on the value side. Leaving the rest out is also the
+/// better outcome — `export\u{c}FOO=bar` is then a *name* of `export\u{c}FOO`,
+/// which [`check_name`] refuses, rather than a keyword line producing a
+/// silently odd key.
 fn strip_export(line: &str) -> &str {
     let Some(rest) = line.strip_prefix("export") else {
         return line;

--- a/tests/adapters_test.rs
+++ b/tests/adapters_test.rs
@@ -687,8 +687,12 @@ fn dotenv_filters_before_it_validates() {
 
 /// Stripping the literal `"export "` missed a tab, so `export\tFOO=bar` became
 /// the variable `export\tfoo` — a key nothing would look up, produced silently.
+///
+/// Spaces and tabs, matching what the dialect trims on the value side. Anything
+/// else after `export` leaves it part of the name, where the F1.7 name rule
+/// refuses it — an error rather than a silently odd key.
 #[test]
-fn dotenv_export_takes_any_whitespace() {
+fn dotenv_export_takes_spaces_and_tabs() {
     for src in ["export FOO=bar\n", "export\tFOO=bar\n", "export  FOO=bar\n"] {
         let cfg = env::parse_dotenv(src, env::Options::default()).unwrap();
         assert_eq!(cfg.get_string("foo").unwrap(), "bar", "{src:?}");
@@ -696,6 +700,11 @@ fn dotenv_export_takes_any_whitespace() {
     // …and a name that merely begins with "export" is still a name.
     let cfg = env::parse_dotenv("exportFOO=bar\n", env::Options::default()).unwrap();
     assert_eq!(cfg.get_string("exportfoo").unwrap(), "bar");
+
+    // A form feed is not one of the two, so "export" stays part of the name and
+    // the name rule rejects it. That is the intended outcome, not a gap.
+    let err = env::parse_dotenv("export\u{c}FOO=bar\n", env::Options::default()).unwrap_err();
+    assert!(err.message.contains("F1.7"), "{}", err.message);
 }
 
 /// F1.7's rule for values — an error naming the fix rather than a guess about

--- a/tests/adapters_test.rs
+++ b/tests/adapters_test.rs
@@ -661,3 +661,54 @@ fn distinct_paths_render_distinctly() {
     // A literal dot in one segment must not read as the two-segment path.
     assert_ne!(render_one("foo.bar"), render_one("foo__bar"));
 }
+
+// --- F1.7: the filter runs first, and names are validated -------------------
+
+/// A `.env` shared with tools that support trailing comments has to stay
+/// loadable when the caller wants one namespace out of it. `load` already
+/// worked that way ("entries outside the prefix are never inspected", F1.1);
+/// `parse_dotenv` disagreeing with its sibling was the actual inconsistency,
+/// and all four implementations had the same accidental split.
+#[test]
+fn dotenv_filters_before_it_validates() {
+    for src in [
+        "BAD=x # y\n",  // an ambiguous value, discarded by the prefix
+        "BAD NAME=x\n", // a name the rule below refuses, likewise discarded
+        "OTHER__=x\n",  // an empty path segment, likewise
+    ] {
+        let cfg = env::parse_dotenv(src, env_opts("APP_"))
+            .unwrap_or_else(|e| panic!("{src:?} discarded by the prefix, but: {e}"));
+        assert!(cfg.keys().is_empty(), "{src:?} mounted something");
+    }
+    // Kept by the prefix, so validated as strictly as ever.
+    assert!(env::parse_dotenv("APP_BAD=x # y\n", env_opts("APP_")).is_err());
+    assert!(env::parse_dotenv("APP___=x\n", env_opts("APP_")).is_err());
+}
+
+/// Stripping the literal `"export "` missed a tab, so `export\tFOO=bar` became
+/// the variable `export\tfoo` — a key nothing would look up, produced silently.
+#[test]
+fn dotenv_export_takes_any_whitespace() {
+    for src in ["export FOO=bar\n", "export\tFOO=bar\n", "export  FOO=bar\n"] {
+        let cfg = env::parse_dotenv(src, env::Options::default()).unwrap();
+        assert_eq!(cfg.get_string("foo").unwrap(), "bar", "{src:?}");
+    }
+    // …and a name that merely begins with "export" is still a name.
+    let cfg = env::parse_dotenv("exportFOO=bar\n", env::Options::default()).unwrap();
+    assert_eq!(cfg.get_string("exportfoo").unwrap(), "bar");
+}
+
+/// F1.7's rule for values — an error naming the fix rather than a guess about
+/// the author's intent — applies to names too. These used to become the keys
+/// `foo bar` and `foo#x`.
+#[test]
+fn dotenv_refuses_a_name_that_cannot_have_been_meant() {
+    for src in ["FOO BAR=baz\n", "FOO#x=1\n"] {
+        let err = env::parse_dotenv(src, env::Options::default()).unwrap_err();
+        assert!(err.message.contains("F1.7"), "{}", err.message);
+    }
+    // Deliberately narrower than a POSIX name grammar, which would reject this
+    // — a name F1.2 documents as valid.
+    let cfg = env::parse_dotenv("FOO.BAR=v\n", env::Options::default()).unwrap();
+    assert_eq!(cfg.get_string("\"foo.bar\"").unwrap(), "v");
+}


### PR DESCRIPTION
One of four sibling PRs. Closes the code half of o3co/xx.hocon#78 and parts 1–2
of o3co/py.hocon#19; spec F1.7 is amended in the hocon scope.

## Why this needed a decision rather than a fix

Cross-checking parts 1 and 2 of py.hocon#19 found **all four implementations
behaving identically**: the value parsed *before* the prefix filter, the path
mapped *after* it. Neither placement was chosen — the split was an accident, and
the same accident everywhere. Fixing one implementation would have manufactured
a divergence rather than removing one.

| input | all four, before | all four, after |
|---|---|---|
| `parse_dotenv("BAD=x # y\n", prefix="APP_")` | raises | accepted, discarded |
| `parse_dotenv("BAD NAME=x\n", prefix="APP_")` | key `bad name` | discarded |
| `parse_dotenv("OTHER__=x\n", prefix="APP_")` | accepted, unchecked | accepted, discarded |
| `parse_dotenv("APP_BAD=x # y\n", prefix="APP_")` | raises | raises |
| `parse_dotenv("export\tFOO=bar\n")` | key `export\tfoo` | key `foo` |
| `parse_dotenv("FOO BAR=baz\n")` | key `foo bar` | F1.7 error |
| `parse_dotenv("FOO#x=1\n")` | key `foo#x` | F1.7 error |
| `parse_dotenv("FOO.BAR=v\n")` | key `foo.bar` | unchanged |

## The three rules

**Filter first.** A `.env` shared with tools that support trailing comments must
stay loadable when you want one namespace out of it. `load`'s own contract
already said which way this goes — *"entries outside the prefix are never
inspected"*, the F1.1 principle — so `parse_dotenv` disagreeing with its sibling
in the same module was the real inconsistency. Two checks stay ahead of the
filter, because they are about the *line* rather than the entry: a line with no
`=` is not a `NAME=value` pair at all, and an empty name gives nothing to
compare the prefix against.

**`export` takes any whitespace.** Matching the literal `export ` missed a tab,
so `export<TAB>FOO=bar` became the variable `export<TAB>foo` — silently. A name
that merely *begins* with `export` (`exportFOO=1`) is still a name.

**A name with whitespace or `#` is an error.** F1.7's stated rule for values is
an error naming the fix rather than a guess about the author's intent; names had
been getting the guess. Deliberately narrower than a POSIX name grammar
(`[A-Za-z_][A-Za-z0-9_]*`), which would reject `APP_FOO.BAR` — a name F1.2
documents as valid and which the shared fixtures exercise.

## SemVer

`BREAKING` **in both directions**, and the CHANGELOG says so: a `.env` that used
to fail may now load (the filter discards it before validation), and one that
used to load may now fail (the name rule). Minor, per the spec-correction rule.
