### PR TITLE
docs(adapters): cite the F-item spec at its public location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,17 @@ workflow — a stale README fails the cut.
   diverge again. The MSRV the README states is likewise checked against
   `Cargo.toml`.
 
+### Fixed — the F-item spec citations pointed at a document readers cannot open
+
+The `adapters` module doc and the fixture manifest cited
+`docs/specs/format-ingestion-mapping.md`, which is not in this repository — it
+lived in a private working scope. The adapters raise errors that name items from
+it (`(spec F0.5)`, `(spec F1.6)`), so anyone following a citation reached
+nothing. The spec is now published at
+[`xx.hocon/docs/format-ingestion-mapping.md`](https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md) and every citation points
+there ([xx.hocon#81](https://github.com/o3co/xx.hocon/issues/81)). Error text is
+unchanged; only the pointers move.
+
 ## [1.11.0] - 2026-07-26
 
 ### Fixed

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -24,7 +24,8 @@
 //! never a reference (spec F0.2). Ingestion is AST-level — a document is
 //! decoded and turned into a value tree, never rendered to HOCON text.
 //!
-//! See `docs/specs/format-ingestion-mapping.md` in the hocon scope.
+//! See the format-ingestion mapping spec:
+//! <https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md>
 
 use crate::value::HoconValue;
 use crate::Config;

--- a/tests/testdata/format-ingestion/manifest.json
+++ b/tests/testdata/format-ingestion/manifest.json
@@ -1,6 +1,6 @@
 {
   "about": [
-    "Fixtures for the format adapters (docs/specs/format-ingestion-mapping.md, F-items).",
+    "Fixtures for the format adapters (docs/format-ingestion-mapping.md, F-items).",
     "",
     "Unlike expected/hocon/, these expectations are NOT generated from Lightbend.",
     "Lightbend has no equivalent of these adapters, so there is no oracle: the",

--- a/tests/testdata/format-ingestion/manifest.json
+++ b/tests/testdata/format-ingestion/manifest.json
@@ -1,6 +1,7 @@
 {
   "about": [
-    "Fixtures for the format adapters (docs/format-ingestion-mapping.md, F-items).",
+    "Fixtures for the format adapters (F-items). The mapping spec:",
+    "https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md",
     "",
     "Unlike expected/hocon/, these expectations are NOT generated from Lightbend.",
     "Lightbend has no equivalent of these adapters, so there is no oracle: the",


### PR DESCRIPTION
Part of o3co/xx.hocon#81. Depends on o3co/xx.hocon#82 — the URL resolves once that is on `main`.

**The problem**: these citations pointed at `docs/specs/format-ingestion-mapping.md`, which is **not in this repository**. It lived only in a private working scope, and the `in the hocon scope` qualifier named a place the reader still could not reach. The adapters raise errors that cite items from it — `(spec F0.5)`, `(spec F1.6)`, `(spec F3.5)` — so following one led nowhere.

**The change**: every citation now points at <https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md>.

**Error text is unchanged** — items were always cited by number, never by path, so nothing user-visible moves except where the number resolves.

Two places: the `adapters` module doc and `tests/testdata/format-ingestion/manifest.json`. The module doc uses an angle-bracket autolink so rustdoc renders it without tripping `rustdoc::bare_urls`; the manifest's `about` line matches what the testdata sync will fetch.

## Test plan

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo doc --no-deps` — no new warnings (the 3 unresolved intra-doc links are pre-existing, in `resolver/` and `lib.rs`)
- `cargo test --all-features --lib` — 250 passed; `--test adapters_test` — 51 passed

The Lightbend fixture suites need the downloaded corpus, which a fresh worktree does not have; unaffected by this change and green in CI, which syncs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)