### PR TITLE
feat(serde): hocon::from_str / hocon::from_file — one-step text → T entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `hocon::from_str::<T>()` and `hocon::from_file::<T>()` (`serde` feature) —
+  one-step parse + deserialize into any `serde::Deserialize` type, the
+  `serde_json::from_str` shape. Substitutions resolve against the process
+  environment exactly like `parse` / `parse_file`; a deserialization failure
+  surfaces as `HoconError::Config` with an empty `path` (the document root),
+  matching the array-root convention. The existing composition points
+  (`Config::deserialize`, `Config::get_as`, `serde::from_value`) are unchanged.
+
 ## [1.12.0] - 2026-07-31
 
 Cross-impl release, coordinated to land at v1.12.0 across go.hocon / ts.hocon /

--- a/README.ja.md
+++ b/README.ja.md
@@ -54,6 +54,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+自分の型へ直接デシリアライズすることもできます（`serde` フィーチャー）:
+
+```rust
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct App {
+    server: Server,
+}
+
+#[derive(Deserialize)]
+struct Server {
+    host: String,
+    port: u16,
+}
+
+let app: App = hocon::from_str(input)?;          // テキスト → T の 1 ステップ
+let app: App = hocon::from_file("app.conf")?;    // ファイルからも同様
+```
+
 ## なぜ HOCON？
 
 | | `.env` | JSON | YAML | HOCON |
@@ -82,7 +102,8 @@ HOCON は単なるシリアライズ形式ではなく、**プログラムに注
 - 環境変数の参照（`${HOME}`）
 - ドット区切りパス式（`server.host`）
 - フォールバック設定のマージ（`with_fallback`）
-- オプションの Serde デシリアライゼーション
+- オプションの Serde デシリアライゼーション: 1 ステップの `hocon::from_str::<T>()` /
+  `from_file::<T>()`、パス指定の `Config::get_as::<T>(path)`、`Config::deserialize::<T>()`
 - Lightbend 等価テスト合格（equiv01 - equiv05）
 
 ## API リファレンス
@@ -167,10 +188,17 @@ struct ServerConfig {
     port: u16,
 }
 
+// テキスト (またはファイル) → T の 1 ステップ — serde_json::from_str と同型:
+let server: ServerConfig = hocon::from_str("host = localhost, port = 8080")?;
+let server: ServerConfig = hocon::from_file("server.conf")?;
+
+// パス指定: パス上の任意ノード (オブジェクト・配列・スカラー) をデシリアライズ:
 let config = hocon::parse(input)?;
-let server: ServerConfig = config
-    .get_config("server")?
-    .deserialize()?;
+let server: ServerConfig = config.get_as("server")?;
+let ports: Vec<u16> = config.get_as("ports")?;
+
+// Config 全体からも (with_fallback / resolve の後などに):
+let server: ServerConfig = config.deserialize()?;
 ```
 
 ## エラー型

--- a/README.ja.md
+++ b/README.ja.md
@@ -70,8 +70,16 @@ struct Server {
     port: u16,
 }
 
-let app: App = hocon::from_str(input)?;          // テキスト → T の 1 ステップ
-let app: App = hocon::from_file("app.conf")?;    // ファイルからも同様
+// テキスト → T の 1 ステップ
+let app: App = hocon::from_str(r#"
+    server {
+        host = "localhost"
+        port = 8080
+    }
+"#)?;
+
+// ファイルからも同様
+let app: App = hocon::from_file("app.conf")?;
 ```
 
 ## なぜ HOCON？

--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+Or deserialize straight into your own types (with the `serde` feature):
+
+```rust
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct App {
+    server: Server,
+}
+
+#[derive(Deserialize)]
+struct Server {
+    host: String,
+    port: u16,
+}
+
+let app: App = hocon::from_str(input)?;          // one step: text → T
+let app: App = hocon::from_file("app.conf")?;    // same, from a file
+```
+
 ## Why HOCON?
 
 | | `.env` | JSON | YAML | HOCON |
@@ -86,7 +106,9 @@ On top of that, HOCON combines the readability of YAML with the structure of JSO
 - Fallback configuration merging (`with_fallback`)
 - Deferred resolution lifecycle: `parse_string_with_options` → `with_fallback` → `resolve()`
   per Lightbend `parseString` / `withFallback` / `resolve()` API (E12, v1.4.0)
