### PR TITLE
fix(s9.2,s13.12): Lightbend conformance — keep triple-quote leading newline + omit undefined optional array elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **BREAKING (spec fix, S9.2): a triple-quoted string whose content starts
+  with a newline now preserves it** (`"""<LF>hello"""` → `"\nhello"`, was
+  `"hello"`). The lexer stripped the leading newline; the Lightbend reference
+  preserves every character between the quotes (probe 2026-08-18). Surfaced
+  by the py.hocon spec-verification wave — the same port bug ships in
+  ts.hocon and py.hocon fixes in lockstep.
+- **BREAKING (spec fix, S13.12): an undefined optional substitution in array
+  element position is now omitted** (`[1, ${?missing}, 3]` → `[1, 3]`, was
+  `[1, null, 3]`). Spec HOCON.md L635 and the Lightbend reference both drop
+  the element; a literal `null` element is unaffected. The previous ✅ cited
+  a fixture with no array-element case.
+
 - **BREAKING (spec fix, S13a.12): a substitution whose target lies inside the
   field being defined (`foo : ${foo.a}`) now resolves against the field's
   "below" value — the merge of the stack beneath the substitution — instead of

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -193,8 +193,8 @@ same item descriptions verbatim.
   tests: src/lexer.rs:770 (tokenizes_triple_quoted_strings); tests/integration_test.rs:105 (parse_with_triple_quoted_string); tests/testdata/hocon/equiv05/triple-quotes.conf (fixture)
   status: ✅
 - **S9.2** Newlines and whitespace preserved literally — §Multi-line strings (L293)
-  tests: src/lexer.rs:770 (tokenizes_triple_quoted_strings); tests/testdata/hocon/equiv05/triple-quotes.conf (fixture)
-  status: ✅
+  tests: src/lexer.rs:770 (tokenizes_triple_quoted_strings); tests/s9_s13_lightbend_conformance.rs (leading-newline case); tests/testdata/hocon/equiv05/triple-quotes.conf (fixture)
+  status: ✅ — the lexer stripped a LEADING newline (spec deviation; Lightbend preserves every character between the quotes — probe 2026-08-18, surfaced by the py.hocon verification wave); fixed 2026-08-18. equiv05 has no leading-newline case, which is how the strip survived the fixture.
 - **S9.3** Unicode escapes NOT interpreted inside triple-quoted — §Multi-line strings (L294)
   tests: tests/testdata/hocon/equiv05/triple-quotes.conf (fixture)
   status: ✅
@@ -353,8 +353,8 @@ same item descriptions verbatim.
   tests: src/resolver/mod.rs:157 (drops_field_for_optional_missing); tests/testdata/hocon/equiv04/missing-substitutions.conf (fixture)
   status: ✅
 - **S13.12** Optional undefined in array element → element not added — §Substitutions (L635)
-  tests: tests/testdata/hocon/equiv04/missing-substitutions.conf (fixture)
-  status: ✅
+  tests: tests/s9_s13_lightbend_conformance.rs (element omitted; literal null kept; nested arrays; concat-element remainder)
+  status: ✅ — the previous ✅ was a stale citation: equiv04/missing-substitutions.conf contains no array-element case, and the resolver actually null-filled the element ([1, null, 3]; Lightbend yields [1, 3] — probe 2026-08-18, surfaced by the py.hocon verification wave). Fixed 2026-08-18.
 - **S13.13** Optional undefined in string concat → empty string — §Substitutions (L636)
   tests: tests/integration_test.rs:1041 (s13_13_optional_undefined_in_string_concat_is_empty)
   status: ✅

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -339,9 +339,6 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
                     col: sc,
                 });
             }
