### PR TITLE
fix(parser)!: reject overflowing float literals (E19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **BREAKING (extra-spec E19, xx.hocon#97): a numeric literal whose magnitude
+  overflows the f64 range (`1e999`) is now a parse error** instead of silently
+  becoming `inf` — a value HOCON cannot render or re-parse as a number
+  (Lightbend's own render → re-parse turns it into the string `"Infinity"`),
+  and which the serde path silently degraded to `null` in a `serde_json`
+  target. This aligns rs with go, which has always errored here; a deliberate,
+  documented divergence from Lightbend. Underflow (`1e-400`) still reads as
+  `0`. Workaround for configs that carried such a literal as data: quote it
+  (`a = "1e999"` stays a string).
+- The serde deserializers now refuse a non-finite `f64` loudly
+  (`DeserializeError`) instead of letting `serde_json` degrade it to `null` —
+  defense in depth for number scalars constructed programmatically, which the
+  parser fix above cannot reach.
+
 ## [1.13.1] - 2026-08-26
 
 ### Fixed

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1023,7 +1023,11 @@ impl<'a> Parser<'a> {
                 TokenKind::Unquoted => {
                     let (_, val, line, col) = self.advance_get();
                     AstNode::Scalar {
-                        value: parse_scalar_value(&val),
+                        value: parse_scalar_value(&val).map_err(|message| ParseError {
+                            message,
+                            line,
+                            col,
+                        })?,
                         pos: Pos { line, col },
                         separator: false,
                     }
@@ -1185,12 +1189,12 @@ fn validate_package_file_arg(file: &str, line: usize, col: usize) -> Result<(), 
     Ok(())
 }
 
-fn parse_scalar_value(raw: &str) -> ScalarValue {
+fn parse_scalar_value(raw: &str) -> Result<ScalarValue, String> {
     match raw {
         "true" | "false" => {
-            return ScalarValue::new(raw.to_string(), ScalarType::Boolean);
+            return Ok(ScalarValue::new(raw.to_string(), ScalarType::Boolean));
         }
-        "null" => return ScalarValue::null(),
+        "null" => return Ok(ScalarValue::null()),
         _ => {}
     }
 
@@ -1212,18 +1216,28 @@ fn parse_scalar_value(raw: &str) -> ScalarValue {
         // (`get_i64`, serde `ScalarType::Number`) already parse `raw`, so the
         // standalone semantic value is unchanged (`01` still reads as 1).
         if raw.parse::<i64>().is_ok() {
-            return ScalarValue::number(raw.to_string());
+            return Ok(ScalarValue::number(raw.to_string()));
         }
         // f64 fallback for fractional / scientific forms — preserve the
         // original input text rather than f64-round-tripping (Lightbend
         // keeps the input form for fractions; round-trip would change
         // precision and surface non-canonical exponents).
-        if raw.parse::<f64>().is_ok() {
-            return ScalarValue::number(raw.to_string());
+        if let Ok(f) = raw.parse::<f64>() {
+            // E19 (xx.hocon#97): a numeric literal whose magnitude overflows
+            // f64 (`1e999`) is a parse error. Lightbend admits Infinity but
+            // cannot render or re-parse it as a number; erroring at the parse
+            // (as go always has via strconv.ParseFloat) is the documented
+            // divergence. Underflow (`1e-400`) parses as 0 and stays accepted
+            // — a number-shaped raw can never yield NaN, so only the infinite
+            // case is checked.
+            if f.is_infinite() {
+                return Err(format!("invalid float \"{raw}\""));
+            }
+            return Ok(ScalarValue::number(raw.to_string()));
         }
     }
 
-    ScalarValue::string(raw.to_string())
+    Ok(ScalarValue::string(raw.to_string()))
 }
 
 #[cfg(test)]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -184,6 +184,20 @@ impl<'de> ::serde::Deserializer<'de> for HoconDeserializer<'de> {
                         }
                     }
                     if let Ok(f) = sv.raw.parse::<f64>() {
+                        // E19 hardening (xx.hocon#97): a non-finite f64 cannot
+                        // be represented by serde_json::Number — passing it on
+                        // would silently degrade to `null` in a serde_json
+                        // target. The parser already rejects overflowing
+                        // literals, so this only fires on internally
+                        // constructed values; refuse loudly instead.
+                        if !f.is_finite() {
+                            return Err(DeserializeError {
+                                message: format!(
+                                    "non-finite number {:?} cannot be deserialized",
+                                    sv.raw
+                                ),
+                            });
+                        }
                         return visitor.visit_f64(f);
                     }
                     visitor.visit_string(sv.raw.clone())
@@ -608,6 +622,17 @@ impl<'de> ::serde::Deserializer<'de> for OwnedHoconDeserializer {
                         }
                     }
                     if let Ok(f) = sv.raw.parse::<f64>() {
+                        // E19 hardening (xx.hocon#97): see the borrowed
+                        // deserializer above — refuse a non-finite f64 loudly
+                        // rather than letting serde_json degrade it to null.
+                        if !f.is_finite() {
+                            return Err(DeserializeError {
+                                message: format!(
+                                    "non-finite number {:?} cannot be deserialized",
+                                    sv.raw
+                                ),
+                            });
+                        }
                         return visitor.visit_f64(f);
                     }
                     visitor.visit_string(sv.raw)

--- a/tests/e19_float_overflow_test.rs
+++ b/tests/e19_float_overflow_test.rs
@@ -47,6 +47,15 @@ fn rejects_overflow_in_array_element() {
 }
 
 #[test]
+fn rejects_integer_form_beyond_double_range() {
+    // E19 is keyed on the lexeme's value, not its spelling: an integer-form
+    // literal beyond the double range overflows the i64 → f64 fallback the
+    // same way an exponent form does.
+    let src = format!("a = {}", "9".repeat(400));
+    assert!(matches!(parse_err(&src), HoconError::Parse(_)));
+}
+
+#[test]
 fn accepts_underflow_as_zero() {
     let cfg = hocon::parse("a = 1e-400").expect("underflow parses");
     assert_eq!(cfg.get_f64("a").expect("get_f64"), 0.0);

--- a/tests/e19_float_overflow_test.rs
+++ b/tests/e19_float_overflow_test.rs
@@ -1,0 +1,87 @@
+// E19 — overflowing float literal is a parse error (xx.hocon#97, posture B).
+//
+// A numeric literal whose magnitude overflows the f64 range is a parse error
+// in all four sibling implementations. This is a documented divergence from
+// Lightbend: the reference admits the literal as Infinity, but HOCON has no
+// Infinity literal, so the value cannot be rendered or re-parsed as a number
+// (Lightbend's own render -> re-parse silently turns it into the STRING
+// "Infinity"). go.hocon has always errored here via strconv.ParseFloat;
+// ts/py/rs align with it. Port of ts.hocon's e19-float-overflow.test.ts.
+//
+// Underflow is NOT an error: `1e-400` reads as 0 in every implementation and
+// in Lightbend, so only the infinite case is rejected.
+
+use hocon::HoconError;
+
+fn parse_err(src: &str) -> HoconError {
+    hocon::parse(src).expect_err("expected a parse error")
+}
+
+#[test]
+fn rejects_overflow() {
+    match parse_err("a = 1e999") {
+        HoconError::Parse(e) => {
+            assert_eq!(e.message, "invalid float \"1e999\"");
+            assert_eq!((e.line, e.col), (1, 5));
+        }
+        other => panic!("expected Parse error, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_negative_overflow() {
+    match parse_err("a = -1e999") {
+        HoconError::Parse(e) => assert_eq!(e.message, "invalid float \"-1e999\""),
+        other => panic!("expected Parse error, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_fractional_overflow() {
+    assert!(matches!(parse_err("a = 2.5e999"), HoconError::Parse(_)));
+}
+
+#[test]
+fn rejects_overflow_in_array_element() {
+    assert!(matches!(parse_err("a = [1, 1e999]"), HoconError::Parse(_)));
+}
+
+#[test]
+fn accepts_underflow_as_zero() {
+    let cfg = hocon::parse("a = 1e-400").expect("underflow parses");
+    assert_eq!(cfg.get_f64("a").expect("get_f64"), 0.0);
+}
+
+#[test]
+fn accepts_finite_extremes() {
+    let cfg = hocon::parse("a = 1e308\nb = 5e-324").expect("finite extremes parse");
+    assert_eq!(cfg.get_f64("a").expect("get_f64"), 1e308);
+    assert_eq!(cfg.get_f64("b").expect("get_f64"), 5e-324);
+}
+
+#[test]
+fn quoted_overflow_stays_string() {
+    let cfg = hocon::parse("a = \"1e999\"").expect("quoted literal parses");
+    assert_eq!(cfg.get_string("a").expect("get_string"), "1e999");
+}
+
+#[test]
+fn unquoted_infinity_stays_string() {
+    // No Infinity literal exists in HOCON; the word is an unquoted string.
+    let cfg = hocon::parse("a = Infinity").expect("unquoted word parses");
+    assert_eq!(cfg.get_string("a").expect("get_string"), "Infinity");
+}
+
+// E19 hardening: the parser now rejects overflowing literals, but a
+// non-finite number scalar can still be constructed programmatically.
+// The serde path must refuse it loudly instead of letting serde_json
+// silently degrade it to `null`.
+#[cfg(feature = "serde")]
+#[test]
+fn serde_refuses_programmatically_constructed_non_finite_number() {
+    use hocon::{from_value, HoconValue, ScalarValue};
+    let v = HoconValue::Scalar(ScalarValue::number("1e999".to_string()));
+    let res: Result<serde_json::Value, _> = from_value(&v);
+    let err = res.expect_err("non-finite must not silently degrade to null");
+    assert!(err.to_string().contains("non-finite"), "got: {err}");
+}

--- a/tests/issue56_i64_coercion_precision.rs
+++ b/tests/issue56_i64_coercion_precision.rs
@@ -100,8 +100,14 @@ fn huge_exponent_rejects_without_huge_allocation() {
     // Must reject quickly, not attempt a multi-GB zero-padded string.
     // E19 (xx.hocon#97): the overflowing literal is now rejected at parse
     // time (it reads as +Inf), one layer earlier than the accessor-level
-    // rejection this test originally pinned.
-    assert!(parse("n = 1e2147483647").is_err());
+    // rejection this test originally pinned. Assert the specific E19 error
+    // so an unrelated parse failure cannot satisfy this test.
+    match parse("n = 1e2147483647") {
+        Err(hocon::HoconError::Parse(e)) => {
+            assert_eq!(e.message, "invalid float \"1e2147483647\"");
+        }
+        other => panic!("expected E19 parse error, got {other:?}"),
+    }
     let c2 = parse("n = 1e-2147483648").unwrap();
     assert_eq!(c2.get("n").unwrap().as_i64(), None); // ~0, non-whole
 }

--- a/tests/issue56_i64_coercion_precision.rs
+++ b/tests/issue56_i64_coercion_precision.rs
@@ -97,10 +97,11 @@ fn i64_min_and_max_float_form_preserved() {
 
 #[test]
 fn huge_exponent_rejects_without_huge_allocation() {
-    // Must return None quickly, not attempt a multi-GB zero-padded string.
-    let c = parse("n = 1e2147483647").unwrap();
-    assert_eq!(c.get("n").unwrap().as_i64(), None);
-    assert!(c.get_i64("n").is_err());
+    // Must reject quickly, not attempt a multi-GB zero-padded string.
+    // E19 (xx.hocon#97): the overflowing literal is now rejected at parse
+    // time (it reads as +Inf), one layer earlier than the accessor-level
+    // rejection this test originally pinned.
+    assert!(parse("n = 1e2147483647").is_err());
     let c2 = parse("n = 1e-2147483648").unwrap();
     assert_eq!(c2.get("n").unwrap().as_i64(), None); // ~0, non-whole
 }


### PR DESCRIPTION
Part of the four-impl posture-B alignment for [xx.hocon#97](https://github.com/o3co/xx.hocon/issues/97): an overflowing float literal is a parse error in all four cores. Sibling PRs: o3co/ts.hocon#194, o3co/py.hocon#45.

## What changes

- `parse_scalar_value` is now fallible: a number-shaped token whose `f64` parse yields an infinity raises `ParseError: invalid float "1e999"` (same message shape as go) at the literal's position. Underflow (`1e-400`) is unchanged — it reads as `0`.
- **Both serde deserializers refuse a non-finite `f64` loudly** (`DeserializeError`) instead of letting `serde_json` silently degrade it to `null` — this was the renderer gap measured in the issue (`a = 1e999` → canonical JSON `null`). The parser fix makes this unreachable from parsed input; the guard covers number scalars constructed programmatically (`ScalarValue::number` is public).
- Quoted `"1e999"` and unquoted `Infinity` remain strings.
- The issue56 huge-exponent test now observes the rejection one layer earlier (parse time instead of accessor time); its no-huge-allocation intent is preserved.

## Why error instead of following Lightbend

Lightbend admits the literal as `Infinity`, but the value cannot survive any downstream path: HOCON has no Infinity literal, so no emitter can round-trip it (Lightbend's own `render()` → re-parse silently turns it into the STRING `"Infinity"`), and serde_json cannot carry it. go has always errored here. Documented divergence: extra-spec **E19**, added to xx.hocon in the same window.

**BREAKING**: a config that previously parsed with `a = 1e999` (yielding `inf`) now errors. Workaround: quote the literal. CHANGELOG entry included; ships in the next lockstep minor.

## Tests

`tests/e19_float_overflow_test.rs` pins: overflow (plain / negative / fractional / array-element) → `Parse` error with position; underflow → 0; finite extremes accepted; quoted / `Infinity` string behavior unchanged; and the serde hardening via a programmatically constructed non-finite scalar. Full matrix green locally: `cargo test` / `--features serde` / `--all-features`, clippy `-D warnings`, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)