-- Optional Serde deserialization support
+- Optional Serde deserialization: one-step `hocon::from_str::<T>()` /
+  `from_file::<T>()`, path-scoped `Config::get_as::<T>(path)`, and
+  `Config::deserialize::<T>()`
 - Passes Lightbend equivalence tests (equiv01 through equiv05)
 
 ## API Reference
@@ -205,10 +227,17 @@ struct ServerConfig {
     port: u16,
 }
 
+// One step, text (or file) → T — like serde_json::from_str:
+let server: ServerConfig = hocon::from_str("host = localhost, port = 8080")?;
+let server: ServerConfig = hocon::from_file("server.conf")?;
+
+// Path-scoped: deserialize any node (object, array, or scalar) at a path:
 let config = hocon::parse(input)?;
-let server: ServerConfig = config
-    .get_config("server")?
-    .deserialize()?;
+let server: ServerConfig = config.get_as("server")?;
+let ports: Vec<u16> = config.get_as("ports")?;
+
+// Or the whole Config, e.g. after with_fallback / resolve:
+let server: ServerConfig = config.deserialize()?;
 ```
 
 ## Error Types

--- a/README.md
+++ b/README.md
@@ -72,8 +72,16 @@ struct Server {
     port: u16,
 }
 
-let app: App = hocon::from_str(input)?;          // one step: text → T
-let app: App = hocon::from_file("app.conf")?;    // same, from a file
+// one step: text → T
+let app: App = hocon::from_str(r#"
+    server {
+        host = "localhost"
+        port = 8080
+    }
+"#)?;
+
+// same, from a file
+let app: App = hocon::from_file("app.conf")?;
 ```
 
 ## Why HOCON?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ pub use value_factory::from_map;
 pub use lexer::{tokenize, Segment, SubstPayload, Token, TokenKind};
 
 #[cfg(feature = "serde")]
-pub use serde::{from_value, DeserializeError};
+pub use serde::{from_file, from_str, from_value, DeserializeError};
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,7 +1,9 @@
+use crate::error::{ConfigError, HoconError};
 use crate::numeric_array::numeric_object_to_array;
 use crate::value::{HoconValue, ScalarType, ScalarValue};
 use indexmap::IndexMap;
 use std::fmt;
+use std::path::Path;
 
 // ---------------------------------------------------------------------------
 // Error type
