### PR TITLE
fix(s19,s21): exact unit-table alignment with Lightbend — kB case / PB-YB / drop the week unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **BREAKING (spec fix, S21.2–S21.3): byte units now match the Lightbend
+  reference exactly.** The kilo-decimal spelling is `kB` — the old `KB` key
+  (which Lightbend rejects) is now an error, and the case-sensitive table
+  gains the missing units: `PB`–`YB`, `PiB`–`YiB` (+ long forms) and
+  single-letter `Z`/`z`/`Y`/`y`; the bare byte unit gains its `b` spelling.
+  Multipliers past i64 (ZB, YB, Zi, Yi) route through the float path, where
+  any count ≥ 1 overflows exactly as it does in Lightbend (probe
+  2026-08-18). Part of the four-impl units audit.
+- **BREAKING (spec fix, S19): the duration parser no longer accepts
+  `w`/`week`/`weeks`.** The spec's duration unit list ends at days and the
+  Lightbend reference rejects `"1w"`; weeks remain valid in the Period
+  format (`get_period`), which matches Lightbend's `parsePeriod`.
+
 - **BREAKING (spec fix, S9.2): a triple-quoted string whose content starts
   with a newline now preserves it** (`"""<LF>hello"""` → `"\nhello"`, was
   `"hello"`). The lexer stripped the leading newline; the Lightbend reference

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -698,7 +698,7 @@ same item descriptions verbatim.
   tests: src/config.rs:756 (get_duration_hours); src/config.rs:774 (get_duration_fractional)
   status: ✅
 - **S19.7** `d` / `day` / `days` — §Duration format (L1313)
