### PR TITLE
fix(resolver): S13a.12 — resolve prefix self-refs to below (with allow_prefix narrowing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **BREAKING (spec fix, S13a.12): a substitution whose target lies inside the
+  field being defined (`foo : ${foo.a}`) now resolves against the field's
+  "below" value — the merge of the stack beneath the substitution — instead of
+  the final tree.** The spec example `foo:{a:{c:1}}; foo:${foo.a}; foo:{a:2}`
+  now yields `{a:2, c:1}` (was `{a:2}`, dropping `c`), and the two-layer form
+  now resolves instead of erroring. A required prefix self-ref with nothing
+  below errors with the undefined classification; an optional one vanishes
+  transparently. The rule applies only in value-stack positions — an
+  object-interior sibling reference (`a = { x = ${a.p.v} }`) keeps S13a.14
+  lazy final-tree semantics. Found by a cross-impl probe — all four siblings
+  shared the gap and the fixes land in lockstep.
+
 ### Added
 
 - `hocon::from_str::<T>()` and `hocon::from_file::<T>()` (`serde` feature) —

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -416,8 +416,15 @@ same item descriptions verbatim.
   tests: tests/lightbend_test.rs:303 (lightbend_test09_delayed_merge_object); tests/lightbend_test.rs:316 (lightbend_test10_nested_include)
   status: ✅
 - **S13a.12** Self-ref in path expression `${foo.a}` resolves to "below" — §Self-Referential (L791)
-  tests: tests/lightbend_test.rs:275 (lightbend_test06_delayed_merge)
-  status: ✅
+  tests: tests/s13a12_prefix_self_ref_test.rs
+  status: ✅ — Fixed 2026-08-18. The previous ✅ was a misclassification: the cited
+  lightbend_test06 cannot discriminate (its later object overrides every key the
+  substitution contributes, so discard and merge produce identical output). A cross-impl
+  probe showed the L791 example yielded `{a:2}` (c lost) in all four siblings — the
+  prefix direction (`foo` ⊏ `foo.a`) was missing from self-reference detection. Fixed in
+  lockstep with ts/py/go: fold-side prefix folding (value-stack positions only — an
+  object-interior sibling reference keeps S13a.14 lazy final-tree semantics) with layer
+  merge, plus resolve-side prior navigation with undefined semantics on a miss.
 - **S13a.13** `a = ${?a}foo` resolves to `"foo"` (look-back undefined) — §Self-Referential (L841)
   tests: tests/integration_test.rs (s13a_13_optional_self_ref_concat_with_no_prior_spec); tests/self_ref_lookback_test.rs (sr01–sr11)
   status: ✅ (fixed in #76; cleared in cluster phase6-3f)

--- a/src/resolver/fold_self_ref.rs
+++ b/src/resolver/fold_self_ref.rs
@@ -307,10 +307,19 @@ fn merge_prior_layers(base: &ResObj, top: &ResObj) -> ResObj {
             }
         }
     }
+    // Carry BOTH layers' bookkeeping: top's prior_values (its keys' own
+    // delayed-merge chains) win per key over base's, and reset_keys union so
+    // reset markers from either layer survive the splice.
+    let mut prior_values = base.prior_values.clone();
+    for (k, pv) in &top.prior_values {
+        prior_values.insert(k.clone(), pv.clone());
+    }
+    let mut reset_keys = base.reset_keys.clone();
+    reset_keys.extend(top.reset_keys.iter().cloned());
     ResObj {
         fields,
-        prior_values: base.prior_values.clone(),
-        reset_keys: base.reset_keys.clone(),
+        prior_values,
+        reset_keys,
     }
 }
 

--- a/src/resolver/fold_self_ref.rs
+++ b/src/resolver/fold_self_ref.rs
@@ -29,18 +29,112 @@
 use super::types::{ConcatPlaceholder, ResObj, ResolverValue, SubstPlaceholder};
 use super::utils::segments_to_key;
 use crate::lexer::Segment;
