### PR TITLE
chore(release): 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-08-19
+
 ### Fixed
 
 - **BREAKING (spec fix, S21.2–S21.3): byte units now match the Lightbend
@@ -824,7 +826,8 @@ Behaviour:
 
 - **CI: content-addressable testdata cache** (closes [#101](https://github.com/o3co/rs.hocon/issues/101)). `.github/workflows/test.yml` and `.github/workflows/publish.yml` previously used `actions/cache@v5` with `key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}`. The hash evaluated BEFORE the cache restore step ran, but `.xx-hocon-version` is gitignored and absent on fresh checkouts — so the key collapsed to a constant and cache entries shared the same slot. Split into `actions/cache/restore@v5` (matches via `restore-keys`) + `actions/cache/save@v5` (writes with the post-fetch hash, gated on `make testdata` success). No production code touched.
 
-[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.12.0...HEAD
+[Unreleased]: https://github.com/o3co/rs.hocon/compare/v1.13.0...HEAD
+[1.13.0]: https://github.com/o3co/rs.hocon/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/o3co/rs.hocon/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/o3co/rs.hocon/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/o3co/rs.hocon/compare/v1.9.0...v1.10.0


### PR DESCRIPTION
## Summary

Release prep for the v1.13.0 lockstep cut: move `[Unreleased]` into `[1.13.0] - 2026-08-19`. No version-file bumps — published versions come from the tag (the design established for 1.12.0). The release workflow's CHANGELOG-extraction awk was run locally and yields a non-empty section (the empty-section abort guard will not trigger).

Contents (lockstep across the four implementations): the BREAKING spec-fix batch — S13a.12, S9.2 (leading-newline strip; plus go's CRLF normalization), S13.12 — the Lightbend units alignment (kB case sensitivity and the extended byte table, BREAKING), the JSON5 adapter (F3.3), and the HOCON emitter (E18).

Same-window PRs: go / ts / rs / py. After all four merge, `v1.13.0` is tagged on each default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)