### PR TITLE
fix(adapters/json5): accept underflowing float literals as 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The JSON5 adapter no longer rejects a float literal that underflows f64
+  (`1e-400`): it now reads it as `0`, matching the go/ts/py siblings and the
+  dialect owner (JS `Number`). The rejection came from over-generalizing Go's
+  `strconv.ParseFloat` range error, which only fires on overflow. Overflowing
+  literals (`1e999`) are still errors (spec F0.6).
+
 ## [1.13.0] - 2026-08-19
 
 ### Fixed

--- a/src/adapters/json5.rs
+++ b/src/adapters/json5.rs
@@ -680,14 +680,12 @@ impl<'a> Parser<'a> {
             let f: f64 = unsigned
                 .parse()
                 .map_err(|_| self.err(format!("malformed number {text:?}")))?;
-            // Go's strconv.ParseFloat reports out-of-range values as errors;
-            // Rust's parse saturates to ±Inf on overflow and to 0 on
-            // underflow, so both conditions are re-checked here to keep the
-            // implementations agreeing. Underflow = a mantissa with a
-            // significant digit that still came out as zero.
-            let mantissa = text.split(['e', 'E']).next().unwrap_or(text);
-            let underflow = f == 0.0 && mantissa.bytes().any(|b| b.is_ascii_digit() && b != b'0');
-            if !f.is_finite() || underflow {
+            // Overflow only: Go's strconv.ParseFloat returns ErrRange for
+            // ±Inf but accepts underflow silently as 0 (measured), and the
+            // dialect owner (JS `Number`) reads `1e-400` as 0 — so an
+            // underflowing literal is the value 0, not an error. Rust's parse
+            // saturates to ±Inf on overflow, which F0.6 rejects.
+            if !f.is_finite() {
                 return Err(self.err(format!("malformed number {text:?}")));
             }
             // {:?} keeps a whole-valued float visibly a float ("1000.0"),

--- a/tests/adapter_json5_test.rs
+++ b/tests/adapter_json5_test.rs
@@ -195,6 +195,20 @@ fn number_errors() {
     parse_err("{a: -Infinityx}", "malformed number");
 }
 
+/// A literal whose magnitude falls outside f64's range: overflow saturates to
+/// ±Inf, which F0.6 rejects, but underflow is the representable value 0 — the
+/// dialect owner (JS `Number`) and the go/ts/py siblings all read `1e-400` as
+/// 0, and go's strconv.ParseFloat only errors on the overflow side.
+#[test]
+fn float_range_edges() {
+    parse_err("{a: 1e999}", "malformed number");
+    parse_err("{a: -1e999}", "malformed number");
+    assert_eq!(parse("{a: 1e-400}").get_f64("a").unwrap(), 0.0);
+    assert_eq!(parse("{a: -1e-400}").get_f64("a").unwrap(), 0.0);
+    // The smallest denormal is in range and survives exactly.
+    assert_eq!(parse("{a: 5e-324}").get_f64("a").unwrap(), 5e-324);
+}
+
 // ---------------------------------------------------------------------------
 // Comments, whitespace, structure
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The JSON5 adapter rejected a float literal that underflows f64 (`1e-400`) as a malformed number. The check's stated premise — that Go's `strconv.ParseFloat` reports out-of-range values as errors — is only true for **overflow**; measured, Go returns `0` with a nil error on underflow, so the go/ts/py adapters all read `1e-400` as `0`. The dialect owner (JS `Number`) agrees.

## Changes

- Drop the underflow arm; keep the overflow rejection (`1e999` → error, spec F0.6).
- Pin the three range edges in a new `float_range_edges` test: `±1e999` → error, `±1e-400` → `0`, `5e-324` (smallest denormal) survives exactly.

## Cross-impl matrix (measured, 1.13.0)

| input | go | ts | py | rs before | rs after |
|---|---|---|---|---|---|
| `{a: 1e-400}` | 0 | 0 | 0 | **error** | 0 |
| `{a: 5e-324}` | 5e-324 | 5e-324 | 5e-324 | 5e-324 | 5e-324 |
| `{a: 1e999}` | error | error | error | error | error |

A shared `fi` fixture pinning this will follow in xx.hocon once this lands (fixtures need four-way parity first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)