+use crate::value::HoconValue;
+
+/// S13a.12: remainder segment texts when `full_key` is a PROPER segment-wise
+/// prefix of the subst's path (`foo` ⊏ `foo.a` → `["a"]`), else None.
+/// Boundary-safe on the dotted keys because both sides share
+/// `segments_to_key`'s quoting — a literal dotted segment renders quoted and
+/// can never string-prefix `foo.`.
+pub(crate) fn prefix_self_ref_remainder(
+    sp: &SubstPlaceholder,
+    full_key: &str,
+) -> Option<Vec<String>> {
+    if !subst_full_key(sp).starts_with(&format!("{full_key}.")) {
+        return None;
+    }
+    for n in 1..sp.segments.len() {
+        if segments_to_key(&sp.segments[..n]) == full_key {
+            return Some(
+                sp.segments[n..]
+                    .iter()
+                    .map(|seg| seg.text.clone())
+                    .collect(),
+            );
+        }
+    }
+    None
+}
+
+/// Result of a structural walk into a resolver value (S13a.12). `Found`
+/// carries a clone — navigated values feed straight into saved priors, and
+/// every consumer would clone anyway.
+pub(crate) enum NavResult {
+    /// The walk reached a node.
+    Found(ResolverValue),
+    /// A segment was missing, or the walk dead-ended in a scalar/array —
+    /// path semantics treat both as absent.
+    Missing,
+    /// The walk hit a node it cannot see through (a live substitution or
+    /// concat placeholder).
+    Unnavigable,
+}
+
+/// Structural navigation of `remainder` into a resolver value, following
+/// ResObj fields and already-resolved object fields.
+pub(crate) fn navigate_resolver_value(v: &ResolverValue, remainder: &[String]) -> NavResult {
+    let mut cur = v;
+    for (i, seg) in remainder.iter().enumerate() {
+        match cur {
+            ResolverValue::Subst(_) | ResolverValue::Concat(_) => return NavResult::Unnavigable,
+            ResolverValue::Obj(o) => match o.fields.get(seg.as_str()) {
+                Some(next) => cur = next,
+                None => return NavResult::Missing,
+            },
+            ResolverValue::Resolved(hv) => return navigate_resolved(hv, &remainder[i..]),
+            _ => return NavResult::Missing,
+        }
+    }
+    NavResult::Found(cur.clone())
+}
+
+fn navigate_resolved(hv: &HoconValue, remainder: &[String]) -> NavResult {
+    let mut cur = hv;
+    for seg in remainder {
+        match cur {
+            HoconValue::Object(fields) => match fields.get(seg.as_str()) {
+                Some(next) => cur = next,
+                None => return NavResult::Missing,
+            },
+            _ => return NavResult::Missing,
+        }
+    }
+    NavResult::Found(ResolverValue::Resolved(cur.clone()))
+}
 
 /// Returns true if `v` contains at least one `Subst` whose dotted-path key
