### PR TITLE
fix(adapters): feature-gate omission when adapters-json5 is enabled alone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@
 #[cfg(any(
     feature = "adapters-properties",
     feature = "adapters-env",
+    feature = "adapters-json5",
     feature = "adapters-jsonc",
     feature = "adapters-toml",
     feature = "adapters-yaml",


### PR DESCRIPTION
## Summary

A latent bug from rs#176: `pub mod json5` in `adapters/mod.rs` was gated, but `adapters-json5` was missing from the `any(...)` list in `lib.rs` that exposes `pub mod adapters`, so **a consumer enabling this feature alone hit E0433** (masked under `--all-features` or when combined with other adapters, so it slipped past CI).

Verified with `cargo build --no-default-features --features adapters-json5` and a test run with the feature alone (20 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