-            if value.starts_with('\n') {
-                value = value[1..].to_string();
-            }
             tokens.push(Token {
                 kind: TokenKind::TripleQuotedString,
                 value,
@@ -1008,9 +1005,12 @@ mod tests {
     }
 
     #[test]
-    fn strips_leading_newline_from_triple_quoted() {
+    fn preserves_leading_newline_in_triple_quoted() {
+        // S9.2: Lightbend preserves every character between the quotes
+        // (typesafe-config 1.4.6 probe, 2026-08-18); the old strip was a
+        // spec deviation shared by the ts/py/rs ports.
         let t = first("\"\"\"\nhello\"\"\"");
-        assert_eq!(t.value, "hello");
+        assert_eq!(t.value, "\nhello");
     }
 
     #[test]

--- a/src/resolver/substitution_resolver.rs
+++ b/src/resolver/substitution_resolver.rs
@@ -186,12 +186,16 @@ impl<'a> SubstitutionResolver<'a> {
             }
             ResolverValue::Obj(o) => self.resolve_res_obj(o).map(Some),
             ResolverValue::UnresolvedArray(items) => {
+                // S13.12 (HOCON.md L635): an element that resolves to nothing
+                // (an undefined optional substitution) is NOT added — Lightbend
+                // yields [1, 3] for `[1, ${?missing}, 3]`, never [1, null, 3].
+                // A literal `null` element resolves to a null scalar (Some),
+                // and is kept.
                 let mut resolved_items = Vec::new();
                 for item in items {
-                    let resolved = self
-                        .resolve_val(item, scope)?
-                        .unwrap_or(HoconValue::Scalar(ScalarValue::null()));
-                    resolved_items.push(resolved);
+                    if let Some(resolved) = self.resolve_val(item, scope)? {
+                        resolved_items.push(resolved);
+                    }
                 }
                 Ok(Some(HoconValue::Array(resolved_items)))
             }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -112,7 +112,10 @@ world"""
     "#,
     )
     .unwrap();
-    assert_eq!(config.get_string("msg").unwrap(), "hello\nworld");
+    // S9.2: the newline right after `"""` is content — Lightbend preserves
+    // every character between the quotes (the old leading-newline strip was
+    // a spec deviation, removed 2026-08-18).
+    assert_eq!(config.get_string("msg").unwrap(), "\nhello\nworld");
 }
 
 #[test]

--- a/tests/s9_s13_lightbend_conformance.rs
+++ b/tests/s9_s13_lightbend_conformance.rs
@@ -1,0 +1,57 @@
+#![cfg(feature = "serde")]
+
+// S9.2 + S13.12 — two Lightbend-conformance fixes surfaced by the py.hocon
+// spec-verification wave (2026-08-18). Both were shared ts/py/rs port bugs;
+// go.hocon conformed all along. Expected values verified against the
+// Lightbend oracle (typesafe-config 1.4.6 probes):
+//   - `"""<LF>hello"""` → "\nhello" (every character between the quotes is
+//     preserved; the lexer used to strip a leading newline)
+//   - `[1, ${?missing}, 3]` → [1, 3] (an undefined optional substitution in
+//     element position is NOT added; the resolver used to null-fill it).
+//     The prior ✅ cited equiv04/missing-substitutions.conf, which contains
+//     no array-element case — a stale citation.
+
+use serde_json::{json, Value};
+
+fn parse_json(src: &str) -> Value {
+    let cfg = hocon::parse(src).expect("parse should succeed");
+    cfg.deserialize().expect("deserialize should succeed")
+}
+
+#[test]
+fn s9_2_leading_newline_preserved() {
+    let v = parse_json("x = \"\"\"\nhello\"\"\"");
+    assert_eq!(v, json!({"x": "\nhello"}));
+}
+
+#[test]
+fn s9_2_inner_whitespace_still_preserved() {
+    let v = parse_json("x = \"\"\"a\n  b\"\"\"");
+    assert_eq!(v, json!({"x": "a\n  b"}));
+}
+
+#[test]
+fn s13_12_undefined_optional_element_omitted() {
+    let v = parse_json("arr = [1, ${?missing}, 3]");
+    assert_eq!(v, json!({"arr": [1, 3]}));
+}
+
+#[test]
+fn s13_12_literal_null_element_kept() {
+    let v = parse_json("arr = [1, null, 3]");
+    assert_eq!(v, json!({"arr": [1, null, 3]}));
+}
+
+#[test]
+fn s13_12_nested_arrays_drop_independently() {
+    let v = parse_json("arr = [[${?m}], [1]]");
+    assert_eq!(v, json!({"arr": [[], [1]]}));
+}
+
+#[test]
+fn s13_12_concat_element_keeps_literal_remainder() {
+    // S13.13 semantics inside the element: the optional contributes an empty
+    // string, so the element itself survives as the concatenated remainder.
+    let v = parse_json("arr = [${?m} foo]");
+    assert_eq!(v, json!({"arr": [" foo"]}));
+}


### PR DESCRIPTION
## Summary

Fixes **two port bugs shared by ts/py/rs** discovered by py.hocon's verification-pinning wave ([o3co/py.hocon#39](https://github.com/o3co/py.hocon/pull/39)) (go.hocon conformed from the start). Expected values are settled by a JVM probe of Lightbend (typesafe-config 1.4.6) (2026-08-18).

1. **S9.2**: the lexer was stripping the leading newline of `"""<LF>hello"""` → keep it (`"\nhello"`). The existing fixture equiv05 contains no leading-newline case, so it could not detect this. **BREAKING**
2. **S13.12**: the resolver was null-filling `[1, ${?missing}, 3]` into `[1, null, 3]` → omit the element (`[1, 3]`). The previous ✅ was a stale citation of equiv04, which **does not contain** an array-element case (the same shape of miscitation as S13a.12). Literal `null` elements are preserved. **BREAKING**

Same-window: py is py#39 (lockstep assuming it merges), and the other sibling gets a simultaneous PR. Once every sibling is merged, discriminating fixtures (triple-quote leading newline + subst array element) and a matrix correction will be submitted to xx.hocon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