-/// equals `full_key`. Walks Subst / Concat / UnresolvedArray / Obj (all
-/// wrapping shapes covered by the #118/#120 union).
+/// equals `full_key` — or, per S13a.12, whose path has `full_key` as a proper
+/// segment-wise prefix (`${foo.a}` inside the stack of `foo`). Walks Subst /
+/// Concat / UnresolvedArray / Obj (all wrapping shapes covered by the
+/// #118/#120 union).
 pub(crate) fn contains_self_ref(v: &ResolverValue, full_key: &str) -> bool {
+    contains_self_ref_inner(v, full_key, true)
+}
+
+/// `allow_prefix` narrows the S13a.12 prefix rule to value-stack positions:
+/// it stays true through Concat nodes and array elements (the value chain of
+/// the field itself) but turns false when descending into object interiors —
+/// a substitution nested inside an object literal that references a sibling
+/// branch of the same field (`a = { x = ${a.p.v} }`) is a lazy final-tree
+/// lookup (S13a.14), NOT a below-lookback.
+fn contains_self_ref_inner(v: &ResolverValue, full_key: &str, allow_prefix: bool) -> bool {
     match v {
-        ResolverValue::Subst(sp) => !sp.known_absent && subst_full_key(sp) == full_key,
-        ResolverValue::Concat(c) => c.nodes.iter().any(|n| contains_self_ref(n, full_key)),
-        ResolverValue::UnresolvedArray(elems) => {
-            elems.iter().any(|e| contains_self_ref(e, full_key))
+        ResolverValue::Subst(sp) => {
+            !sp.known_absent
+                && (subst_full_key(sp) == full_key
+                    || (allow_prefix && prefix_self_ref_remainder(sp, full_key).is_some()))
         }
-        ResolverValue::Obj(o) => o.fields.values().any(|f| contains_self_ref(f, full_key)),
+        ResolverValue::Concat(c) => c
+            .nodes
+            .iter()
+            .any(|n| contains_self_ref_inner(n, full_key, allow_prefix)),
+        ResolverValue::UnresolvedArray(elems) => elems
+            .iter()
+            .any(|e| contains_self_ref_inner(e, full_key, allow_prefix)),
+        ResolverValue::Obj(o) => o
+            .fields
+            .values()
+            .any(|f| contains_self_ref_inner(f, full_key, false)),
         _ => false,
     }
 }
@@ -55,13 +149,33 @@ pub(crate) fn fold_self_ref(
     full_key: &str,
     replacement: &ResolverValue,
 ) -> ResolverValue {
+    fold_self_ref_inner(v, full_key, replacement, true)
+}
+
+/// See [`contains_self_ref_inner`] for the `allow_prefix` narrowing rule.
+fn fold_self_ref_inner(
+    v: &ResolverValue,
+    full_key: &str,
+    replacement: &ResolverValue,
+    allow_prefix: bool,
+) -> ResolverValue {
     match v {
         ResolverValue::Subst(sp) if subst_full_key(sp) == full_key => replacement.clone(),
+        // S13a.12: a prefix self-ref folds to the remainder navigated into the
+        // below value (undefined classification on a miss; unchanged when the
+        // below cannot be seen through — the resolve-time guard covers it).
+        ResolverValue::Subst(sp)
+            if allow_prefix && prefix_self_ref_remainder(sp, full_key).is_some() =>
+        {
+            let remainder = prefix_self_ref_remainder(sp, full_key)
+                .expect("guard checked prefix_self_ref_remainder is Some");
+            fold_prefix_self_ref(sp, replacement, &remainder)
+        }
         ResolverValue::Concat(c) => ResolverValue::Concat(ConcatPlaceholder {
             nodes: c
                 .nodes
                 .iter()
-                .map(|n| fold_self_ref(n, full_key, replacement))
+                .map(|n| fold_self_ref_inner(n, full_key, replacement, allow_prefix))
                 .collect(),
             separator_flags: c.separator_flags.clone(),
             line: c.line,
@@ -70,13 +184,16 @@ pub(crate) fn fold_self_ref(
         ResolverValue::UnresolvedArray(elems) => ResolverValue::UnresolvedArray(
             elems
                 .iter()
-                .map(|e| fold_self_ref(e, full_key, replacement))
+                .map(|e| fold_self_ref_inner(e, full_key, replacement, allow_prefix))
                 .collect(),
         ),
         ResolverValue::Obj(o) => {
             let mut new_fields = indexmap::IndexMap::new();
             for (k, val) in &o.fields {
-                new_fields.insert(k.clone(), fold_self_ref(val, full_key, replacement));
+                new_fields.insert(
+                    k.clone(),
+                    fold_self_ref_inner(val, full_key, replacement, false),
+                );
             }
             ResolverValue::Obj(ResObj {
                 fields: new_fields,
@@ -152,6 +269,51 @@ pub(crate) fn fold_known_absent_self_ref(
 /// The no-prior optional case preserves S13a.13's "optional self-ref with no
 /// prior resolves to undefined" rule while still saving the literal parts of
 /// a concat for the next overwrite (sr15: `${?a}1; ${?a}2` → `12`).
+/// Folds one prefix self-reference against the below value (S13a.12). A
+/// missing path folds to the undefined classification — a `known_absent`
+/// placeholder that disappears when optional and errors at resolve time when
+/// required. An unnavigable path leaves the subst unchanged for the
+/// resolve-time guard.
+fn fold_prefix_self_ref(
+    sp: &SubstPlaceholder,
+    replacement: &ResolverValue,
+    remainder: &[String],
+) -> ResolverValue {
+    match navigate_resolver_value(replacement, remainder) {
+        NavResult::Unnavigable => ResolverValue::Subst(sp.clone()),
+        NavResult::Missing => {
+            let mut absent = sp.clone();
+            absent.known_absent = true;
+            ResolverValue::Subst(absent)
+        }
+        NavResult::Found(nav) => nav,
+    }
+}
+
+/// Prior-layer object merge for the standalone-prefix-self-ref save case
+/// (S13a.12): below layer as base, navigated value on top. A local,
+/// bookkeeping-free merge — deliberately NOT the include-oriented deep merge,
+/// which re-runs prior-save logic that has already happened for these layers.
+fn merge_prior_layers(base: &ResObj, top: &ResObj) -> ResObj {
+    let mut fields = base.fields.clone();
+    for (k, tv) in &top.fields {
+        match (fields.get(k.as_str()), tv) {
+            (Some(ResolverValue::Obj(bo)), ResolverValue::Obj(to)) => {
+                let merged = merge_prior_layers(bo, to);
+                fields.insert(k.clone(), ResolverValue::Obj(merged));
+            }
+            _ => {
+                fields.insert(k.clone(), tv.clone());
+            }
+        }
+    }
+    ResObj {
+        fields,
+        prior_values: base.prior_values.clone(),
+        reset_keys: base.reset_keys.clone(),
+    }
+}
+
 pub(crate) fn fold_or_skip_prior(
     prior: &ResolverValue,
     full_key: &str,
@@ -159,6 +321,27 @@ pub(crate) fn fold_or_skip_prior(
 ) -> Option<ResolverValue> {
     if !contains_self_ref(prior, full_key) {
         return Some(prior.clone());
+    }
+    // S13a.12: a STANDALONE prefix self-ref in field-value position is a
+    // merge LAYER — an object it navigates to merges over the stack below,
+    // so the saved prior keeps the below layer's other keys. An optional one
+    // whose navigated path is absent vanishes transparently (the below layer
+    // itself survives as the prior). Nested occurrences substitute in place
+    // via the generic fold below.
+    if let (ResolverValue::Subst(sp), Some(o)) = (prior, old) {
+        if !sp.known_absent {
+            if let Some(remainder) = prefix_self_ref_remainder(sp, full_key) {
+                match navigate_resolver_value(o, &remainder) {
+                    NavResult::Missing if sp.optional => return Some(o.clone()),
+                    NavResult::Found(ResolverValue::Obj(nav_obj)) => {
+                        if let ResolverValue::Obj(old_obj) = o {
+                            return Some(ResolverValue::Obj(merge_prior_layers(old_obj, &nav_obj)));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
     }
     if let Some(o) = old {
         return Some(fold_self_ref(prior, full_key, o));
@@ -196,8 +379,20 @@ pub(crate) fn fold_or_skip_prior(
 /// Tests: sr17 (pure-optional), sr18 (required external), sr19 (required
 /// self-ref mixed) in tests/self_ref_lookback_test.rs.
 fn fold_optional_self_ref_absent(v: &ResolverValue, full_key: &str) -> Option<ResolverValue> {
+    fold_optional_self_ref_absent_inner(v, full_key, true)
+}
+
+/// See [`contains_self_ref_inner`] for the `allow_prefix` narrowing rule.
+fn fold_optional_self_ref_absent_inner(
+    v: &ResolverValue,
+    full_key: &str,
+    allow_prefix: bool,
+) -> Option<ResolverValue> {
     match v {
-        ResolverValue::Subst(sp) if subst_full_key(sp) == full_key => {
+        ResolverValue::Subst(sp)
+            if subst_full_key(sp) == full_key
+                || (allow_prefix && prefix_self_ref_remainder(sp, full_key).is_some()) =>
+        {
             if !sp.optional {
                 return None;
             }
@@ -208,7 +403,11 @@ fn fold_optional_self_ref_absent(v: &ResolverValue, full_key: &str) -> Option<Re
         ResolverValue::Concat(c) => {
             let mut nodes = Vec::with_capacity(c.nodes.len());
             for n in &c.nodes {
-                nodes.push(fold_optional_self_ref_absent(n, full_key)?);
+                nodes.push(fold_optional_self_ref_absent_inner(
+                    n,
+                    full_key,
+                    allow_prefix,
+                )?);
             }
             Some(ResolverValue::Concat(ConcatPlaceholder {
                 nodes,
@@ -220,14 +419,21 @@ fn fold_optional_self_ref_absent(v: &ResolverValue, full_key: &str) -> Option<Re
         ResolverValue::UnresolvedArray(elems) => {
             let mut folded = Vec::with_capacity(elems.len());
             for e in elems {
-                folded.push(fold_optional_self_ref_absent(e, full_key)?);
+                folded.push(fold_optional_self_ref_absent_inner(
+                    e,
+                    full_key,
+                    allow_prefix,
+                )?);
             }
             Some(ResolverValue::UnresolvedArray(folded))
         }
         ResolverValue::Obj(o) => {
             let mut new_fields = indexmap::IndexMap::new();
             for (k, val) in &o.fields {
-                new_fields.insert(k.clone(), fold_optional_self_ref_absent(val, full_key)?);
+                new_fields.insert(
+                    k.clone(),
+                    fold_optional_self_ref_absent_inner(val, full_key, false)?,
+                );
             }
             Some(ResolverValue::Obj(ResObj {
                 fields: new_fields,

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -153,10 +153,7 @@ impl<'a> SubstitutionResolver<'a> {
         let mut cur = v;
         for seg in remainder {
             match cur {
-                HoconValue::Object(fields) => match fields.get(seg.as_str()) {
-                    Some(next) => cur = next,
-                    None => return None,
-                },
+                HoconValue::Object(fields) => cur = fields.get(seg.as_str())?,
                 _ => return None,
             }
         }

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -214,7 +214,11 @@ impl<'a> SubstitutionResolver<'a> {
             // disappearance. The `+=` chain-bottom sentinel is always `${?…}`
             // and keeps the silent path.
             if !s.optional {
-                let k = segments_to_key(&s.segments);
+                let k = if s.list_suffix {
+                    format!("{}[]", segments_to_key(&s.segments))
+                } else {
+                    segments_to_key(&s.segments)
+                };
                 if self.allow_unresolved {
                     use crate::value::PlaceholderValue;
                     return Ok(Some(HoconValue::Placeholder(PlaceholderValue {
@@ -266,7 +270,11 @@ impl<'a> SubstitutionResolver<'a> {
                     if s.optional {
                         return Ok(None);
                     }
-                    let k = segments_to_key(&s.segments);
+                    let k = if s.list_suffix {
+                        format!("{}[]", segments_to_key(&s.segments))
+                    } else {
+                        segments_to_key(&s.segments)
+                    };
                     if self.allow_unresolved {
                         use crate::value::PlaceholderValue;
                         return Ok(Some(HoconValue::Placeholder(PlaceholderValue {

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -34,6 +34,12 @@ pub(crate) struct SubstitutionResolver<'a> {
     /// than the original path-equality check. Spec amendment deferred to a
     /// follow-up xx.hocon PR (see Phase 6 #3f close-out notes).
     resolving_field_path: Vec<String>,
+    /// S13a.12 recursion guard: field keys whose prior is currently being
+    /// resolved through the prefix-self-ref branch. Saved priors are
+    /// prefix-self-ref-free by the fold invariant; re-entry only happens on a
+    /// shape the fold could not see through — it is reported as unresolvable
+    /// instead of recursing forever.
+    resolving_prefix_priors: HashSet<String>,
 }
 
 impl<'a> SubstitutionResolver<'a> {
@@ -51,6 +57,7 @@ impl<'a> SubstitutionResolver<'a> {
             use_system_environment,
             allow_unresolved,
             resolving_field_path: Vec::new(),
+            resolving_prefix_priors: HashSet::new(),
         }
     }
 
@@ -140,6 +147,22 @@ impl<'a> SubstitutionResolver<'a> {
         Ok(HoconValue::Object(result))
     }
 
+    /// S13a.12: walk resolved-object fields by segment text. A missing
+    /// segment or a walk into a scalar/array is path-absent → None.
+    fn navigate_resolved_hocon_impl(v: &HoconValue, remainder: &[String]) -> Option<HoconValue> {
+        let mut cur = v;
+        for seg in remainder {
+            match cur {
+                HoconValue::Object(fields) => match fields.get(seg.as_str()) {
+                    Some(next) => cur = next,
+                    None => return None,
+                },
+                _ => return None,
+            }
+        }
+        Some(cur.clone())
+    }
+
     fn cache_descendants(&mut self, prefix: &str, value: &HoconValue) {
         if let HoconValue::Object(fields) = value {
             for (key, child) in fields {
@@ -185,7 +208,80 @@ impl<'a> SubstitutionResolver<'a> {
         scope: &ResObj,
     ) -> Result<Option<HoconValue>, ResolveError> {
         if s.known_absent {
+            // S13a.12: a REQUIRED substitution folded to known_absent (prefix
+            // fold with no below value at the navigated path) is the spec's
+            // "undefined" classification — an error, not a silent
+            // disappearance. The `+=` chain-bottom sentinel is always `${?…}`
+            // and keeps the silent path.
+            if !s.optional {
+                let k = segments_to_key(&s.segments);
+                if self.allow_unresolved {
+                    use crate::value::PlaceholderValue;
+                    return Ok(Some(HoconValue::Placeholder(PlaceholderValue {
+                        path: k,
+                        optional: false,
+                    })));
+                }
+                return Err(ResolveError {
+                    message: format!("could not resolve substitution: ${{{k}}}"),
+                    path: k,
+                    line: s.line,
+                    col: s.col,
+                });
+            }
             return Ok(None);
+        }
+
+        // S13a.12 (HOCON.md L791): a substitution whose target lies INSIDE
+        // the field currently being resolved (the field path is a proper
+        // prefix of the target path, e.g. `foo : ${foo.a}` while resolving
+        // `foo`) is self-referential and resolves against the field's
+        // "below" value — its saved prior — never the final tree. Runs
+        // before the cache fast path: the cache holds final-tree values.
+        {
+            let rfp = &self.resolving_field_path;
+            if !rfp.is_empty() && rfp.len() < s.segments.len() {
+                let rfp_key = string_segments_to_key(rfp.iter().map(String::as_str));
+                if segments_to_key(&s.segments[..rfp.len()]) == rfp_key {
+                    if !self.resolving_prefix_priors.contains(&rfp_key) {
+                        let leaf = rfp.last().expect("rfp non-empty").clone();
+                        if let Some(prior) = scope.prior_values.get(leaf.as_str()) {
+                            let prior = prior.clone();
+                            let remainder: Vec<String> = s.segments[rfp.len()..]
+                                .iter()
+                                .map(|seg| seg.text.clone())
+                                .collect();
+                            self.resolving_prefix_priors.insert(rfp_key.clone());
+                            let prior_result = self.resolve_val(&prior, scope);
+                            self.resolving_prefix_priors.remove(&rfp_key);
+                            if let Some(prior_resolved) = prior_result? {
+                                if let Some(nav) =
+                                    Self::navigate_resolved_hocon_impl(&prior_resolved, &remainder)
+                                {
+                                    return Ok(Some(nav));
+                                }
+                            }
+                        }
+                    }
+                    if s.optional {
+                        return Ok(None);
+                    }
+                    let k = segments_to_key(&s.segments);
+                    if self.allow_unresolved {
+                        use crate::value::PlaceholderValue;
+                        return Ok(Some(HoconValue::Placeholder(PlaceholderValue {
+                            path: k,
+                            optional: false,
+                        })));
+                    }
+                    return Err(ResolveError {
+                        message: format!("could not resolve substitution: ${{{k}}}"),
+                        path: k,
+                        line: s.line,
+                        col: s.col,
+                    });
+                }
+            }
         }
 
         // Cache key includes list_suffix to prevent `${X}` and `${X[]}` collisions:

--- a/tests/s13a12_prefix_self_ref_test.rs
+++ b/tests/s13a12_prefix_self_ref_test.rs
@@ -1,0 +1,112 @@
+#![cfg(feature = "serde")]
+
+// S13a.12 (HOCON.md L791) — prefix self-reference resolves to "below".
+//
+// A substitution whose target lies INSIDE the field being defined
+// (`foo : ${foo.a}`) resolves against the field's below value (the merge of
+// the stack beneath the substitution), never the final tree. Found 2026-08-18
+// by a cross-impl probe: all four siblings resolved the spec example against
+// the final tree, yielding {a:2} instead of {a:2, c:1} — this crate's
+// recorded ✅ cited lightbend_test06, which cannot discriminate (its later
+// object overrides every key the substitution contributes). Fixed in lockstep
+// with ts.hocon / py.hocon / go.hocon.
+//
+// The prefix rule applies only in value-stack positions: a substitution
+// nested inside an object literal that references a sibling branch of the
+// same field is a lazy final-tree lookup (S13a.14), pinned here too.
+
+use serde_json::{json, Value};
+
+fn parse_json(src: &str) -> Value {
+    let cfg = hocon::parse(src).expect("parse should succeed");
+    cfg.deserialize().expect("deserialize should succeed")
+}
+
+#[test]
+fn spec_example_sandwich() {
+    let v = parse_json("foo : { a : { c : 1 } }\nfoo : ${foo.a}\nfoo : { a : 2 }");
+    assert_eq!(v["foo"], json!({"a": 2, "c": 1}));
+}
+
+#[test]
+fn two_layers_subst_last() {
+    let v = parse_json("foo : { a : { c : 1 } }\nfoo : ${foo.a}");
+    assert_eq!(v["foo"], json!({"a": {"c": 1}, "c": 1}));
+}
+
+#[test]
+fn below_layer_keys_survive() {
+    let v = parse_json("foo : { a : { c : 1 }, keep : 9 }\nfoo : ${foo.a}\nfoo : { a : 2 }");
+    assert_eq!(v["foo"], json!({"a": 2, "keep": 9, "c": 1}));
+}
+
+#[test]
+fn scalar_navigation_resets_stack() {
+    let v = parse_json("foo : { a : 5 }\nfoo : ${foo.a}\nfoo : { b : 2 }");
+    assert_eq!(v["foo"], json!({"b": 2}));
+}
+
+#[test]
+fn optional_miss_vanishes_transparently() {
+    let v = parse_json("foo : { a : 1 }\nfoo : ${?foo.nope}\nfoo : { b : 2 }");
+    assert_eq!(v["foo"], json!({"a": 1, "b": 2}));
+}
+
+#[test]
+fn required_miss_is_undefined_error() {
+    let err = hocon::parse("foo : { a : 1 }\nfoo : ${foo.nope}\nfoo : { b : 2 }")
+        .expect_err("required prefix self-ref with nothing below must error");
+    assert!(
+        err.to_string().contains("could not resolve substitution"),
+        "expected undefined classification, got: {err}"
+    );
+}
+
+#[test]
+fn nested_paths() {
+    let v = parse_json(
+        "srv : { foo : { a : { c : 1 } } }\nsrv : { foo : ${srv.foo.a} }\nsrv : { foo : { a : 2 } }",
+    );
+    assert_eq!(v["srv"]["foo"], json!({"a": 2, "c": 1}));
+}
+
+#[test]
+fn regression_non_self_ref_sandwich_unchanged() {
+    let v =
+        parse_json("d = { x : { c : 1 } }\nfoo : { a : { c : 9 } }\nfoo : ${d.x}\nfoo : { a : 2 }");
+    assert_eq!(v["foo"], json!({"c": 1, "a": 2}));
+}
+
+#[test]
+fn regression_sibling_ref_in_deeper_prior_sees_final_tree() {
+    let v = parse_json("bar { nested { x = { q: 10 }\na = ${bar.nested.x}\na = { c: 3 } } }");
+    assert_eq!(v["bar"]["nested"]["a"], json!({"q": 10, "c": 3}));
+}
+
+#[test]
+fn interior_sibling_ref_stays_lazy_final_tree() {
+    // ${a.p.v} sits INSIDE a's object literal — an object-interior sibling
+    // reference, not a value-stack layer. It must keep S13a.14 lazy final-tree
+    // semantics (the allow_prefix narrowing), not fold to a below value.
+    let v = parse_json("a = { p : { v : 1 }, x : ${a.p.v} }\na = { y : 2 }");
+    assert_eq!(v["a"], json!({"p": {"v": 1}, "x": 1, "y": 2}));
+}
+
+#[test]
+fn two_layers_required_miss_errors() {
+    let err = hocon::parse("foo : { a : 1 }\nfoo : ${foo.nope}")
+        .expect_err("two-layer required miss must error");
+    assert!(err.to_string().contains("could not resolve substitution"));
+}
+
+#[test]
+fn two_layers_optional_miss_keeps_prior() {
+    let v = parse_json("foo : { a : 1 }\nfoo : ${?foo.nope}");
+    assert_eq!(v["foo"], json!({"a": 1}));
+}
+
+#[test]
+fn unnavigable_below_optional_stays_resolvable() {
+    let v = parse_json("foo : { a : ${x} }\nfoo : ${?foo.a.b}\nfoo : { z : 1 }\nx : { b : 7 }");
+    assert_eq!(v["foo"], json!({"z": 1}));
+}


### PR DESCRIPTION
## Summary

The 4th of the four same-window implementation fixes ([ts#188](https://github.com/o3co/ts.hocon/pull/188) / [py#37](https://github.com/o3co/py.hocon/pull/37) / [go#192](https://github.com/o3co/go.hocon/pull/192); the reclassification is [xx#89](https://github.com/o3co/xx.hocon/pull/89)).

The spec L791 example goes from `{a:2}` → **`{a:2, c:1}`**. rs's previous ✅ was a misclassification based on the non-discriminating lightbend_test06 (the later object overrides every key the substitution contributes).

## Important: allow_prefix narrowing (an overdetection caught by rs's unit tests)

A naive prefix extension would also treat **sibling references inside objects** (`a = { x = ${a.p.v} }` — subject to S13a.14 lazy final-tree resolution) as self-refs (`issue135_obj_obj_merge_saves_self_ref_free_outer_prior` detected this). The prefix rule is **restricted to value-stack positions (standalone / concat / array element)** and disabled when recursing into object interiors. This narrowing will also be reflected into the open ts/go PRs and a py follow-up.

## Implementation

- fold side: `prefix_self_ref_remainder` / `navigate_resolver_value` (NavResult: Found/Missing/Unnavigable) / `fold_prefix_self_ref` / `merge_prior_layers`. Standalone preserves the other keys of below via layer merge; an optional whose navigation target is absent falls through to below
- resolve side: prefix branch guarded by `resolving_prefix_priors` (saved prior + remainder navigation). `allow_unresolved` follows the existing convention of returning a Placeholder. The known_absent branch respects optionality

## Tests

- 13 dedicated cases (spec example / keep preservation / interior-sibling narrowing / sibling-in-prior regression, among others)
- `make test` (default / serde / all-features) + clippy `-D warnings` + fmt + docs gate all green. No contamination of tracked fixtures
- BREAKING recorded in the CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)
