### PR TITLE
test(adapters/env): pin F1.7 name whitespace to Unicode White_Space

### DIFF
--- a/tests/adapters_test.rs
+++ b/tests/adapters_test.rs
@@ -707,6 +707,34 @@ fn dotenv_export_takes_spaces_and_tabs() {
     assert!(err.message.contains("F1.7"), "{}", err.message);
 }
 
+/// F1.7 pins "whitespace" in a name to the Unicode `White_Space` property
+/// rather than to whichever predicate a stdlib offers, because the four do not
+/// agree. Enumerated over the whole codepoint space on 2026-07-31:
+///
+/// ```text
+/// Go   unicode.IsSpace     == White_Space
+/// Rust char::is_whitespace == White_Space
+/// Py   str.isspace         == White_Space + U+001C..U+001F
+/// JS   regex \s            == White_Space - U+0085 + U+FEFF
+/// ```
+///
+/// Rust is already exactly right, so this test exists to keep it that way: the
+/// two codepoints below are the ones that separate the four, and swapping
+/// `char::is_whitespace` for a hand-rolled set would move one of them.
+#[test]
+fn dotenv_name_whitespace_is_unicode_white_space() {
+    // U+0085 NEL is White_Space, so the name is a mis-parse and refused.
+    // ts.hocon accepted it until the same spec item was pinned.
+    let err = env::parse_dotenv("FOO\u{85}BAR=baz\n", env::Options::default()).unwrap_err();
+    assert!(err.message.contains("F1.7"), "{}", err.message);
+
+    // U+001F UNIT SEPARATOR is not White_Space, so it is an ordinary name
+    // character. Python's str.isspace disagrees, which is why the set is
+    // pinned here rather than inherited.
+    let cfg = env::parse_dotenv("FOO\u{1f}BAR=baz\n", env::Options::default()).unwrap();
+    assert_eq!(cfg.get_string("\"foo\u{1f}bar\"").unwrap(), "baz");
+}
+
 /// F1.7's rule for values — an error naming the fix rather than a guess about
 /// the author's intent — applies to names too. These used to become the keys
 /// `foo bar` and `foo#x`.

--- a/tests/format_ingestion_test.rs
+++ b/tests/format_ingestion_test.rs
@@ -58,7 +58,16 @@ struct EnvFixture {
     vars: HashMap<String, String>,
 }
 
-fn ingest(format: &str, kind: Option<&str>, text: &str, id: &str) -> Result<Config, AdapterError> {
+/// Dispatch a case to its adapter. `prefix` is the manifest's optional
+/// `prefix`, which only `dotenv` cases carry — an `env-vars` input names its
+/// own prefix inside the JSON document.
+fn ingest(
+    format: &str,
+    kind: Option<&str>,
+    prefix: &str,
+    text: &str,
+    id: &str,
+) -> Result<Config, AdapterError> {
     match format {
         "jsonc" => jsonc::parse(text, Some(id)),
         "properties" => properties::parse(text, Some(id)),
@@ -69,8 +78,8 @@ fn ingest(format: &str, kind: Option<&str>, text: &str, id: &str) -> Result<Conf
                 return env::parse_dotenv(
                     text,
                     env::Options {
+                        prefix: prefix.to_string(),
                         origin: Some(id.to_string()),
-                        ..Default::default()
                     },
                 );
             }
@@ -100,11 +109,12 @@ fn format_ingestion_fixtures() {
         let id = c["id"].as_str().unwrap();
         let format = c["format"].as_str().unwrap();
         let kind = c["kind"].as_str();
+        let prefix = c["prefix"].as_str().unwrap_or("");
         let note = c["note"].as_str().unwrap_or("");
         let text = std::fs::read_to_string(root().join(c["input"].as_str().unwrap()))
             .unwrap_or_else(|e| panic!("{id}: input: {e}"));
 
-        let result = ingest(format, kind, &text, id);
+        let result = ingest(format, kind, prefix, &text, id);
 
         if c["expect"] == "error" {
             let err = result


### PR DESCRIPTION
## What the cross-check found

The four `.env` name checks each used their host stdlib's whitespace predicate. Enumerated over the whole codepoint space (2026-07-31), those four are **not the same set**:

| implementation | predicate | set |
|---|---|---|
| go.hocon | `unicode.IsSpace` | `White_Space` |
| rs.hocon | `char::is_whitespace` | `White_Space` |
| py.hocon | `str.isspace` | `White_Space` **+ U+001C–U+001F** |
| ts.hocon | `/\s/` | `White_Space` **− U+0085** **+ U+FEFF** |

So the same `.env` got different answers:

- `FOO<NEL>BAR=baz` — an error in go / rs / py, the key `foo<NEL>bar` in ts.
- `FOO<US>BAR=baz` — an error in py only.

F1.7 said "a name containing whitespace … is an error" without saying what whitespace is, which is exactly the hole F1.3 exists to close for case folding: **whether a name is refused must not depend on which stdlib helper the implementation reached for.**

## The fix

F1.7 now pins the Unicode `White_Space` property (spec amended in the sibling xx.hocon PR). U+FEFF is deliberately *not* whitespace — F0.9 already removes the realistic case, a leading BOM, and a citable definition beats hand-listing invisible codepoints.

**This is not a released behaviour.** The name rule itself landed in this same unreleased 1.12.0 window, so pinning its edge now costs users nothing; after the tag it would be a second breaking change.

## Also here

The fixture runner now reads a `dotenv` case's optional `prefix`. xx.hocon's new `fi18-dotenv-prefix` needs it, and a runner that ignores it **fails** that case rather than passing it vacuously — the line the case expects to be filtered away is one the dialect otherwise refuses.

## rs specifically

**No behaviour change** — `char::is_whitespace` is already exactly `White_Space`. The test pins it.

One incidental improvement: the runner's `env::Options` literal no longer uses `..Default::default()`, so adding a field to `Options` becomes a compile error here instead of a silently defaulted fixture.

## Test plan

- `cargo test --all-features --test adapters_test dotenv_name_whitespace` — 1 passed
- fixture runner against the unmerged xx.hocon fixtures (copied in locally, then reverted) — 28 cases pass
- `cargo fmt --check` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)