### PR TITLE
feat(adapters): json5 — JSON5 1.0.0 ingestion, hand-rolled scanner with zero dependencies (F3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`adapters::json5` — JSON5 documents mounted as HOCON (spec F3.3).** The
+  accepted grammar is JSON5 1.0.0 as defined by the reference implementation
+  (the json5 npm package), the dialect owner F3.3 tracks. A hand-rolled
+  scanner and recursive-descent parser behind the new `adapters-json5`
+  feature, with zero extra dependencies — JSON5 changes the token grammar
+  itself (identifier keys, single quotes, hex integers, line continuations),
+  so the JSONC comment-stripping approach cannot apply. Where the mapping
+  spec is stricter than JSON5 the spec wins: hex and decimal integers must
+  fit in `i64` (F0.5), `Infinity`/`NaN` in every spelling are errors (F0.6),
+  an unpaired `\uXXXX` surrogate is an error and a valid pair combines
+  (F3.5), and duplicate keys follow HOCON semantics — objects merge,
+  otherwise last-wins (F0.7). Nesting is capped at the core parser's 128
+  levels (rs-specific: a stack overflow aborts the process). Lands in
+  lockstep with go.hocon#193 and the ts.hocon / py.hocon ports.
 - `hocon::from_str::<T>()` and `hocon::from_file::<T>()` (`serde` feature) —
   one-step parse + deserialize into any `serde::Deserialize` type, the
   `serde_json::from_str` shape. Substitutions resolve against the process

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,10 @@ serde = ["dep:serde", "dep:serde_json"]
 include-package = []
 
 # Format adapters. Each is opt-in so the default build still depends on
-# indexmap alone; properties and env need nothing extra.
+# indexmap alone; properties, env and json5 need nothing extra.
 adapters-properties = []
 adapters-env = []
+adapters-json5 = []
 adapters-jsonc = ["dep:serde_json"]
 adapters-toml = ["dep:toml"]
 adapters-yaml = ["dep:yaml-rust2"]
@@ -36,6 +37,7 @@ adapters-yaml = ["dep:yaml-rust2"]
 adapters = [
     "adapters-properties",
     "adapters-env",
+    "adapters-json5",
     "adapters-jsonc",
     "adapters-toml",
     "adapters-yaml",

--- a/README.md
+++ b/README.md
@@ -468,16 +468,17 @@ Deferring resolution matters: the plain `parse` resolves as it goes, so a
 | --- | --- | --- |
 | `adapters-properties` | `java.util.Properties`, sharing the `include` syntax layer | — |
 | `adapters-env` | Bulk-mounts a prefixed namespace; also reads `.env` | — |
+| `adapters-json5` | JSON5 documents (JSON5 1.0.0, hand-rolled scanner) | — |
 | `adapters-jsonc` | JSON with comments and trailing commas | `serde_json` |
 | `adapters-toml` | TOML documents | `toml` |
 | `adapters-yaml` | YAML documents | `yaml-rust2` |
 
-`adapters` enables all five. Every one is opt-in, so the default build still
+`adapters` enables all six. Every one is opt-in, so the default build still
 depends on `indexmap` alone. Plain JSON needs no adapter — HOCON is a JSON
 superset, so `hocon::parse` accepts it as it stands.
 
 ```sh
-cargo add hocon-parser --features adapters        # all five
+cargo add hocon-parser --features adapters        # all six
 cargo add hocon-parser --features adapters-env    # or just the one you need
 ```
 
@@ -522,6 +523,18 @@ splice its neighbors together:
 ```jsonc
 {"a": 1/*x*/2}   // syntax error — NOT the number 12
 ```
+
+### JSON5 is scanned, not preprocessed
+
+JSON5 changes the token grammar itself — unquoted identifier keys, single
+quotes, hex integers, line continuations — so `adapters::json5` is a
+hand-rolled scanner and recursive-descent parser rather than a preprocessor in
+front of a JSON decoder, and needs no extra dependency. The accepted grammar
+is JSON5 1.0.0 as defined by the reference implementation (the json5 npm
+package). Where the mapping spec is stricter than JSON5, the spec wins:
+integers must fit in `i64` (F0.5), `Infinity`/`NaN` are errors (F0.6), a lone
+`\uXXXX` surrogate is an error (F3.5), and duplicate keys follow HOCON
+semantics — objects merge, otherwise the later value wins (F0.7).
 
 ### YAML scalar resolution is the library's answer
 

--- a/src/adapters/json5.rs
+++ b/src/adapters/json5.rs
@@ -68,7 +68,8 @@ pub fn parse_file(path: impl AsRef<std::path::Path>) -> Result<Config, AdapterEr
     let path = path.as_ref();
     let text = std::fs::read_to_string(path)
         .map_err(|e| AdapterError::new(format!("json5: {}: {e}", path.display())))?;
-    parse(&text, Some(&path.display().to_string()))
+    let origin = path.display().to_string();
+    parse(&text, Some(origin.as_str()))
 }
 
 fn adapter_err(origin: Option<&str>, msg: &str) -> AdapterError {
@@ -655,7 +656,22 @@ impl<'a> Parser<'a> {
         }
         let text = &src[start..self.pos];
         if !saw_digit {
-            return Err(self.err(format!("malformed number {text:?}")));
+            // Extend the reported token past the sign so `+foo` reports
+            // "+foo", not a bare "+" (identifier chars only; no state change
+            // beyond the error path).
+            let mut end = self.pos;
+            while end < src.len() {
+                let Some(c) = src[end..].chars().next() else {
+                    break;
+                };
+                if c.is_alphanumeric() || c == '_' || c == '$' {
+                    end += c.len_utf8();
+                } else {
+                    break;
+                }
+            }
+            let shown = &src[start..end];
+            return Err(self.err(format!("malformed number {shown:?}")));
         }
         // F0.5: '.', 'e', 'E' make a float; everything else is an i64 or an
         // error. The leading '+' is stripped for str::parse's sake.

--- a/src/adapters/json5.rs
+++ b/src/adapters/json5.rs
@@ -1,0 +1,686 @@
+//! JSON5 (<https://json5.org>, spec 1.0.0) as HOCON config.
+//!
+//! Unlike the jsonc adapter — which strips comments and hands the rest to
+//! `serde_json` — JSON5 changes the token grammar itself (unquoted identifier
+//! keys, single-quoted strings with line continuations, hex integers, leading
+//! and trailing decimal points, an explicit plus sign), so this module is a
+//! hand-rolled scanner and recursive-descent parser. Zero extra dependencies.
+//!
+//! The accepted grammar is JSON5 1.0.0 as defined by the reference
+//! implementation (the json5 npm package), the dialect owner this spec item
+//! tracks — the same ownership rule F3.2 applies to JSONC. Where the mapping
+//! spec is stricter than JSON5, the spec wins:
+//!
+//! - Infinity and NaN (signed or bare) are errors, not values (spec F0.6).
+//! - Integers — decimal or hex — must fit in i64 (spec F0.5); floats decode
+//!   as f64. A number written with `.`, `e` or `E` is a float, all other
+//!   decimal forms and every hex form are integers.
+//! - An unpaired `\uXXXX` surrogate is an error, and a valid pair combines
+//!   into the astral codepoint (spec F3.5).
+//! - Duplicate keys follow HOCON semantics: objects merge, otherwise the
+//!   later value wins (spec F0.7).
+//! - The document holds exactly one value; whitespace and comments may follow
+//!   it, anything else is an error (the F3.2 strictness rule).
+//!
+//! One divergence this implementation adds, shared with the crate's core
+//! parser rather than with the go adapter: nesting is capped at
+//! [`MAX_DOCUMENT_DEPTH`] levels, because a Rust stack overflow is `SIGABRT`
+//! and cannot be converted into an `Err` after the fact.
+//!
+//! See the F3.x items in the format-ingestion mapping spec:
+//! <https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md>
+
+use indexmap::IndexMap;
+
+use super::{config_from_object, AdapterError};
+use crate::depth::MAX_DOCUMENT_DEPTH;
+use crate::value::{HoconValue, ScalarValue};
+use crate::Config;
+
+/// Read JSON5 text. `origin` names the source in error messages; `None`
+/// reports it as "document".
+pub fn parse(input: &str, origin: Option<&str>) -> Result<Config, AdapterError> {
+    // F0.9: a leading BOM is not data. (JSON5 additionally treats U+FEFF as
+    // whitespace anywhere, which the scanner handles; stripping here keeps
+    // the origin column of the first token honest.)
+    let src = super::strip_bom(input);
+    let mut p = Parser {
+        src,
+        pos: 0,
+        line: 0,
+        line_at: 0,
+    };
+    let doc = p
+        .parse_document()
+        .map_err(|msg| adapter_err(origin, &msg))?;
+    match doc {
+        HoconValue::Object(_) => Ok(config_from_object(doc, origin)),
+        // F0.3: the root has to be an object, like every other adapter.
+        _ => Err(adapter_err(
+            origin,
+            "document root must be an object (spec F0.3)",
+        )),
+    }
+}
+
+/// Read a JSON5 file, using its path as the origin description.
+pub fn parse_file(path: impl AsRef<std::path::Path>) -> Result<Config, AdapterError> {
+    let path = path.as_ref();
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| AdapterError::new(format!("json5: {}: {e}", path.display())))?;
+    parse(&text, Some(&path.display().to_string()))
+}
+
+fn adapter_err(origin: Option<&str>, msg: &str) -> AdapterError {
+    AdapterError::new(format!("json5: {}: {msg}", origin.unwrap_or("document")))
+}
+
+// ---------------------------------------------------------------------------
+// Scanner / parser
+// ---------------------------------------------------------------------------
+
+struct Parser<'a> {
+    src: &'a str,
+    pos: usize,     // byte offset; always a char boundary by construction
+    line: usize,    // 0-based; reported 1-based
+    line_at: usize, // byte offset where the current line starts
+}
+
+/// The JSON5 LineTerminator set: LF, CR, LS, PS. This deliberately differs
+/// from JSONC (F3.2), whose dialect owner ends `//` comments at LF/CR only —
+/// the JSON5 spec includes LS and PS.
+fn is_line_terminator(c: char) -> bool {
+    matches!(c, '\n' | '\r' | '\u{2028}' | '\u{2029}')
+}
+
+/// The JSON5 WhiteSpace set: TAB, VT, FF, SP, NBSP, BOM, and any Unicode Zs
+/// character.
+///
+/// std has no Zs predicate, but `char::is_whitespace` is the Unicode
+/// `White_Space` property, and `White_Space` = Zs ∪ {TAB, LF, VT, FF, CR,
+/// NEL, LS, PS} exactly — so subtracting the enumerated non-Zs members gives
+/// the precise Zs set, no approximation. NEL (U+0085) is neither JSON5
+/// whitespace nor a JSON5 line terminator, so it must fall out here and
+/// surface as an unexpected character.
+fn is_json5_space(c: char) -> bool {
+    matches!(
+        c,
+        '\t' | '\u{000b}' | '\u{000c}' | ' ' | '\u{00a0}' | '\u{feff}'
+    ) || (c.is_whitespace() && !matches!(c, '\n' | '\r' | '\u{0085}' | '\u{2028}' | '\u{2029}'))
+}
+
+/// ES5 IdentifierName characters, the key grammar the JSON5 spec adopts:
+/// start = UnicodeLetter (Lu Ll Lt Lm Lo Nl) | `$` | `_`; continue adds
+/// Mn Mc Nd Pc and ZWNJ/ZWJ.
+///
+/// The crate carries no Unicode category tables and this adapter deliberately
+/// adds no dependency, so the checks are built from std's char methods, which
+/// expose Unicode *properties* rather than general categories. The deviations
+/// from the exact ES5 sets (which the go implementation gets from
+/// `unicode.In`) are:
+///
+/// - `char::is_alphabetic` is the `Alphabetic` property =
+///   Lu∪Ll∪Lt∪Lm∪Lo∪Nl ∪ Other_Alphabetic. The first six are exactly ES5's
+///   letter set, so the divergence is Other_Alphabetic — a few hundred
+///   combining marks (e.g. U+0345, Indic matras). Those are Mn/Mc and hence
+///   legal *continue* characters anyway; the lenient divergence is accepting
+///   them as the *first* character of a key, which go rejects.
+/// - `char::is_numeric` is Nd∪Nl∪No. Nd is what ES5 wants and Nl is already a
+///   legal letter; the lenient divergence is accepting No characters (e.g.
+///   `²`, `½`) in the continue position, which go rejects.
+/// - Pc is ten stable codepoints, matched exactly (`_` via the start set).
+/// - Mn/Mc marks *outside* Other_Alphabetic — e.g. the plain combining
+///   accents U+0300..U+036F — are **rejected** in the continue position where
+///   go accepts them: the one strict divergence. A key that needs one can be
+///   quoted.
+///
+/// Every deviation therefore affects only which *unquoted* keys are accepted,
+/// never how an accepted document decodes.
+fn is_ident_start(c: char) -> bool {
+    c == '$' || c == '_' || c.is_alphabetic()
+}
+
+fn is_ident_part(c: char) -> bool {
+    is_ident_start(c)
+        || c == '\u{200c}'
+        || c == '\u{200d}'
+        || c.is_numeric()
+        || matches!(
+            c,
+            // Pc (connector punctuation) minus '_', in full.
+            '\u{203f}'
+                | '\u{2040}'
+                | '\u{2054}'
+                | '\u{fe33}'
+                | '\u{fe34}'
+                | '\u{fe4d}'
+                | '\u{fe4e}'
+                | '\u{fe4f}'
+                | '\u{ff3f}'
+        )
+}
+
+/// Whether `s` continues with an identifier character at byte offset `i` —
+/// used to reject tokens like `nullx` and to give `Infinityx` the ordinary
+/// unexpected-token error rather than the F0.6 one.
+fn continues_identifier(s: &str, i: usize) -> bool {
+    s[i..].chars().next().is_some_and(is_ident_part)
+}
+
+/// Merge `src` over `dst` per HOCON duplicate-key semantics (F0.7), returning
+/// a new map.
+fn merge_objects(
+    dst: &IndexMap<String, HoconValue>,
+    src: &IndexMap<String, HoconValue>,
+) -> IndexMap<String, HoconValue> {
+    let mut out = dst.clone();
+    for (k, v) in src {
+        let merged = match (out.get(k), v) {
+            (Some(HoconValue::Object(po)), HoconValue::Object(vo)) => {
+                HoconValue::Object(merge_objects(po, vo))
+            }
+            _ => v.clone(),
+        };
+        out.insert(k.clone(), merged);
+    }
+    out
+}
+
+impl<'a> Parser<'a> {
+    fn err(&self, msg: impl std::fmt::Display) -> String {
+        let col = self.src[self.line_at..self.pos].chars().count() + 1;
+        format!("line {} col {}: {msg}", self.line + 1, col)
+    }
+
+    /// The char at `pos`, without advancing.
+    fn peek(&self) -> Option<char> {
+        self.src[self.pos..].chars().next()
+    }
+
+    /// The byte at offset `pos + ahead`, if any.
+    fn byte_at(&self, ahead: usize) -> Option<u8> {
+        self.src.as_bytes().get(self.pos + ahead).copied()
+    }
+
+    fn advance(&mut self, c: char) {
+        self.pos += c.len_utf8();
+        if is_line_terminator(c) {
+            // Treat CRLF as one terminator for line counting.
+            if c == '\r' && self.byte_at(0) == Some(b'\n') {
+                self.pos += 1;
+            }
+            self.line += 1;
+            self.line_at = self.pos;
+        }
+    }
+
+    /// Parse exactly one JSON5 value, allowing only whitespace and comments
+    /// after it (the F3.2 strictness rule).
+    fn parse_document(&mut self) -> Result<HoconValue, String> {
+        self.skip_space()?;
+        let v = self.parse_value(0)?;
+        self.skip_space()?;
+        if self.pos < self.src.len() {
+            return Err(self.err("unexpected content after top-level value"));
+        }
+        Ok(v)
+    }
+
+    /// Consume whitespace, line terminators, and both comment forms.
+    fn skip_space(&mut self) -> Result<(), String> {
+        while let Some(c) = self.peek() {
+            if is_json5_space(c) || is_line_terminator(c) {
+                self.advance(c);
+            } else if c == '/' && self.byte_at(1) == Some(b'/') {
+                self.pos += 2;
+                // A LS or PS terminates a // comment too (unlike JSONC).
+                while let Some(c2) = self.peek() {
+                    if is_line_terminator(c2) {
+                        break;
+                    }
+                    self.pos += c2.len_utf8();
+                }
+            } else if c == '/' && self.byte_at(1) == Some(b'*') {
+                self.pos += 2;
+                let mut closed = false;
+                while let Some(c2) = self.peek() {
+                    if c2 == '*' && self.byte_at(1) == Some(b'/') {
+                        self.pos += 2;
+                        closed = true;
+                        break;
+                    }
+                    self.advance(c2);
+                }
+                if !closed {
+                    return Err(self.err("unterminated /* comment"));
+                }
+            } else {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn parse_value(&mut self, depth: usize) -> Result<HoconValue, String> {
+        let Some(c) = self.peek() else {
+            return Err(self.err("unexpected end of input, expected a value"));
+        };
+        match c {
+            '{' => self.parse_object(depth),
+            '[' => self.parse_array(depth),
+            '"' | '\'' => Ok(HoconValue::Scalar(ScalarValue::string(
+                self.parse_string(c)?,
+            ))),
+            '+' | '-' | '.' | '0'..='9' => self.parse_number(),
+            _ => self.parse_keyword(),
+        }
+    }
+
+    /// Handle true/false/null and reject Infinity/NaN by name so the error
+    /// explains itself (spec F0.6).
+    fn parse_keyword(&mut self) -> Result<HoconValue, String> {
+        let rest = &self.src[self.pos..];
+        for (kw, v) in [
+            ("true", HoconValue::Scalar(ScalarValue::boolean(true))),
+            ("false", HoconValue::Scalar(ScalarValue::boolean(false))),
+            ("null", HoconValue::Scalar(ScalarValue::null())),
+        ] {
+            if rest.starts_with(kw) && !continues_identifier(rest, kw.len()) {
+                self.pos += kw.len();
+                return Ok(v);
+            }
+        }
+        for kw in ["Infinity", "NaN"] {
+            if rest.starts_with(kw) && !continues_identifier(rest, kw.len()) {
+                return Err(self.err(format!(
+                    "{kw} is not representable in the HOCON number model (spec F0.6)"
+                )));
+            }
+        }
+        let c = rest.chars().next().expect("parse_value checked non-empty");
+        Err(self.err(format!("unexpected character {c:?}")))
+    }
+
+    /// Refuse to open a container beyond [`MAX_DOCUMENT_DEPTH`] — the same
+    /// cap and reasoning as the core parser: exhausting the stack in Rust
+    /// aborts the process rather than raising.
+    fn check_depth(&self, depth: usize) -> Result<(), String> {
+        if depth >= MAX_DOCUMENT_DEPTH {
+            return Err(self.err(format!(
+                "document nests deeper than {MAX_DOCUMENT_DEPTH} levels; this \
+                 limit exists because exhausting the stack in Rust aborts the \
+                 process rather than raising"
+            )));
+        }
+        Ok(())
+    }
+
+    fn parse_object(&mut self, depth: usize) -> Result<HoconValue, String> {
+        self.check_depth(depth)?;
+        self.pos += 1; // '{'
+        let mut obj: IndexMap<String, HoconValue> = IndexMap::new();
+        loop {
+            self.skip_space()?;
+            let Some(c) = self.peek() else {
+                return Err(self.err("unterminated object, expected '}'"));
+            };
+            if c == '}' {
+                self.pos += 1;
+                return Ok(HoconValue::Object(obj));
+            }
+            let key = self.parse_member_name()?;
+            self.skip_space()?;
+            if self.peek() != Some(':') {
+                return Err(self.err(format!("expected ':' after object key {key:?}")));
+            }
+            self.pos += 1;
+            self.skip_space()?;
+            let mut val = self.parse_value(depth + 1)?;
+            // F0.7: duplicate keys follow HOCON semantics — two objects
+            // merge, any other combination is last-wins.
+            if let (Some(HoconValue::Object(po)), HoconValue::Object(vo)) = (obj.get(&key), &val) {
+                val = HoconValue::Object(merge_objects(po, vo));
+            }
+            obj.insert(key, val);
+            self.skip_space()?;
+            match self.peek() {
+                None => return Err(self.err("unterminated object, expected ',' or '}'")),
+                Some(',') => self.pos += 1, // trailing comma before '}' is legal
+                Some('}') => {
+                    self.pos += 1;
+                    return Ok(HoconValue::Object(obj));
+                }
+                Some(_) => return Err(self.err("expected ',' or '}' in object")),
+            }
+        }
+    }
+
+    fn parse_array(&mut self, depth: usize) -> Result<HoconValue, String> {
+        self.check_depth(depth)?;
+        self.pos += 1; // '['
+        let mut arr: Vec<HoconValue> = Vec::new();
+        loop {
+            self.skip_space()?;
+            let Some(c) = self.peek() else {
+                return Err(self.err("unterminated array, expected ']'"));
+            };
+            if c == ']' {
+                self.pos += 1;
+                return Ok(HoconValue::Array(arr));
+            }
+            arr.push(self.parse_value(depth + 1)?);
+            self.skip_space()?;
+            match self.peek() {
+                None => return Err(self.err("unterminated array, expected ',' or ']'")),
+                Some(',') => self.pos += 1, // trailing comma before ']' is legal
+                Some(']') => {
+                    self.pos += 1;
+                    return Ok(HoconValue::Array(arr));
+                }
+                Some(_) => return Err(self.err("expected ',' or ']' in array")),
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Member names (quoted or ES5 IdentifierName)
+    // -----------------------------------------------------------------------
+
+    fn parse_member_name(&mut self) -> Result<String, String> {
+        match self.peek() {
+            Some(c @ ('"' | '\'')) => self.parse_string(c),
+            _ => self.parse_identifier(),
+        }
+    }
+
+    /// Scan an ES5 IdentifierName, honouring `\uXXXX` escapes in the name
+    /// (the escaped codepoint must itself be a legal identifier character for
+    /// its position, per ES5 — `1` cannot start a key; a surrogate escape is
+    /// never a legal identifier character).
+    fn parse_identifier(&mut self) -> Result<String, String> {
+        let mut out = String::new();
+        let mut first = true;
+        while let Some(c) = self.peek() {
+            let (ch, escaped) = if c == '\\' {
+                if self.byte_at(1) != Some(b'u') {
+                    return Err(self.err("only \\uXXXX escapes are allowed in identifiers"));
+                }
+                self.pos += 2;
+                let cp = self.read_hex4()?;
+                match char::from_u32(cp) {
+                    Some(ch) => (ch, true),
+                    // A surrogate half: not a char, and never a legal
+                    // identifier character in go either.
+                    None => {
+                        return Err(self.err(format!(
+                            "escape \\u{cp:04X} is not a valid identifier character here"
+                        )))
+                    }
+                }
+            } else {
+                (c, false)
+            };
+            let legal = if first {
+                is_ident_start(ch)
+            } else {
+                is_ident_part(ch)
+            };
+            if !legal {
+                if escaped {
+                    return Err(self.err(format!(
+                        "escape \\u{:04X} is not a valid identifier character here",
+                        ch as u32
+                    )));
+                }
+                if first {
+                    return Err(self.err(format!("expected an object key, got {ch:?}")));
+                }
+                break;
+            }
+            out.push(ch);
+            if !escaped {
+                self.pos += ch.len_utf8();
+            }
+            first = false;
+        }
+        if out.is_empty() {
+            return Err(self.err("expected an object key"));
+        }
+        Ok(out)
+    }
+
+    /// Read exactly four hex digits at `pos` and return the codepoint value
+    /// (which may be a surrogate half — the callers decide what that means).
+    fn read_hex4(&mut self) -> Result<u32, String> {
+        let bytes = &self.src.as_bytes()[self.pos..];
+        if bytes.len() < 4 {
+            return Err(self.err("truncated \\u escape"));
+        }
+        let mut n: u32 = 0;
+        for &b in &bytes[..4] {
+            let Some(d) = (b as char).to_digit(16) else {
+                let quad = String::from_utf8_lossy(&bytes[..4]);
+                return Err(self.err(format!("invalid \\u escape {:?}", format!("\\u{quad}"))));
+            };
+            n = n * 16 + d;
+        }
+        self.pos += 4;
+        Ok(n)
+    }
+
+    // -----------------------------------------------------------------------
+    // Strings
+    // -----------------------------------------------------------------------
+
+    /// Scan a single- or double-quoted JSON5 string; `quote` is the opening
+    /// quote. JSON5 differences from JSON: either quote character, `\xHH`
+    /// escapes, `\v`, `\0`, line continuations (backslash before a line
+    /// terminator, including CRLF as one), any other non-digit character
+    /// escaping to itself, and unescaped LS/PS allowed inside the string.
+    fn parse_string(&mut self, quote: char) -> Result<String, String> {
+        self.pos += 1; // opening quote
+        let mut out = String::new();
+        loop {
+            let Some(c) = self.peek() else {
+                return Err(self.err("unterminated string"));
+            };
+            match c {
+                _ if c == quote => {
+                    self.pos += 1;
+                    return Ok(out);
+                }
+                '\n' | '\r' => return Err(self.err("unescaped line terminator in string")),
+                '\\' => {
+                    self.pos += 1;
+                    self.read_escape(&mut out)?;
+                }
+                // LS/PS are legal unescaped inside JSON5 strings.
+                _ => {
+                    out.push(c);
+                    self.advance(c);
+                }
+            }
+        }
+    }
+
+    /// Consume one escape sequence (the backslash is already consumed) and
+    /// append its value to `out`.
+    fn read_escape(&mut self, out: &mut String) -> Result<(), String> {
+        let Some(c) = self.peek() else {
+            return Err(self.err("unterminated escape sequence"));
+        };
+        // Line continuation: backslash before a line terminator joins the
+        // lines, contributing nothing. CRLF counts as one terminator.
+        if is_line_terminator(c) {
+            self.advance(c);
+            return Ok(());
+        }
+        match c {
+            'n' => out.push('\n'),
+            't' => out.push('\t'),
+            'r' => out.push('\r'),
+            'b' => out.push('\u{0008}'),
+            'f' => out.push('\u{000c}'),
+            'v' => out.push('\u{000b}'),
+            '0' => {
+                // \0 is NUL unless followed by a decimal digit (octal escapes
+                // are not part of JSON5).
+                if matches!(self.byte_at(1), Some(b'0'..=b'9')) {
+                    return Err(self.err("octal escape sequences are not allowed"));
+                }
+                out.push('\0');
+            }
+            '1'..='9' => {
+                return Err(self.err(format!(
+                    "escape \\{c} is not allowed (digits cannot be escaped)"
+                )))
+            }
+            'x' => {
+                self.pos += 1;
+                if self.pos + 2 > self.src.len() {
+                    return Err(self.err("truncated \\x escape"));
+                }
+                let hi = (self.src.as_bytes()[self.pos] as char).to_digit(16);
+                let lo = (self.src.as_bytes()[self.pos + 1] as char).to_digit(16);
+                let (Some(hi), Some(lo)) = (hi, lo) else {
+                    return Err(self.err("invalid \\x escape"));
+                };
+                self.pos += 2;
+                out.push(char::from_u32(hi * 16 + lo).expect("\\xHH is at most U+00FF"));
+                return Ok(());
+            }
+            'u' => {
+                self.pos += 1;
+                let cp = self.read_hex4()?;
+                // F3.5: a lone surrogate is an error; a valid pair combines.
+                if (0xD800..=0xDFFF).contains(&cp) {
+                    if self.pos + 6 <= self.src.len()
+                        && self.byte_at(0) == Some(b'\\')
+                        && self.byte_at(1) == Some(b'u')
+                    {
+                        self.pos += 2;
+                        let lo = self.read_hex4()?;
+                        if (0xD800..=0xDBFF).contains(&cp) && (0xDC00..=0xDFFF).contains(&lo) {
+                            let combined = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+                            out.push(char::from_u32(combined).expect("valid astral codepoint"));
+                            return Ok(());
+                        }
+                    }
+                    return Err(self.err(format!("unpaired \\u{cp:04X} surrogate (spec F3.5)")));
+                }
+                out.push(char::from_u32(cp).expect("non-surrogate BMP codepoint"));
+                return Ok(());
+            }
+            // Any other character escapes to itself (JSON5's
+            // SingleEscapeCharacter and NonEscapeCharacter collapse to this).
+            _ => {
+                out.push(c);
+                self.advance(c);
+                return Ok(());
+            }
+        }
+        self.pos += 1; // the single-character escapes above
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Numbers
+    // -----------------------------------------------------------------------
+
+    /// Scan a JSON5 numeric literal: optional sign, then a hex integer or a
+    /// decimal with optional leading/trailing point and exponent. Signed
+    /// Infinity/NaN are routed to the F0.6 error here.
+    fn parse_number(&mut self) -> Result<HoconValue, String> {
+        let src = self.src;
+        let bytes = src.as_bytes();
+        let start = self.pos;
+        let mut neg = false;
+        if matches!(bytes[self.pos], b'+' | b'-') {
+            neg = bytes[self.pos] == b'-';
+            self.pos += 1;
+        }
+        let rest = &src[self.pos..];
+        for kw in ["Infinity", "NaN"] {
+            if rest.starts_with(kw) && !continues_identifier(rest, kw.len()) {
+                return Err(self.err(format!(
+                    "{kw} is not representable in the HOCON number model (spec F0.6)"
+                )));
+            }
+        }
+
+        if rest.starts_with("0x") || rest.starts_with("0X") {
+            self.pos += 2;
+            let ds = self.pos;
+            while self.pos < bytes.len() && bytes[self.pos].is_ascii_hexdigit() {
+                self.pos += 1;
+            }
+            if self.pos == ds {
+                return Err(self.err("hex literal needs at least one digit"));
+            }
+            let limit: u64 = if neg { 1 << 63 } else { (1 << 63) - 1 };
+            let Some(mag) = u64::from_str_radix(&src[ds..self.pos], 16)
+                .ok()
+                .filter(|m| *m <= limit)
+            else {
+                return Err(self.err(format!(
+                    "integer {} does not fit in i64 (spec F0.5)",
+                    &src[start..self.pos]
+                )));
+            };
+            // −mag is exactly representable for every mag ≤ 2^63: 2^63 as
+            // i64 wraps to i64::MIN, which is the value -0x8000000000000000
+            // denotes, and wrapping_neg leaves it in place.
+            let value = if neg {
+                (mag as i64).wrapping_neg()
+            } else {
+                mag as i64
+            };
+            return Ok(HoconValue::Scalar(ScalarValue::number(value.to_string())));
+        }
+
+        let (mut saw_digit, mut saw_dot, mut saw_exp) = (false, false, false);
+        while self.pos < bytes.len() {
+            match bytes[self.pos] {
+                b'0'..=b'9' => saw_digit = true,
+                b'.' if !saw_dot && !saw_exp => saw_dot = true,
+                b'e' | b'E' if saw_digit && !saw_exp => {
+                    saw_exp = true;
+                    if matches!(bytes.get(self.pos + 1), Some(b'+' | b'-')) {
+                        self.pos += 1;
+                    }
+                }
+                _ => break,
+            }
+            self.pos += 1;
+        }
+        let text = &src[start..self.pos];
+        if !saw_digit {
+            return Err(self.err(format!("malformed number {text:?}")));
+        }
+        // F0.5: '.', 'e', 'E' make a float; everything else is an i64 or an
+        // error. The leading '+' is stripped for str::parse's sake.
+        let unsigned = text.strip_prefix('+').unwrap_or(text);
+        if saw_dot || saw_exp {
+            let f: f64 = unsigned
+                .parse()
+                .map_err(|_| self.err(format!("malformed number {text:?}")))?;
+            // Go's strconv.ParseFloat reports out-of-range values as errors;
+            // Rust's parse saturates to ±Inf on overflow and to 0 on
+            // underflow, so both conditions are re-checked here to keep the
+            // implementations agreeing. Underflow = a mantissa with a
+            // significant digit that still came out as zero.
+            let mantissa = text.split(['e', 'E']).next().unwrap_or(text);
+            let underflow = f == 0.0 && mantissa.bytes().any(|b| b.is_ascii_digit() && b != b'0');
+            if !f.is_finite() || underflow {
+                return Err(self.err(format!("malformed number {text:?}")));
+            }
+            // {:?} keeps a whole-valued float visibly a float ("1000.0"),
+            // where {} would render "1000".
+            return Ok(HoconValue::Scalar(ScalarValue::number(format!("{f:?}"))));
+        }
+        let i: i64 = unsigned
+            .parse()
+            .map_err(|_| self.err(format!("integer {text} does not fit in i64 (spec F0.5)")))?;
+        Ok(HoconValue::Scalar(ScalarValue::number(i.to_string())))
+    }
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -17,8 +17,8 @@
 //! `${...}` aimed at the fallback would fail before the fallback is attached.
 //!
 //! Every adapter is behind a cargo feature, so the crate's default build still
-//! depends on `indexmap` alone. `properties` and `env` need nothing extra;
-//! `jsonc`, `toml` and `yaml` pull one crate each.
+//! depends on `indexmap` alone. `properties`, `env` and `json5` need nothing
+//! extra; `jsonc`, `toml` and `yaml` pull one crate each.
 //!
 //! Foreign data stays data: a `${a.b}` in an ingested value is literal text,
 //! never a reference (spec F0.2). Ingestion is AST-level — a document is
@@ -32,6 +32,8 @@ use crate::Config;
 
 #[cfg(feature = "adapters-env")]
 pub mod env;
+#[cfg(feature = "adapters-json5")]
+pub mod json5;
 #[cfg(feature = "adapters-jsonc")]
 pub mod jsonc;
 #[cfg(feature = "adapters-properties")]

--- a/tests/adapter_json5_test.rs
+++ b/tests/adapter_json5_test.rs
@@ -1,0 +1,348 @@
+//! The json5 adapter's conformance battery, ported case-for-case from
+//! go.hocon's adapters/json5/json5_test.go so the two implementations pin the
+//! same JSON5 1.0.0 semantics (spec F3.3) with the same expected values.
+//!
+//! Two go tests have no direct rs equivalent, deliberately:
+//! - invalid UTF-8 inside strings/comments cannot reach `parse`, whose input
+//!   is `&str`; the rs boundary is `parse_file`, pinned below.
+//! - go has no document-depth cap; rs caps at 128 like the crate's core
+//!   parser (a Rust stack overflow aborts the process), pinned below.
+#![cfg(feature = "adapters-json5")]
+
+use hocon::adapters::json5;
+use hocon::HoconValue;
+use tempfile::tempdir;
+
+fn parse(src: &str) -> hocon::Config {
+    json5::parse(src, Some("test.json5")).unwrap_or_else(|e| panic!("parse({src:?}): {e}"))
+}
+
+fn parse_err(src: &str, want: &str) {
+    let err = json5::parse(src, Some("test.json5"))
+        .err()
+        .unwrap_or_else(|| panic!("parse({src:?}): expected error containing {want:?}, got Ok"));
+    assert!(
+        err.message.contains(want),
+        "parse({src:?}): error {:?} does not contain {want:?}",
+        err.message
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The json5.org front-page example, minus Infinity/NaN (spec F0.6 rejects
+// those — pinned separately below).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn front_page_example() {
+    let cfg = parse(
+        "{
+  // comments
+  unquoted: 'and you can quote me on that',
+  singleQuotes: 'I can use \"double quotes\" here',
+  lineBreaks: \"Look, Mom! \\
+No \\\\n's!\",
+  hexadecimal: 0xdecaf,
+  leadingDecimalPoint: .8675309, andTrailing: 8675309.,
+  positiveSign: +1,
+  trailingComma: 'in objects', andIn: ['arrays',],
+  \"backwardsCompatible\": \"with JSON\",
+}",
+    );
+
+    for (path, want) in [
+        ("unquoted", "and you can quote me on that"),
+        ("singleQuotes", "I can use \"double quotes\" here"),
+        ("lineBreaks", "Look, Mom! No \\n's!"),
+        ("trailingComma", "in objects"),
+        ("backwardsCompatible", "with JSON"),
+    ] {
+        assert_eq!(cfg.get_string(path).unwrap(), want, "{path}");
+    }
+    assert_eq!(cfg.get_i64("hexadecimal").unwrap(), 0xdecaf);
+    assert_eq!(cfg.get_f64("leadingDecimalPoint").unwrap(), 0.8675309);
+    assert_eq!(cfg.get_f64("andTrailing").unwrap(), 8675309.0);
+    assert_eq!(cfg.get_i64("positiveSign").unwrap(), 1);
+    let and_in = cfg.get_list("andIn").unwrap();
+    assert_eq!(and_in.len(), 1);
+    match &and_in[0] {
+        HoconValue::Scalar(sv) => assert_eq!(sv.raw, "arrays"),
+        other => panic!("andIn[0] = {other:?}, want the string \"arrays\""),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Identifier keys (ES5 IdentifierName)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn identifier_keys() {
+    let cfg = parse("{a: 1, $b: 2, _c: 3, é: 4, a1: 5}");
+    for (path, want) in [("a", 1), ("\"$b\"", 2), ("_c", 3), ("\"é\"", 4), ("a1", 5)] {
+        assert_eq!(cfg.get_i64(path).unwrap(), want, "{path}");
+    }
+}
+
+#[test]
+fn identifier_key_unicode_escape() {
+    // \u0061 = 'a'; ES5 allows \u escapes inside IdentifierName.
+    let cfg = parse(r"{\u0061\u0062: 7}");
+    assert_eq!(cfg.get_i64("ab").unwrap(), 7);
+}
+
+#[test]
+fn identifier_key_errors() {
+    parse_err("{1a: 1}", "expected an object key");
+    // \u0031 = '1' — a legal escape, but not a legal identifier START.
+    parse_err(r"{\u0031x: 1}", "not a valid identifier character");
+    parse_err(r"{\x61: 1}", r"only \uXXXX escapes");
+}
+
+// ---------------------------------------------------------------------------
+// Strings
+// ---------------------------------------------------------------------------
+
+#[test]
+fn string_escapes() {
+    let cfg = parse(
+        "{
+  hex: \"\\x41\\x42\",
+  vtab: \"a\\vb\",
+  nul: \"a\\0b\",
+  self: \"\\q\\'\\\"\",
+  astral: \"\\uD83D\\uDE00\",
+}",
+    );
+    for (path, want) in [
+        ("hex", "AB"),
+        ("vtab", "a\u{000b}b"),
+        ("nul", "a\u{0000}b"),
+        ("self", "q'\""),
+        ("astral", "😀"),
+    ] {
+        assert_eq!(cfg.get_string(path).unwrap(), want, "{path}");
+    }
+}
+
+#[test]
+fn string_line_continuations() {
+    // LF, CRLF, and LS continuations all contribute nothing.
+    let cfg = parse("{a: 'x\\\ny', b: 'x\\\r\ny', c: 'x\\\u{2028}y'}");
+    for path in ["a", "b", "c"] {
+        assert_eq!(cfg.get_string(path).unwrap(), "xy", "{path}");
+    }
+}
+
+#[test]
+fn string_unescaped_separators_allowed() {
+    // LS/PS are legal unescaped inside JSON5 strings (the ES5 quirk).
+    let cfg = parse("{a: 'x\u{2028}y'}");
+    assert_eq!(cfg.get_string("a").unwrap(), "x\u{2028}y");
+}
+
+#[test]
+fn string_errors() {
+    parse_err("{a: 'x\ny'}", "unescaped line terminator");
+    parse_err("{a: 'oops}", "unterminated string");
+    parse_err(r"{a: '\01'}", "octal escape");
+    parse_err(r"{a: '\7'}", "digits cannot be escaped");
+    // F3.5: a lone surrogate is an error, high or low, paired-wrong or alone.
+    parse_err(r#"{a: "\uD800"}"#, "spec F3.5");
+    parse_err(r#"{a: "\uD800\u0041"}"#, "spec F3.5");
+    parse_err(r#"{a: "\uDE00"}"#, "spec F3.5");
+}
+
+// ---------------------------------------------------------------------------
+// Numbers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn numbers() {
+    let cfg = parse(
+        "{
+  hex: 0xFF, hexneg: -0x10, hexplus: +0xA,
+  min: -0x8000000000000000, max: 0x7FFFFFFFFFFFFFFF,
+  lead: .5, trail: 5., plus: +5, exp: 1e3, negzero: -0,
+}",
+    );
+    assert_eq!(cfg.get_i64("hex").unwrap(), 255);
+    assert_eq!(cfg.get_i64("hexneg").unwrap(), -16);
+    assert_eq!(cfg.get_i64("hexplus").unwrap(), 10);
+    assert_eq!(cfg.get_i64("min").unwrap(), i64::MIN);
+    assert_eq!(cfg.get_i64("max").unwrap(), i64::MAX);
+    assert_eq!(cfg.get_f64("lead").unwrap(), 0.5);
+    assert_eq!(cfg.get_f64("trail").unwrap(), 5.0);
+    assert_eq!(cfg.get_i64("plus").unwrap(), 5);
+    assert_eq!(cfg.get_f64("exp").unwrap(), 1000.0);
+    assert_eq!(cfg.get_i64("negzero").unwrap(), 0);
+}
+
+#[test]
+fn number_errors() {
+    // F0.5: integers that do not fit in i64 are errors, not silent floats.
+    parse_err("{a: 0x10000000000000000}", "spec F0.5");
+    parse_err("{a: -0x8000000000000001}", "spec F0.5");
+    parse_err("{a: 9223372036854775808}", "spec F0.5");
+    parse_err("{a: 0x}", "hex literal needs at least one digit");
+    // F0.6: Infinity and NaN in every spelling.
+    for lit in ["Infinity", "-Infinity", "+Infinity", "NaN", "-NaN", "+NaN"] {
+        parse_err(&format!("{{a: {lit}}}"), "spec F0.6");
+    }
+    // A longer identifier that merely STARTS with those spellings is not the
+    // F0.6 case — it errors as an unexpected token / malformed number.
+    parse_err("{a: Infinityx}", "unexpected character");
+    parse_err("{a: NaNx}", "unexpected character");
+    parse_err("{a: -Infinityx}", "malformed number");
+}
+
+// ---------------------------------------------------------------------------
+// Comments, whitespace, structure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn comments_and_whitespace() {
+    // The LS after "line comment" TERMINATES the // comment (deliberately
+    // different from jsonc, whose dialect owner ends comments at LF/CR only),
+    // so `a: 1,` on the same source line is live. NBSP and EM SPACE (Zs) are
+    // whitespace.
+    let cfg = parse(
+        "{\n  // line comment\u{2028} a: 1,\n  /* block\n comment */ b: 2,\u{00a0}c:\u{2003}3\n}",
+    );
+    for (path, want) in [("a", 1), ("b", 2), ("c", 3)] {
+        assert_eq!(cfg.get_i64(path).unwrap(), want, "{path}");
+    }
+}
+
+#[test]
+fn comment_and_structure_errors() {
+    parse_err("{a: 1} /* open", "unterminated /* comment");
+    parse_err("{a: 1} }", "unexpected content after top-level value");
+    parse_err("{a: 1", "unterminated object");
+    parse_err("[1, 2", "unterminated array");
+    parse_err("[,1]", "unexpected character");
+    parse_err("[1,,2]", "unexpected character");
+    parse_err("{a 1}", "expected ':'");
+    // F0.3: the root must be an object.
+    parse_err("[1, 2]", "spec F0.3");
+    parse_err("\"just a string\"", "spec F0.3");
+}
+
+/// Trailing whitespace and comments after the value are fine (only content is
+/// an error).
+#[test]
+fn trailing_trivia_accepted() {
+    let cfg = parse("{a: 1} // done\n/* and a block */\n\n");
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
+}
+
+/// Errors carry the origin and a 1-based line/col so a reader can find the
+/// spot. (go pins the same shape through its origin wrapper.)
+#[test]
+fn errors_name_the_origin_and_the_line() {
+    let err = json5::parse("{\na: 'x\ny'}", Some("test.json5")).unwrap_err();
+    assert!(
+        err.message.contains("json5: test.json5:"),
+        "{}",
+        err.message
+    );
+    assert!(err.message.contains("line 2"), "{}", err.message);
+
+    let err = json5::parse("{", None).unwrap_err();
+    assert!(err.message.contains("json5: document:"), "{}", err.message);
+}
+
+// ---------------------------------------------------------------------------
+// Duplicate keys (spec F0.7)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn duplicate_keys_follow_hocon_semantics() {
+    // Two objects merge…
+    let cfg = parse("{a: {x: 1, shared: {p: 1}}, a: {y: 2, shared: {q: 2}}}");
+    assert_eq!(cfg.get_i64("a.x").unwrap(), 1);
+    assert_eq!(cfg.get_i64("a.y").unwrap(), 2);
+    assert_eq!(cfg.get_i64("a.shared.p").unwrap(), 1);
+    assert_eq!(cfg.get_i64("a.shared.q").unwrap(), 2);
+
+    // …anything else is last-wins.
+    let cfg = parse("{a: 1, a: 2}");
+    assert_eq!(cfg.get_i64("a").unwrap(), 2);
+    let cfg = parse("{a: {x: 1}, a: 2}");
+    assert_eq!(cfg.get_i64("a").unwrap(), 2, "scalar over object");
+}
+
+// ---------------------------------------------------------------------------
+// BOM and encoding (spec F0.9, S1.1 posture)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bom_stripped_leading_and_whitespace_interior() {
+    let cfg = parse("\u{feff}{a: \u{feff}1}");
+    assert_eq!(cfg.get_i64("a").unwrap(), 1);
+}
+
+/// go pins that invalid UTF-8 is rejected wherever it hides; in rs the type
+/// system moves that boundary to `parse_file` — `parse` takes `&str`, which
+/// cannot hold invalid bytes — so the file entry point is what gets pinned.
+#[test]
+fn parse_file_rejects_invalid_utf8() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("bad.json5");
+    std::fs::write(&path, b"{a: \"\xff\"}").unwrap();
+    let err = json5::parse_file(&path).unwrap_err();
+    assert!(err.message.contains("bad.json5"), "{}", err.message);
+}
+
+// ---------------------------------------------------------------------------
+// Depth (rs-specific: the cap the core parser also enforces)
+// ---------------------------------------------------------------------------
+
+/// go has no depth cap; in Rust a stack overflow is SIGABRT, so the adapter
+/// refuses deep nesting with the core parser's own limit instead of aborting
+/// the process.
+#[test]
+fn deep_nesting_is_an_error_not_an_abort() {
+    let deep = |n: usize| format!("{}1{}", "{\"a\":".repeat(n), "}".repeat(n));
+    assert!(json5::parse(&deep(128), None).is_ok(), "128 must fit");
+    let err = json5::parse(&deep(129), None).unwrap_err();
+    assert!(
+        err.message.contains("nests deeper than 128"),
+        "{}",
+        err.message
+    );
+    // Deep enough to have aborted without the cap, even on a small stack.
+    assert!(json5::parse(&deep(5000), None).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Merge with a HOCON document (the adapter's purpose)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn with_fallback_merge() {
+    let base = json5::parse("{db: {host: 'localhost', port: 5432}}", Some("base.json5")).unwrap();
+    let opts = hocon::ParseOptions::defaults().with_resolve_substitutions(false);
+    let cfg =
+        hocon::parse_string_with_options("db { host = db.example.com }\nurl = ${db.host}", opts)
+            .unwrap();
+    let merged = cfg
+        .with_fallback(&base)
+        .resolve(hocon::ResolveOptions::defaults())
+        .unwrap();
+    assert_eq!(merged.get_string("db.host").unwrap(), "db.example.com");
+    assert_eq!(merged.get_i64("db.port").unwrap(), 5432);
+    assert_eq!(merged.get_string("url").unwrap(), "db.example.com");
+}
+
+#[test]
+fn parse_file_uses_path_as_origin() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("conf.json5");
+    std::fs::write(&path, "{a: [}").unwrap();
+    let err = json5::parse_file(&path).unwrap_err();
+    assert!(
+        err.message.contains("conf.json5"),
+        "expected the error to name the file: {}",
+        err.message
+    );
+}

--- a/tests/format_ingestion_test.rs
+++ b/tests/format_ingestion_test.rs
@@ -9,7 +9,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use hocon::adapters::{env, jsonc, properties, toml, yaml, AdapterError};
+use hocon::adapters::{env, json5, jsonc, properties, toml, yaml, AdapterError};
 use hocon::{Config, HoconValue};
 
 fn root() -> PathBuf {
@@ -69,6 +69,7 @@ fn ingest(
     id: &str,
 ) -> Result<Config, AdapterError> {
     match format {
+        "json5" => json5::parse(text, Some(id)),
         "jsonc" => jsonc::parse(text, Some(id)),
         "properties" => properties::parse(text, Some(id)),
         "toml" => toml::parse(text, Some(id)),


### PR DESCRIPTION
## Summary

Horizontal rollout of [go.hocon#193](https://github.com/o3co/go.hocon/pull/193) (JSON5 adapter, merged). Ports the go implementation as the semantic source — hand-rolled scanner + recursive descent (zero dependencies). The grammar follows the dialect owner (the json5 npm reference implementation), and the spec-first divergences of mapping spec F3.3 ([xx#92](https://github.com/o3co/xx.hocon/pull/92)) are preserved (F0.5 int64 / F0.6 Infinity & NaN / F3.5 surrogates / F0.7 duplicate keys / strict EOF).

go's test battery is ported case-for-case; host-language differences (int representation, invalid-UTF-8 boundaries, recursion guard) are resolved per each repo's existing conventions (details in the commit body / in-code comments). json5 dispatch is registered in the fixture runner — **with 4-implementation parity now in place, once this same-window batch merges, the json5 fixture set goes into xx and F3.3 flips to ✅**.

Same-window: 3 PRs across ts / py / rs (go is already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
