### PR TITLE
perf(adapters/jsonc): drop the Vec<char> from the strip passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,36 @@ nothing. The spec is now published at
 there ([xx.hocon#81](https://github.com/o3co/xx.hocon/issues/81)). Error text is
 unchanged; only the pointers move.
 
+### Changed — `adapters/jsonc`: the strip passes no longer allocate a `Vec<char>` ([#155](https://github.com/o3co/rs.hocon/issues/155))
+
+`strip_comments` and `strip_trailing_commas` each collected the whole document
+into a `Vec<char>` — four bytes per character on top of the text it came from —
+so a large `.jsonc` peaked at several times its own size. Both now walk the
+`&str` with `char_indices()` and slice it directly.
+
+Measured on a 1 MiB document, peak allocation above the input:
+
+| | peak |
+|---|---|
+| `Vec<char>` | 5.6x |
+| `char_indices` | 3.45x |
+
+The remainder is `serde_json`'s `Value` and the `Config` tree, which this does
+not touch.
+
+**The safety property is preserved by the same argument, not weakened.** The
+`Vec<char>` was there because indexing chars makes a non-char-boundary slice
+structurally impossible, and a byte-level rewrite would have given that up.
+Offsets from `char_indices()` are char boundaries *by provenance* — each is
+either an index the iterator yielded or that index plus the exact `len_utf8` of
+the character there, never computed arithmetic — so `&src[i..j]` still cannot
+panic.
+
+The adversarial corpus that established the original property is now committed
+(52 inputs across the eight categories the issue names) and runs on every build,
+along with a peak-allocation guard that fails if a `Vec<char>` reappears. No
+behaviour change: `parse` accepts and refuses exactly what it did.
+
 ## [1.11.0] - 2026-07-26
 
 ### Fixed

--- a/src/adapters/jsonc.rs
+++ b/src/adapters/jsonc.rs
@@ -203,6 +203,197 @@ fn strip_trailing_commas(src: &str) -> String {
 mod tests {
     use super::*;
 
+    /// The adversarial corpus behind issue #155.
+    ///
+    /// The security review on #154 ran 36 hostile inputs through the strip
+    /// passes and found no panic, and that result is the reason the passes
+    /// still build a `Vec<char>`: indexing chars makes a non-char-boundary
+    /// slice structurally impossible. The inputs themselves were never
+    /// committed, so the evidence lived only in a sentence in the issue —
+    /// which is worth exactly nothing to the next person who rewrites this.
+    ///
+    /// This is that corpus, rebuilt from the eight categories the issue names
+    /// (unterminated block comments, multibyte characters straddling comment
+    /// boundaries, comment markers inside strings, escaped quotes at string
+    /// end, BOM, CRLF, U+2028, deep nesting) and extended where reading the
+    /// code suggested a neighbouring shape. It is a reconstruction, not the
+    /// original list — the original is not recoverable — so the count differs
+    /// and the ids are ours.
+    ///
+    /// The bar every entry must clear is the one the review established:
+    /// **`parse` returns, one way or the other.** `Ok` and `Err` are both
+    /// acceptable answers for a hostile input; a panic is not, because
+    /// `parse_file` is public and a panic in a config loader takes the process
+    /// with it.
+    const ADVERSARIAL: &[(&str, &str)] = &[
+        // --- unterminated block comments ---
+        ("ub01-bare", "/*"),
+        ("ub02-after-doc", "{\"a\":1} /*"),
+        ("ub03-open-brace", "{/*"),
+        ("ub04-mid-value", "{\"a\": /*x"),
+        ("ub05-slash-star-slash", "/*/"),
+        ("ub06-star-at-eof", "{\"a\":1} /*x*"),
+        // --- unterminated strings, including an escape that runs off the end ---
+        ("us01-bare-quote", "\""),
+        ("us02-in-key", "{\"a"),
+        ("us03-in-value", "{\"a\": \"b"),
+        ("us04-trailing-backslash", "{\"a\": \"b\\"),
+        ("us05-escape-eats-quote", "{\"a\": \"b\\\""),
+        // --- escaped quotes and backslashes at a string boundary ---
+        ("eq01-escaped-quote", "{\"a\": \"b\\\"\"}"),
+        ("eq02-escaped-backslash", "{\"a\": \"b\\\\\"}"),
+        ("eq03-double-escaped", "{\"a\": \"b\\\\\\\\\"}"),
+        ("eq04-escape-in-key", "{\"a\\\\\": 1}"),
+        (
+            "eq05-escaped-quote-then-comment",
+            "{\"a\": \"b\\\"\" /*c*/}",
+        ),
+        // --- comment markers that are data, not comments ---
+        ("cm01-line-in-string", "{\"a\": \"//x\"}"),
+        ("cm02-block-in-string", "{\"a\": \"/*x*/\"}"),
+        ("cm03-closer-in-string", "{\"a\": \"*/\"}"),
+        ("cm04-marker-as-key", "{\"//\": 1}"),
+        ("cm05-quoted-quote-then-marker", "{\"a\": \"\\\"/*\\\"\"}"),
+        ("cm06-opener-only-in-string", "{\"a\": \"/*\"}"),
+        // --- multibyte characters straddling a comment or string boundary ---
+        ("mb01-after-block", "{\"a\": 1 /*\u{3042}*/}"),
+        ("mb02-before-value", "{\"a\": /*\u{3042}*/ 1}"),
+        ("mb03-in-key", "{\"\u{3042}\": 1}"),
+        (
+            "mb04-around-marker-in-string",
+            "{\"a\": \"\u{3042}/*b*/\u{3044}\"}",
+        ),
+        ("mb05-unterminated-block", "/*\u{3042}"),
+        ("mb06-astral", "{\"a\": \"\u{1f600}\" /*\u{1f600}*/}"),
+        ("mb07-astral-unterminated", "{\"a\": \"\u{1f600}"),
+        // --- BOM (F0.9) ---
+        ("bo01-doc", "\u{feff}{\"a\":1}"),
+        ("bo02-alone", "\u{feff}"),
+        ("bo03-then-comment", "\u{feff}/*c*/{\"a\":1}"),
+        // --- CRLF and lone CR (F3.2: a `//` comment ends at LF *or* CR) ---
+        ("cr01-trailing-crlf", "{\"a\":1}\r\n"),
+        ("cr02-inside-doc", "{\r\n\"a\":1\r\n}"),
+        ("cr03-lone-cr-ends-line-comment", "{\"a\":1 //c\r}"),
+        ("cr04-leading-line-comment", "//c\r{\"a\":1}"),
+        ("cr05-cr-in-block", "{\"a\": /*x\ry*/ 1}"),
+        // --- U+2028 / U+2029, which deliberately do NOT end a comment ---
+        ("ls01-in-line-comment", "{\"a\":1} //c\u{2028}"),
+        ("ls02-raw-in-string", "{\"a\": \"\u{2028}\"}"),
+        ("ls03-in-block-comment", "{\"a\": 1 /*\u{2028}*/}"),
+        ("ls04-paragraph-separator", "{\"a\":1} //c\u{2029}"),
+        // --- degenerate punctuation the trailing-comma pass has to survive ---
+        ("tc01-empty-object-comma", "{,}"),
+        ("tc02-empty-array-comma", "[,]"),
+        ("tc03-double-comma", "{\"a\":1,,}"),
+        ("tc04-comma-alone", ","),
+        ("tc05-comma-then-eof", "{\"a\":1,"),
+        // --- lone markers and the empty document ---
+        ("lm01-empty", ""),
+        ("lm02-slash", "/"),
+        ("lm03-closer", "*/"),
+        ("lm04-slash-then-eof", "{\"a\":1}/"),
+    ];
+
+    /// Deep nesting is generated rather than written out, so it lives beside
+    /// the table instead of in it.
+    fn deeply_nested() -> Vec<(String, String)> {
+        vec![
+            (
+                "dn01-arrays".to_string(),
+                "[".repeat(200) + &"]".repeat(200),
+            ),
+            (
+                "dn02-objects".to_string(),
+                "{\"a\":".repeat(200) + "1" + &"}".repeat(200),
+            ),
+            ("dn03-unterminated-arrays".to_string(), "[".repeat(200)),
+            (
+                "dn04-nested-in-comment".to_string(),
+                format!("/*{}*/{{\"a\":1}}", "[".repeat(200)),
+            ),
+        ]
+    }
+
+    /// The property the security review established, now enforced.
+    ///
+    /// `catch_unwind` rather than a bare call so a regression names the input
+    /// that caused it — a panic escaping the loop would otherwise report only
+    /// the slice index, which is the least useful half of the story.
+    #[test]
+    fn adversarial_inputs_never_panic() {
+        let mut cases: Vec<(String, String)> = ADVERSARIAL
+            .iter()
+            .map(|(id, src)| (id.to_string(), src.to_string()))
+            .collect();
+        cases.extend(deeply_nested());
+
+        let mut accepted = 0;
+        for (id, src) in &cases {
+            let outcome =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| parse(src, None).is_ok()));
+            match outcome {
+                Ok(true) => accepted += 1,
+                Ok(false) => {}
+                Err(_) => panic!("{id} panicked on {src:?}"),
+            }
+        }
+
+        // A corpus where everything errors would pass the panic check while
+        // exercising almost nothing — the interesting inputs are the ones that
+        // survive stripping and reach serde_json. Guarding the mix keeps a
+        // future "reject earlier" change from quietly hollowing this out.
+        assert!(
+            accepted >= 15 && accepted < cases.len(),
+            "{accepted} of {} accepted — the corpus has stopped exercising both paths",
+            cases.len()
+        );
+    }
+
+    /// A hostile input may be accepted or refused, but the refusals that carry
+    /// a diagnosis must keep carrying it — an unterminated construct reported
+    /// as a generic JSON syntax error sends the reader to the wrong line.
+    #[test]
+    fn unterminated_constructs_are_named() {
+        for src in ["/*", "{\"a\":1} /*", "/*/", "/*\u{3042}", "{\"a\":1} /*x*"] {
+            let err = strip_comments(src).expect_err(src);
+            assert!(
+                err.message.contains("unterminated block comment"),
+                "{src:?}: {}",
+                err.message
+            );
+        }
+        for src in [
+            "\"",
+            "{\"a",
+            "{\"a\": \"b",
+            "{\"a\": \"b\\",
+            "{\"a\": \"\u{1f600}",
+        ] {
+            let err = strip_comments(src).expect_err(src);
+            assert!(
+                err.message.contains("unterminated string literal"),
+                "{src:?}: {}",
+                err.message
+            );
+        }
+    }
+
+    /// U+2028 and U+2029 are line breaks to JavaScript but not to the JSONC
+    /// dialect this tracks (spec F3.2). If one ended a `//` comment, the
+    /// closing braces after it would become trailing content and the document
+    /// would be refused — so accepting it is the assertion.
+    #[test]
+    fn a_line_separator_does_not_end_a_line_comment() {
+        for sep in ['\u{2028}', '\u{2029}'] {
+            let src = format!("{{\"a\":1 //c{sep}}}}}}}");
+            let stripped = strip_comments(&src).expect(&src);
+            assert!(
+                !stripped.contains('}'),
+                "{sep:?} ended the comment: {stripped:?}"
+            );
+        }
+    }
+
     /// The sequence of line terminators, which is what "same line structure"
     /// means: a `\r\n` collapsed to `\n`, or a lone `\r` dropped, both show up
     /// here as a difference.

--- a/src/adapters/jsonc.rs
+++ b/src/adapters/jsonc.rs
@@ -102,63 +102,81 @@ fn convert(v: &JsonValue, at: &str) -> Result<HoconValue, AdapterError> {
 /// body collapses to a single space — so only line numbers are meaningful,
 /// which is the same trade `//` stripping has always made.
 fn strip_comments(src: &str) -> Result<String, AdapterError> {
-    let b: Vec<char> = src.chars().collect();
     let mut out = String::with_capacity(src.len());
-    let mut i = 0;
-    while i < b.len() {
-        match b[i] {
+    let mut it = src.char_indices().peekable();
+    while let Some((i, c)) = it.next() {
+        match c {
             '"' => {
-                let end = end_of_string(&b, i)?;
-                out.extend(&b[i..end]);
-                i = end;
+                let end = end_of_string(&mut it)?;
+                out.push_str(&src[i..end]);
             }
-            '/' if i + 1 < b.len() && b[i + 1] == '/' => {
+            '/' if peek_is(&mut it, '/') => {
                 // A lone CR ends the comment too: a classic-Mac or otherwise
                 // CR-delimited file would otherwise have the rest of the
                 // document swallowed by the first `//` (spec F3.2). The
-                // terminator itself is left in place, so it still separates
-                // tokens.
-                while i < b.len() && b[i] != '\n' && b[i] != '\r' {
-                    i += 1;
+                // terminator itself is left for the outer loop, so it still
+                // separates tokens.
+                while let Some(&(_, c)) = it.peek() {
+                    if c == '\n' || c == '\r' {
+                        break;
+                    }
+                    it.next();
                 }
             }
-            '/' if i + 1 < b.len() && b[i + 1] == '*' => {
-                let mut j = i + 2;
-                loop {
-                    if j + 1 >= b.len() {
-                        return Err(AdapterError::new("jsonc: unterminated block comment"));
-                    }
-                    if b[j] == '*' && b[j + 1] == '/' {
+            '/' if peek_is(&mut it, '*') => {
+                it.next(); // the '*'
+                let mut closed = false;
+                while let Some((_, c)) = it.next() {
+                    if c == '*' && peek_is(&mut it, '/') {
+                        it.next();
+                        closed = true;
                         break;
                     }
                     // Re-emit terminators verbatim so a `\r\n` stays a pair
                     // and a lone `\r` is not silently dropped. Keeping only
                     // `\n` collapsed CRLF and lost classic-Mac line breaks
                     // outright, which contradicted the invariant above.
-                    if b[j] == '\n' || b[j] == '\r' {
-                        out.push(b[j]);
+                    if c == '\n' || c == '\r' {
+                        out.push(c);
                     }
-                    j += 1;
+                }
+                if !closed {
+                    return Err(AdapterError::new("jsonc: unterminated block comment"));
                 }
                 out.push(' ');
-                i = j + 2;
             }
-            c => {
-                out.push(c);
-                i += 1;
-            }
+            c => out.push(c),
         }
     }
     Ok(out)
 }
 
-fn end_of_string(b: &[char], i: usize) -> Result<usize, AdapterError> {
-    let mut j = i + 1;
-    while j < b.len() {
-        match b[j] {
-            '\\' => j += 2,
+/// Whether the next character is `want`, without consuming it.
+fn peek_is(it: &mut std::iter::Peekable<std::str::CharIndices<'_>>, want: char) -> bool {
+    matches!(it.peek(), Some(&(_, c)) if c == want)
+}
+
+/// Consume a string literal whose opening quote has already been taken from
+/// `it`, and return the byte offset just past its closing quote.
+///
+/// The returned offset is a char boundary **by provenance**: it is either an
+/// index yielded by `char_indices` or that index plus the exact `len_utf8` of
+/// the character there, never a computed guess. That is what lets the callers
+/// slice `src` directly with no possibility of a panic — the property the old
+/// `Vec<char>` bought at four bytes per character.
+fn end_of_string(
+    it: &mut std::iter::Peekable<std::str::CharIndices<'_>>,
+) -> Result<usize, AdapterError> {
+    while let Some((j, c)) = it.next() {
+        match c {
+            // Whatever follows an escape is data, including a quote. A
+            // backslash at the end of the document consumes nothing and the
+            // loop exits, which is the unterminated case below.
+            '\\' if it.next().is_none() => break,
+            '\\' => {}
+            // `"` is one byte, so the char boundary after it is j + 1.
             '"' => return Ok(j + 1),
-            _ => j += 1,
+            _ => {}
         }
     }
     Err(AdapterError::new("jsonc: unterminated string literal"))
@@ -166,35 +184,45 @@ fn end_of_string(b: &[char], i: usize) -> Result<usize, AdapterError> {
 
 /// Drop a comma whose next meaningful character closes its object or array.
 fn strip_trailing_commas(src: &str) -> String {
-    let b: Vec<char> = src.chars().collect();
     let mut out = String::with_capacity(src.len());
-    let mut i = 0;
-    while i < b.len() {
-        if b[i] == '"' {
-            match end_of_string(&b, i) {
-                Ok(end) => {
-                    out.extend(&b[i..end]);
-                    i = end;
-                    continue;
-                }
+    let mut it = src.char_indices().peekable();
+    while let Some((i, c)) = it.next() {
+        if c == '"' {
+            match end_of_string(&mut it) {
+                Ok(end) => out.push_str(&src[i..end]),
+                // An unterminated string is not this pass's error to raise —
+                // `strip_comments` has already refused one, so a caller that
+                // reaches here gets the remainder verbatim and the decoder
+                // reports it.
                 Err(_) => {
-                    out.extend(&b[i..]);
+                    out.push_str(&src[i..]);
                     return out;
                 }
             }
+            continue;
         }
-        if b[i] == ',' {
-            let mut j = i + 1;
-            while j < b.len() && b[j].is_whitespace() {
-                j += 1;
+        if c == ',' {
+            // `,` is one byte, so this is the boundary after it.
+            let after_comma = i + 1;
+            let mut ws_end = after_comma;
+            while let Some(&(j, ch)) = it.peek() {
+                if !ch.is_whitespace() {
+                    break;
+                }
+                ws_end = j + ch.len_utf8();
+                it.next();
             }
-            if j < b.len() && (b[j] == '}' || b[j] == ']') {
-                i += 1;
-                continue;
-            }
+            let closes = matches!(it.peek(), Some(&(_, '}')) | Some(&(_, ']')));
+            // The whitespace is kept either way — only the comma goes — so the
+            // line structure this module promises survives.
+            out.push_str(if closes {
+                &src[after_comma..ws_end]
+            } else {
+                &src[i..ws_end]
+            });
+            continue;
         }
-        out.push(b[i]);
-        i += 1;
+        out.push(c);
     }
     out
 }

--- a/tests/jsonc_allocation_test.rs
+++ b/tests/jsonc_allocation_test.rs
@@ -1,0 +1,139 @@
+//! Peak-allocation guard for the JSONC strip passes (issue #155).
+//!
+//! The issue is a memory bound, so the regression test has to be one too — a
+//! functional test cannot tell 3x from 8x. This file installs a counting
+//! global allocator, which is why it is a separate integration binary: the
+//! counter is process-wide, so anything else running in the same process would
+//! be counted too. **Keep exactly one test here.**
+#![cfg(feature = "adapters")]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use hocon::adapters::jsonc;
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+struct Tracking;
+
+fn record(delta: isize) {
+    let live = if delta >= 0 {
+        LIVE.fetch_add(delta as usize, Ordering::Relaxed) + delta as usize
+    } else {
+        let d = delta.unsigned_abs();
+        LIVE.fetch_sub(d, Ordering::Relaxed) - d
+    };
+    PEAK.fetch_max(live, Ordering::Relaxed);
+}
+
+// SAFETY: every method forwards to `System` unchanged and only adds
+// bookkeeping around it, so the allocator contract is whatever `System`'s is.
+unsafe impl GlobalAlloc for Tracking {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc(layout) };
+        if !p.is_null() {
+            record(layout.size() as isize);
+        }
+        p
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+        record(-(layout.size() as isize));
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let p = unsafe { System.realloc(ptr, layout, new_size) };
+        if !p.is_null() {
+            record(new_size as isize - layout.size() as isize);
+        }
+        p
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Tracking = Tracking;
+
+/// A document whose *text* is large but whose *tree* is small: a few keys, one
+/// of them holding a very long string, plus a minority of comments.
+///
+/// Both halves of that shape are load-bearing, and getting either wrong makes
+/// the measurement meaningless:
+///
+/// - **Mostly content, not mostly comment.** A comment-heavy document shrinks
+///   during stripping, so the second pass runs on a fraction of the input. An
+///   early version of this test did that and reported 1.07x.
+/// - **Few nodes, not many.** With many small keys the peak is dominated by
+///   `serde_json`'s `Value` plus the `Config` tree — measured at roughly 4.5x
+///   on its own — which swamps the strip passes entirely: old and new came out
+///   at 5.8x and 5.5x, a difference this test could not have defended. One
+///   long string keeps the tree at about two copies of the text and leaves the
+///   strip passes as the dominant term.
+fn document(bytes: usize) -> String {
+    let body = bytes * 9 / 10;
+    let mut s = String::with_capacity(bytes + 256);
+    s.push_str("{\n  /* a comment, with a \"quoted\" marker /* inside it */\n");
+    s.push_str("  // a line comment, and a trailing comma below,\n");
+    s.push_str("  \"long\": \"");
+    while s.len() < body {
+        // An escaped quote every so often, so `end_of_string`'s escape branch
+        // is on the measured path rather than only the functional one.
+        s.push_str("filler text that survives stripping, with an escaped \\\" quote; ");
+    }
+    s.push_str("\",\n");
+    while s.len() < bytes {
+        s.push_str("  /* trailing filler comment */\n");
+    }
+    s.push_str("  \"last\": [1, 2, 3,],\n}\n");
+    s
+}
+
+/// `parse` must stay within a small multiple of the input.
+///
+/// Before the `char_indices` rewrite each pass built a `Vec<char>` — 4 bytes
+/// per character on top of the text it was built from — so the second pass
+/// peaked at roughly 6n over its input. Slicing the `&str` directly leaves one
+/// intermediate `String` and the output.
+///
+/// Measured here on a 1 MiB document, peak over baseline (baseline already
+/// holds the input, so this is everything `parse` adds):
+///
+/// ```text
+/// Vec<char>      5.6x     ← fails this guard
+/// char_indices   3.45x    ← passes
+/// ```
+///
+/// The remainder in both figures is `serde_json`'s `Value` and the `Config`
+/// tree, about 1.8x here and not something this change touches.
+///
+/// The bound is 4.5x: below the old implementation, comfortably above the new
+/// one, so reintroducing a `Vec<char>` in either pass fails while an allocator
+/// or `serde_json` change that shifts the constant does not.
+#[test]
+fn parse_stays_within_a_small_multiple_of_the_input() {
+    let src = document(1 << 20);
+    let n = src.len();
+
+    // Warm up: the first parse initialises whatever is lazily allocated
+    // (serde_json scratch, formatting machinery) and would otherwise be
+    // charged to the measured run.
+    drop(jsonc::parse(&src, None).expect("warm-up parse"));
+
+    let baseline = LIVE.load(Ordering::Relaxed);
+    PEAK.store(baseline, Ordering::Relaxed);
+
+    let cfg = jsonc::parse(&src, None).expect("measured parse");
+    let peak = PEAK.load(Ordering::Relaxed);
+    drop(cfg);
+
+    let over = peak.saturating_sub(baseline);
+    let multiple = over as f64 / n as f64;
+    assert!(
+        over * 2 < n * 9,
+        "peak was {over} bytes over baseline for a {n}-byte document ({multiple:.2}x); \
+         the guard allows up to 4.5x"
+    );
+    // Print for the record; `cargo test -- --nocapture` shows it.
+    println!("peak {over} bytes over baseline for {n} bytes in ({multiple:.2}x)");
+}


### PR DESCRIPTION
Closes #155.

Two commits, in the order the issue asks for: **the corpus first, the rewrite second.**

## 1. `dd845dd` — commit the adversarial corpus

The security review on #154 ran 36 hostile inputs through the strip passes and found no panic, and that result is *why* the passes still built a `Vec<char>`. But the inputs were never committed, so the evidence existed only as a sentence in an issue — worth nothing to the next person who touches this.

52 inputs (48 in a table, 4 generated), rebuilt from the eight categories the issue names: unterminated block comments, multibyte characters straddling comment boundaries, comment markers inside strings, escaped quotes at string end, BOM, CRLF, U+2028, deep nesting. **It is a reconstruction, not the original list** — the original is not recoverable — and the doc comment says so.

The bar is the one the review established: **`parse` returns.** `Ok` and `Err` are both fine for a hostile input; a panic is not, because `parse_file` is public and a panic in a config loader takes the process with it.

- `catch_unwind` so a regression names the input rather than only a slice index
- an accepted-count floor, so a future "reject earlier" change cannot hollow the corpus out while still passing
- the unterminated diagnoses are pinned — degrading to a generic JSON syntax error sends the reader to the wrong line

**All green against the unchanged implementation**, which is the point.

## 2. `1961a81` — the rewrite

Both passes now walk the `&str` with `char_indices()` and slice it directly.

| | peak over the input, 1 MiB document |
|---|---|
| `Vec<char>` | **5.6x** |
| `char_indices` | **3.45x** |

The remainder is `serde_json`'s `Value` plus the `Config` tree, untouched here.

**The safety property is preserved by the same argument, not weakened.** The `Vec<char>` was there because indexing chars makes a non-char-boundary slice structurally impossible. Offsets from `char_indices()` are char boundaries *by provenance* — each is either an index the iterator yielded or that index plus the exact `len_utf8` of the character there, never computed arithmetic — so `&src[i..j]` still cannot panic. That is the third option between "keep the 4x memory" and "do byte arithmetic and hope".

Recorded in the issue earlier and still true: **fusing the two passes makes it worse**, not better (peak 7n → 9n), because it replaces a 1n output with a 4n one.

## The allocation guard

`tests/jsonc_allocation_test.rs` installs a counting global allocator, which is why it is a separate integration binary — the counter is process-wide. **The document shape took two corrections**, both recorded in the file:

- a comment-heavy document shrinks during stripping, so pass 2 sees a fraction of the input — that version reported **1.07x** and proved nothing
- many small keys put the peak in `serde_json` + `Config` instead, where old and new measured **5.8x and 5.5x** — a difference the test could not have defended

One long string keeps the tree at about two copies of the text and leaves the strip passes dominant. The guard is 4.5x: verified to **fail on the old implementation** (`git stash` on the source, test re-run) and pass on the new one.

## Test plan

- `cargo test --all-features --lib` — 253 passed
- `--test adapters_test` — 52 passed
- `--test format_ingestion_test` — passes (28 fixture cases)
- `--test jsonc_allocation_test` — passes at 3.45x; **fails at 5.6x against the pre-rewrite source**
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean

No behaviour change: `parse` accepts and refuses exactly what it did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)