-  tests: src/config.rs:765 (get_duration_days); tests/integration_test.rs:211 (test_duration_missing_units); tests/spec_s21_lightbend_units.rs (week rejection)
+  tests: src/config.rs (get_duration_days); tests/integration_test.rs (test_duration_missing_units); tests/spec_s21_lightbend_units.rs (week rejection)
   status: ✅ — the table also carried an extra-spec `w`/`week`/`weeks` arm; removed 2026-08-18 (the spec's duration list ends at days and the Lightbend reference rejects `1w` — probe; weeks remain valid in the Period format, S20).
 - **S19.8** Duration unit names are case sensitive (lowercase only) — §Duration format (L1304)
   tests: tests/spec_phase5.rs (s19_8_spec_uppercase_ms_rejected; s19_8_spec_mixed_case_seconds_rejected; s19_8_spec_uppercase_single_letter_rejected; s19_8_lowercase_units_accepted)

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -698,8 +698,8 @@ same item descriptions verbatim.
   tests: src/config.rs:756 (get_duration_hours); src/config.rs:774 (get_duration_fractional)
   status: ✅
 - **S19.7** `d` / `day` / `days` — §Duration format (L1313)
-  tests: src/config.rs:765 (get_duration_days); tests/integration_test.rs:211 (test_duration_missing_units)
-  status: ✅
+  tests: src/config.rs:765 (get_duration_days); tests/integration_test.rs:211 (test_duration_missing_units); tests/spec_s21_lightbend_units.rs (week rejection)
+  status: ✅ — the table also carried an extra-spec `w`/`week`/`weeks` arm; removed 2026-08-18 (the spec's duration list ends at days and the Lightbend reference rejects `1w` — probe; weeks remain valid in the Period format, S20).
 - **S19.8** Duration unit names are case sensitive (lowercase only) — §Duration format (L1304)
   tests: tests/spec_phase5.rs (s19_8_spec_uppercase_ms_rejected; s19_8_spec_mixed_case_seconds_rejected; s19_8_spec_uppercase_single_letter_rejected; s19_8_lowercase_units_accepted)
   status: ✅
@@ -729,11 +729,11 @@ struct. ts and go remain ➖ (no period accessor).
   tests: src/config.rs:813 (get_bytes_plain)
   status: ✅
 - **S21.2** Powers of 10 (kB, MB, GB, TB, PB, EB, ZB, YB + long forms) — §Size in bytes format (L1365)
-  tests: src/config.rs:819 (get_bytes_kilobytes); src/config.rs:831 (get_bytes_megabytes); src/config.rs:843 (get_bytes_gigabytes); src/config.rs:855 (get_bytes_terabytes); src/config.rs:873 (get_bytes_long_unit)
-  status: ✅
+  tests: src/config.rs (get_bytes_kilobytes and siblings); tests/spec_s21_lightbend_units.rs (PB–YB, case-sensitivity)
+  status: ✅ — the prior ✅ over-claimed: the table stopped at TB and was keyed `KB`, which Lightbend rejects (its kilo-decimal spelling is `kB` — probe 2026-08-18, four-impl units audit). Aligned to the exact case-sensitive reference set; ZB/YB (multipliers past i64) route through the float path, where any count ≥ 1 overflows exactly as it does in Lightbend.
 - **S21.3** Powers of 2 (K/Ki/KiB, M/Mi/MiB, ...) — §Size in bytes format (L1376)
-  tests: src/config.rs:825 (get_bytes_kibibytes); src/config.rs:837 (get_bytes_mebibytes); src/config.rs:849 (get_bytes_gibibytes); src/config.rs:861 (get_bytes_tebibytes)
-  status: ✅
+  tests: src/config.rs (get_bytes_kibibytes and siblings); tests/spec_s21_lightbend_units.rs (Pi–Yi, `kiB`/`ki` rejected)
+  status: ✅ — extended 2026-08-18 through `Yi`/`YiB` + long forms, capital-first exactly per Lightbend.
 - **S21.4** Single-letter abbreviations → powers of 2 (java -Xmx convention) — §Size in bytes format (L1385)
   tests: tests/spec_s21_4_single_letter_bytes.rs (s21_4_1_k_uppercase_is_1024 through s21_4_12_kib_stays_binary); tests/conformance_bsl.rs (bsl01-bsl09); tests/units_default_test.rs (ub05_bytes_with_unit — updated to 1_048_576)
   status: ✅ (was ✅ mis-classified; prior ✅ cited get_bytes_no_space which exercised '512MB' multi-letter, never single-letter K/M/G/T; behavior corrected — BREAKING: K/M/G/T now binary per L1385 — Phase 6 #3h)

--- a/src/config.rs
+++ b/src/config.rs
@@ -475,7 +475,8 @@ impl Config {
     /// `us`/`micro`/`micros`/`microsecond`/`microseconds`,
     /// `ms`/`milli`/`millis`/`millisecond`/`milliseconds`,
     /// `s`/`second`/`seconds`, `m`/`minute`/`minutes`,
-    /// `h`/`hour`/`hours`, `d`/`day`/`days`, `w`/`week`/`weeks`.
+    /// `h`/`hour`/`hours`, `d`/`day`/`days`. (No week unit: the Lightbend
+    /// reference rejects `\"1w\"` — weeks exist only in the Period format.)
     ///
     /// Unit names are case-sensitive and must be lowercase (HOCON spec,
     /// S19.8): `"100 MS"` and `"100 Seconds"` are errors. This also applies
@@ -852,7 +853,10 @@ fn parse_duration(s: &str) -> Option<std::time::Duration> {
         "m" | "minute" | "minutes" => 60_000_000_000.0,
         "h" | "hour" | "hours" => 3_600_000_000_000.0,
         "d" | "day" | "days" => 86_400_000_000_000.0,
-        "w" | "week" | "weeks" => 604_800_000_000_000.0,
+        // NOTE: no week arm — HOCON's duration list ends at days, and the
+        // Lightbend reference rejects "1w" (probe 2026-08-18). Period (S20)
+        // is different: Lightbend's parsePeriod DOES accept weeks, and the
+        // period parser below keeps them.
         _ => return None,
     };
 
@@ -964,35 +968,58 @@ fn parse_bytes(s: &str) -> Option<i64> {
         return None;
     }
 
-    // Case-sensitive matching: KB vs KiB matters.
+    // S21.1–S21.4 — the EXACT Lightbend unit set (typesafe-config 1.4.6
+    // probe, 2026-08-18). Multi-letter units are case-sensitive: the
+    // kilo-decimal spelling is `kB` (KB/kb are errors), binary prefixes are
+    // capital-first (`Ki`, never `ki`), long forms are lowercase only. Only
+    // the bare byte unit (B/b) and the single-letter -Xmx forms accept both
+    // cases.
     //
-    // Single-letter abbreviations (K, M, G, T, P, E) map to **powers of two**
-    // per HOCON.md L1385: "single-character abbreviations ('128K') should go
-    // with… powers of two" — aligned with Lightbend typesafe-config 1.4.3.
-    //
-    // BREAKING (since 1.3.0): K/M/G/T were previously treated as SI decimal
-    // (1_000, 1_000_000, …). They are now binary (1_024, 1_048_576, …).
-    // Multi-letter forms KB/MB/GB/TB remain SI decimal (separate match arms).
-    // See CHANGELOG.md — S21.4 BREAKING entry.
+    // Single-letter abbreviations map to **powers of two** per HOCON.md
+    // L1385 (java -Xmx convention), BREAKING since 1.3.0 for K/M/G/T — see
+    // CHANGELOG.md.
     let multiplier: i64 = match unit_str {
-        "" | "B" | "byte" | "bytes" => 1,
-        // Single-letter → powers of two (HOCON.md L1385). BREAKING for K/M/G/T.
+        "" | "B" | "b" | "byte" | "bytes" => 1,
+        // Single-letter → powers of two (HOCON.md L1385). Z/z/Y/y are in the
+        // big-unit arm below (their multipliers exceed i64).
         "K" | "k" => 1_024,
         "M" | "m" => 1_048_576,
         "G" | "g" => 1_073_741_824,
         "T" | "t" => 1_099_511_627_776,
         "P" | "p" => 1_125_899_906_842_624,
         "E" | "e" => 1_152_921_504_606_846_976,
-        // Multi-letter SI decimal forms (unchanged).
-        "KB" | "kilobyte" | "kilobytes" => 1_000,
-        "KiB" | "Ki" | "kibibyte" | "kibibytes" => 1_024,
+        // Multi-letter forms: SI decimal + IEC binary, through E/Ei.
+        "kB" | "kilobyte" | "kilobytes" => 1_000,
+        "Ki" | "KiB" | "kibibyte" | "kibibytes" => 1_024,
         "MB" | "megabyte" | "megabytes" => 1_000_000,
-        "MiB" | "Mi" | "mebibyte" | "mebibytes" => 1_048_576,
+        "Mi" | "MiB" | "mebibyte" | "mebibytes" => 1_048_576,
         "GB" | "gigabyte" | "gigabytes" => 1_000_000_000,
-        "GiB" | "Gi" | "gibibyte" | "gibibytes" => 1_073_741_824,
+        "Gi" | "GiB" | "gibibyte" | "gibibytes" => 1_073_741_824,
         "TB" | "terabyte" | "terabytes" => 1_000_000_000_000,
-        "TiB" | "Ti" | "tebibyte" | "tebibytes" => 1_099_511_627_776,
-        _ => return None,
+        "Ti" | "TiB" | "tebibyte" | "tebibytes" => 1_099_511_627_776,
+        "PB" | "petabyte" | "petabytes" => 1_000_000_000_000_000,
+        "Pi" | "PiB" | "pebibyte" | "pebibytes" => 1_125_899_906_842_624,
+        "EB" | "exabyte" | "exabytes" => 1_000_000_000_000_000_000,
+        "Ei" | "EiB" | "exbibyte" | "exbibytes" => 1_152_921_504_606_846_976,
+        _ => {
+            // Units whose multiplier exceeds i64 (ZB=10^21, YB=10^24,
+            // Zi=2^70, Yi=2^80). Lightbend recognises them and range-errors
+            // on any result past the long ceiling, so an integer count ≥ 1
+            // can never survive — every valid use is fractional and goes
+            // through the float path with its overflow guard.
+            let big: f64 = match unit_str {
+                "ZB" | "zettabyte" | "zettabytes" => 1e21,
+                "Zi" | "ZiB" | "zebibyte" | "zebibytes" | "Z" | "z" => 2f64.powi(70),
+                "YB" | "yottabyte" | "yottabytes" => 1e24,
+                "Yi" | "YiB" | "yobibyte" | "yobibytes" | "Y" | "y" => 2f64.powi(80),
+                _ => return None,
+            };
+            let f: f64 = num_str.parse().ok()?;
+            if !f.is_finite() || f.abs() * big >= 2f64.powi(63) {
+                return None;
+            }
+            return Some((f * big) as i64);
+        }
     };
 
     // Integer fast-path: lossless, avoids any floating-point rounding.
@@ -1397,7 +1424,7 @@ mod tests {
 
     #[test]
     fn get_bytes_kilobytes() {
-        let c = make_config(vec![("s", sv("10 KB"))]);
+        let c = make_config(vec![("s", sv("10 kB"))]);
         assert_eq!(c.get_bytes("s").unwrap(), 10_000);
     }
 
@@ -1533,9 +1560,12 @@ mod tests {
     // ──────────────────────────────────────────────────────────────
 
     #[test]
-    fn parse_duration_integer_overflow_weeks_is_none() {
-        // i64::MAX weeks would require ~5.6e33 nanos, far past u64::MAX.
-        assert!(parse_duration("9223372036854775807 weeks").is_none());
+    fn parse_duration_weeks_rejected() {
+        // No week unit in HOCON durations: the Lightbend reference rejects
+        // "1w" (probe 2026-08-18); weeks exist only in the Period format.
+        assert!(parse_duration("1w").is_none());
+        assert!(parse_duration("1week").is_none());
+        assert!(parse_duration("1 weeks").is_none());
     }
 
     #[test]
@@ -1566,8 +1596,8 @@ mod tests {
 
     #[test]
     fn parse_duration_fractional_succeeds_below_boundary() {
-        // 1.5 weeks = ~907_200_000_000_000 ns, well within u64.
-        let d = parse_duration("1.5w").unwrap();
+        // 10.5 days = 907_200_000_000_000 ns, well within u64.
+        let d = parse_duration("10.5d").unwrap();
         assert_eq!(d.as_nanos(), 907_200_000_000_000u128);
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -476,7 +476,7 @@ impl Config {
     /// `ms`/`milli`/`millis`/`millisecond`/`milliseconds`,
     /// `s`/`second`/`seconds`, `m`/`minute`/`minutes`,
     /// `h`/`hour`/`hours`, `d`/`day`/`days`. (No week unit: the Lightbend
-    /// reference rejects `\"1w\"` — weeks exist only in the Period format.)
+    /// reference rejects `"1w"` — weeks exist only in the Period format.)
     ///
     /// Unit names are case-sensitive and must be lowercase (HOCON spec,
     /// S19.8): `"100 MS"` and `"100 Seconds"` are errors. This also applies

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -225,7 +225,6 @@ fn test_duration_missing_units() {
         ("dur = 1 microsecond", "dur", 1_000u128),
         ("dur = 1 millis", "dur", 1_000_000u128),
         ("dur = 1 millisecond", "dur", 1_000_000u128),
-        ("dur = 1w", "dur", 604_800_000_000_000u128),
     ];
     for (input, path, expected_nanos) in tests {
         let cfg = hocon::parse(input).unwrap();

--- a/tests/spec_s21_4_single_letter_bytes.rs
+++ b/tests/spec_s21_4_single_letter_bytes.rs
@@ -168,9 +168,9 @@ fn s21_4_f4_7e_succeeds() {
 #[test]
 fn s21_4_11_kb_stays_si_decimal() {
     assert_eq!(
-        parse_bytes_str("1KB").unwrap(),
+        parse_bytes_str("1kB").unwrap(),
         1_000,
-        "S21.4 (regression): 'KB' multi-letter must remain SI decimal 1000"
+        "S21.4 (regression): 'kB' multi-letter must remain SI decimal 1000"
     );
 }
 

--- a/tests/spec_s21_lightbend_units.rs
+++ b/tests/spec_s21_lightbend_units.rs
@@ -1,0 +1,92 @@
+// S19 / S21.2–S21.4 — unit-table alignment with the Lightbend reference
+// (typesafe-config 1.4.6 probes, 2026-08-18), part of the four-impl units
+// audit the py.hocon verification wave triggered. rs-specific deltas: the
+// duration table carried an extra-spec `w`/`week`/`weeks` unit (Lightbend
+// rejects `1w`; weeks exist only in the Period format), the byte table was
+// keyed `KB` (the reference's kilo-decimal spelling is `kB`) and stopped at
+// TiB.
+
+fn bytes_of(lit: &str) -> Option<i64> {
+    let cfg = hocon::parse(&format!("v = \"{lit}\"")).expect("parse should succeed");
+    cfg.get_bytes("v").ok()
+}
+
+fn duration_ok(lit: &str) -> bool {
+    let cfg = hocon::parse(&format!("v = \"{lit}\"")).expect("parse should succeed");
+    cfg.get_duration("v").is_ok()
+}
+
+#[test]
+fn s19_no_week_unit_in_durations() {
+    for lit in ["1w", "1week", "1weeks", "1 w"] {
+        assert!(!duration_ok(lit), "{lit}: durations have no week unit");
+    }
+    // Period keeps weeks (Lightbend's parsePeriod accepts them).
+    let cfg = hocon::parse("v = \"2w\"").unwrap();
+    assert_eq!(cfg.get_period("v").unwrap().days, 14);
+}
+
+#[test]
+fn s21_2_decimal_units_through_yb() {
+    for (lit, want) in [
+        ("1kB", 1_000i64),
+        ("1PB", 1_000_000_000_000_000),
+        ("1petabytes", 1_000_000_000_000_000),
+        ("1EB", 1_000_000_000_000_000_000),
+        ("0.000001ZB", 1_000_000_000_000_000),
+        ("0.000000001YB", 1_000_000_000_000_000),
+        ("0.000001zettabytes", 1_000_000_000_000_000),
+    ] {
+        assert_eq!(bytes_of(lit), Some(want), "{lit}");
+    }
+    // ZB/YB counts >= 1 exceed i64 — Lightbend range-errors, and so do we.
+    assert_eq!(bytes_of("1ZB"), None);
+    assert_eq!(bytes_of("1YB"), None);
+}
+
+#[test]
+fn s21_3_binary_units_through_yi() {
+    for (lit, want) in [
+        ("1Pi", 1i64 << 50),
+        ("1PiB", 1i64 << 50),
+        ("1pebibytes", 1i64 << 50),
+        ("1Ei", 1i64 << 60),
+        ("0.000001Zi", (1e-6 * 2f64.powi(70)) as i64),
+        ("0.000000001Yi", (1e-9 * 2f64.powi(80)) as i64),
+    ] {
+        assert_eq!(bytes_of(lit), Some(want), "{lit}");
+    }
+}
+
+#[test]
+fn s21_4_single_letters_through_y() {
+    for lit in ["1Z", "1z", "1Y", "1y"] {
+        assert_eq!(bytes_of(lit), None, "{lit}: count 1 overflows i64");
+    }
+    let want = (1e-6 * 2f64.powi(70)) as i64;
+    assert_eq!(bytes_of("0.000001Z"), Some(want));
+    assert_eq!(bytes_of("0.000001z"), Some(want));
+}
+
+#[test]
+fn s21_lightbend_case_sensitivity() {
+    // Lightbend's unit table is case-sensitive: kB parses, these do not.
+    for lit in [
+        "1KB",
+        "1kb",
+        "1Kb",
+        "1mB",
+        "1Kilobyte",
+        "1MEGABYTES",
+        "1kiB",
+        "1ki",
+        "1Byte",
+    ] {
+        assert_eq!(bytes_of(lit), None, "{lit}: must be rejected");
+    }
+    // The two-case exceptions: the bare byte unit and the single letters.
+    assert_eq!(bytes_of("1B"), Some(1));
+    assert_eq!(bytes_of("1b"), Some(1));
+    assert_eq!(bytes_of("1K"), Some(1024));
+    assert_eq!(bytes_of("1k"), Some(1024));
+}


### PR DESCRIPTION
## Summary

**Four-implementation units audit** — horizontal rollout of the findings from the py verification-pinning wave. With the JVM probe of Lightbend (typesafe-config 1.4.6) (2026-08-18) as the authority, bring the duration/byte unit tables into exact alignment with the reference.

Lightbend's accepted set (settled by probe):
- kilo-decimal is **`kB` only** (`KB`/`kb`/`Kb` are errors). Decimal covers `MB`–`YB`; long forms are lowercase only (`Kilobyte` is an error)
- Binary is capital-first `Ki`/`KiB`–`Yi`/`YiB` (`kiB`/`ki` are errors)
- Both cases are accepted only for the bare byte unit (`B`/`b`) and the single-letter -Xmx forms (`K`/`k`–`Y`/`y`)
- Durations have **no week** (`1w` is an error; week exists only in the Period format)
- ZB/YB/Zi/Yi are recognized as units, and results exceeding long/int64 are range errors (a count ≥1 always overflows; only fractional values are valid)

Same-window: 4 PRs across go / ts / rs / py. xx matrix update after merge. BREAKING ships with v1.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