@@ -62,6 +64,62 @@ where
     T: ::serde::de::DeserializeOwned,
 {
     T::deserialize(HoconDeserializer::new(value))
+}
+
+/// Parse a HOCON string and deserialize it into `T` in one step.
+///
+/// The one-liner for the common case — `serde_json::from_str`, but for HOCON:
+///
+/// ```
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct Server {
+///     host: String,
+///     port: u16,
+/// }
+///
+/// let server: Server = hocon::from_str("host = localhost, port = 8080")?;
+/// assert_eq!(server.port, 8080);
+/// # Ok::<(), hocon::HoconError>(())
+/// ```
+///
+/// Substitutions are resolved against the process environment, exactly like
+/// [`parse`](crate::parse); use [`crate::parse_with_env`] +
+/// [`Config::deserialize`](crate::Config::deserialize) to control the
+/// environment. For a path-scoped decode use
+/// [`Config::get_as`](crate::Config::get_as).
+///
+/// A deserialization failure is reported as [`HoconError::Config`] with an
+/// empty `path` (the error concerns the document root), matching the
+/// array-root convention.
+pub fn from_str<T>(input: &str) -> Result<T, HoconError>
+where
+    T: ::serde::de::DeserializeOwned,
+{
+    let cfg = crate::parse(input)?;
+    cfg.deserialize().map_err(deserialize_to_hocon_error)
+}
+
+/// Parse a HOCON file and deserialize it into `T` in one step.
+///
+/// The file counterpart of [`from_str`]: `include` directives resolve
+/// relative to the file's directory, exactly like
+/// [`parse_file`](crate::parse_file).
+pub fn from_file<T, P>(path: P) -> Result<T, HoconError>
+where
+    T: ::serde::de::DeserializeOwned,
+    P: AsRef<Path>,
+{
+    let cfg = crate::parse_file(path)?;
+    cfg.deserialize().map_err(deserialize_to_hocon_error)
+}
+
+fn deserialize_to_hocon_error(e: DeserializeError) -> HoconError {
+    HoconError::Config(ConfigError {
+        message: e.message,
+        path: String::new(),
+    })
 }
 
 /// Helper: parse raw string as integer type with float truncation fallback.

--- a/tests/serde_test.rs
+++ b/tests/serde_test.rs
@@ -161,3 +161,70 @@ fn deserialize_vec_from_numeric_keyed_object_sorted_and_compacted() {
         .expect("Vec<String> deserialization must sort by integer key");
     assert_eq!(val.items, vec!["a", "b", "d"]);
 }
+
+// ---------------------------------------------------------------------------
+// from_str / from_file — one-step text → T entry points
+// ---------------------------------------------------------------------------
+
+#[test]
+fn from_str_deserializes_in_one_step() {
+    let server: ServerConfig = hocon::from_str("host = localhost, port = 8080").unwrap();
+    assert_eq!(
+        server,
+        ServerConfig {
+            host: "localhost".to_string(),
+            port: 8080
+        }
+    );
+}
+
+#[test]
+fn from_str_resolves_substitutions() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Cfg {
+        a: i64,
+        b: i64,
+    }
+    let cfg: Cfg = hocon::from_str("a = 1, b = ${a}").unwrap();
+    assert_eq!(cfg, Cfg { a: 1, b: 1 });
+}
+
+#[test]
+fn from_str_parse_error_surfaces_as_parse_variant() {
+    let err = hocon::from_str::<ServerConfig>("host = {").unwrap_err();
+    assert!(
+        matches!(err, hocon::HoconError::Parse(_)),
+        "syntax error must surface as HoconError::Parse, got {err:?}"
+    );
+}
+
+#[test]
+fn from_str_type_mismatch_surfaces_as_config_variant_with_empty_path() {
+    let err = hocon::from_str::<ServerConfig>("host = localhost, port = not-a-number").unwrap_err();
+    match err {
+        hocon::HoconError::Config(e) => {
+            assert!(
+                e.path.is_empty(),
+                "root-level decode error carries an empty path"
+            );
+        }
+        other => panic!("expected HoconError::Config, got {other:?}"),
+    }
+}
+
+#[test]
+fn from_file_deserializes_with_relative_includes() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("defaults.conf"), "port = 8080\n").unwrap();
+    let main = dir.path().join("app.conf");
+    std::fs::write(&main, "include \"defaults.conf\"\nhost = localhost\n").unwrap();
+
+    let server: ServerConfig = hocon::from_file(&main).unwrap();
+    assert_eq!(
+        server,
+        ServerConfig {
+            host: "localhost".to_string(),
+            port: 8080
+        }
+    );
+}


### PR DESCRIPTION
## Summary

Priority 2 of the UX evaluation (2026-08-17). The competing hocon crate has `de::from_str::<T>()` as its entry point, and for typical Serde usage we were a few lines longer. This adds a one-shot API of the same shape as `serde_json::from_str` to close that gap.

```rust
let server: ServerConfig = hocon::from_str("host = localhost, port = 8080")?;
let server: ServerConfig = hocon::from_file("server.conf")?;
```

## Specification

- Lives under the `serde` feature. Substitutions resolve against the process env, same as `parse` / `parse_file` (to control the env, use the existing `parse_with_env` + `Config::deserialize`)
- Deserialize failures are returned as `HoconError::Config` with an empty `path` (document root — the same convention as the array-root error). Syntax errors remain `HoconError::Parse`
- Existing composition points (`Config::deserialize` / `Config::get_as` / `serde::from_value` / `HoconDeserializer`) are unchanged. Additive only = minor

## Tests

5 cases added to serde_test.rs (one-shot decode / substitution resolution / Parse variant / Config variant + empty path / from_file relative include). 1 doctest.

`make test` (default / serde / all-features) green, clippy `-D warnings` green, fmt green. The initial concat_errors suite failure was only because the CI-fetched fixtures (untracked) were missing in a fresh worktree — all green after `make testdata`. **No contamination of tracked fixtures** (`git status | grep testdata` = 0, AGENTS.md HARD RULE confirmed).

README (en/ja): added a one-shot decode example to Quick Start, restructured the Serde section to lead with from_str, made the Features bullet concrete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
